### PR TITLE
add pricing.json as package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,9 @@ pycodestyle.max-doc-length = 80
 [tool.ruff.lint.extend-per-file-ignores]
 "tests/**/*.py" = ["D"]
 
+[tool.setuptools.package-data]
+ursa = ["observability/pricing.json"]
+
 [dependency-groups]
 dev = [
     "langgraph-checkpoint-sqlite>=2.0.10",


### PR DESCRIPTION
`pricing.json` currently is not included as package data, so is never used when installed as a package. This is the fix.