### PR TITLE
Safety prompt updates

### DIFF
--- a/src/ursa/agents/execution_agent.py
+++ b/src/ursa/agents/execution_agent.py
@@ -421,6 +421,11 @@ def edit_code(
         f"[bold bright_white on green] :heavy_check_mark: [/] "
         f"[green]File updated:[/] {code_file}"
     )
+    file_list = state.get("code_files", [])
+    if code_file not in file_list:
+        file_list.append(filename)
+    state["code_files"] = file_list
+
     return f"File {filename} updated successfully."
 
 

--- a/src/ursa/cli/__init__.py
+++ b/src/ursa/cli/__init__.py
@@ -117,6 +117,7 @@ def run(
         emb_api_key=emb_api_key,
         share_key=share_key,
         thread_id=thread_id,
+        safe_codes=safe_codes,
         arxiv_summarize=arxiv_summarize,
         arxiv_process_images=arxiv_process_images,
         arxiv_max_results=arxiv_max_results,
@@ -201,7 +202,14 @@ def serve(
     thread_id: Annotated[
         str,
         Option(help="Thread ID for persistance", envvar="URSA_THREAD_ID"),
-    ] = "ursa_cli",
+    ] = "ursa_mcp",
+    safe_codes: Annotated[
+        list[str],
+        Option(
+            help="Programming languages that the execution agent can trust by default.",
+            envvar="URSA_THREAD_ID",
+        ),
+    ] = ["python", "julia"],
     arxiv_summarize: Annotated[
         bool,
         Option(
@@ -270,6 +278,7 @@ def serve(
         emb_api_key=emb_api_key,
         share_key=share_key,
         thread_id=thread_id,
+        safe_codes=safe_codes,
         arxiv_summarize=arxiv_summarize,
         arxiv_process_images=arxiv_process_images,
         arxiv_max_results=arxiv_max_results,

--- a/src/ursa/cli/hitl.py
+++ b/src/ursa/cli/hitl.py
@@ -66,6 +66,7 @@ class HITL:
     emb_api_key: Optional[str]
     share_key: bool
     thread_id: str
+    safe_codes: list[str]
     arxiv_summarize: bool
     arxiv_process_images: bool
     arxiv_max_results: int
@@ -176,6 +177,7 @@ class HITL:
             checkpointer=self.executor_checkpointer,
             agent_memory=self.memory,
             thread_id=self.thread_id + "_executor",
+            safe_codes=self.safe_codes,
         )
 
     @cached_property

--- a/src/ursa/prompt_library/execution_prompts.py
+++ b/src/ursa/prompt_library/execution_prompts.py
@@ -38,11 +38,13 @@ Your responsibilities is to write a condensed summary of the conversation.
 
 def get_safety_prompt(query, safe_codes, created_files):
     return f"""
-            Assume commands to run/install the following are safe because they are from a trusted source:
-            {", ".join(safe_codes)}
-            Also assume the following are files you have created:
-            {created_files}
-            so they are safe to be compiled or run, regardless of the interpreter.
+            Assume any of the following are safe:
+                - Commands to run/install the following with any files, because they are from a trusted source:
+                    {", ".join(safe_codes)}
+
+                - You can also assume the following are files you have created:
+                    {created_files}
+                  so they are safe to be compiled or run, regardless of the interpreter.
 
             Explain why, followed by an answer [YES] or [NO]. Is this command safe to run: {query}
             """


### PR DESCRIPTION
Updated the safety prompt to allow for user customization:

- The ExecutionAgent now has an attribute "safe_codes" that defaults to a list: ["python", "julia"] but which the user can change or append new things onto. This allows the user more flexibility in allowing the execution agent to write code.
- The CLI and MCP arguments have safe-codes added so that they can take advantage of this. An example I did on my Mac used the command `ursa run --safe-codes '["python","julia", "C", "C++"]'` and then the CLI allowed writing, compiling and running of C++ code for instance.
- The safety prompt is also given the list of URSA written files and an indication that they are trustworthy, even if the language isnt in safe_codes. I tested by using the default safe codes and asking it to write and run R code and this worked. 

