### PR TITLE
simple fix for over cmd stdout/stderr size

### DIFF
--- a/src/ursa/agents/execution_agent.py
+++ b/src/ursa/agents/execution_agent.py
@@ -269,6 +269,41 @@ class ExecutionAgent(BaseAgent):
         )
 
 
+def _snip_text(text: str, max_chars: int) -> tuple[str, bool]:
+    if text is None:
+        return "", False
+    if max_chars <= 0:
+        return "", len(text) > 0
+    if len(text) <= max_chars:
+        return text, False
+    head = max_chars // 2
+    tail = max_chars - head
+    return (
+        text[:head]
+        + f"\n... [snipped {len(text) - max_chars} chars] ...\n"
+        + text[-tail:],
+        True,
+    )
+
+def _fit_streams_to_budget(stdout: str, stderr: str, total_budget: int):
+    label_overhead = len("STDOUT:\n") + len("\nSTDERR:\n")
+    budget = max(0, total_budget - label_overhead)
+
+    if len(stdout) + len(stderr) <= budget:
+        return stdout, stderr
+
+    total_len = max(1, len(stdout) + len(stderr))
+    stdout_budget = int(budget * (len(stdout) / total_len))
+    stderr_budget = budget - stdout_budget
+
+    stdout_snip, _ = _snip_text(stdout, stdout_budget)
+    stderr_snip, _ = _snip_text(stderr, stderr_budget)
+    return stdout_snip, stderr_snip
+
+# the idea here is that we just set a limit - the user could overload
+# that in their env, or maybe we could pull this out of the LLM parameters
+MAX_TOOL_MSG_CHARS = int(os.getenv("MAX_TOOL_MSG_CHARS", "100000"))
+
 @tool
 def run_cmd(query: str, state: Annotated[dict, InjectedState]) -> str:
     """
@@ -293,10 +328,15 @@ def run_cmd(query: str, state: Annotated[dict, InjectedState]) -> str:
         print("Keyboard Interrupt of command: ", query)
         stdout, stderr = "", "KeyboardInterrupt:"
 
-    print("STDOUT: ", stdout)
-    print("STDERR: ", stderr)
+    # Fit BOTH streams under a single overall cap
+    stdout_fit, stderr_fit = _fit_streams_to_budget(
+        stdout or "", stderr or "", MAX_TOOL_MSG_CHARS
+    )
 
-    return f"STDOUT: {stdout} and STDERR: {stderr}"
+    print("STDOUT: ", stdout_fit)
+    print("STDERR: ", stderr_fit)
+
+    return f"STDOUT:\n{stdout_fit}\nSTDERR:\n{stderr_fit}"
 
 
 def _strip_fences(snippet: str) -> str:

--- a/src/ursa/agents/execution_agent.py
+++ b/src/ursa/agents/execution_agent.py
@@ -285,6 +285,7 @@ def _snip_text(text: str, max_chars: int) -> tuple[str, bool]:
         True,
     )
 
+
 def _fit_streams_to_budget(stdout: str, stderr: str, total_budget: int):
     label_overhead = len("STDOUT:\n") + len("\nSTDERR:\n")
     budget = max(0, total_budget - label_overhead)
@@ -300,9 +301,11 @@ def _fit_streams_to_budget(stdout: str, stderr: str, total_budget: int):
     stderr_snip, _ = _snip_text(stderr, stderr_budget)
     return stdout_snip, stderr_snip
 
+
 # the idea here is that we just set a limit - the user could overload
 # that in their env, or maybe we could pull this out of the LLM parameters
-MAX_TOOL_MSG_CHARS = int(os.getenv("MAX_TOOL_MSG_CHARS", "100000"))
+MAX_TOOL_MSG_CHARS = int(os.getenv("MAX_TOOL_MSG_CHARS", "50000"))
+
 
 @tool
 def run_cmd(query: str, state: Annotated[dict, InjectedState]) -> str:


### PR DESCRIPTION
This snips over-long stdout/stderr returns from run_cmd, does a head/tail w/ a "snipped" text in the middle.