### PR TITLE
Fix Typo: temporary variable name retained instead of being replaced by 'self'

### DIFF
--- a/src/ursa/agents/hypothesizer_agent.py
+++ b/src/ursa/agents/hypothesizer_agent.py
@@ -500,7 +500,7 @@ class HypothesizerAgent(BaseAgent):
             final_solution="",
         )
         # Run the graph
-        result = hypothesizer_agent.action.invoke(
+        result = self.action.invoke(
             initial_state,
             {
                 "recursion_limit": recursion_limit,


### PR DESCRIPTION
The code had a simply typo that stops hypothesizer agent from running. 