### PR TITLE
Changing the metrics folder to be visible by default. 

### DIFF
--- a/src/ursa/agents/base.py
+++ b/src/ursa/agents/base.py
@@ -125,7 +125,7 @@ class BaseAgent(ABC):
         llm: BaseChatModel,
         checkpointer: Optional[BaseCheckpointSaver] = None,
         enable_metrics: bool = True,
-        metrics_dir: str = ".ursa_metrics",  # dir to save metrics, with a default
+        metrics_dir: str = "ursa_metrics",  # dir to save metrics, with a default
         autosave_metrics: bool = True,
         thread_id: Optional[str] = None,
         **kwargs,


### PR DESCRIPTION
I think we would rather not have users surprised that we made a bunch of files all over. Not that they are very big, but it can be frustrating to find the folders I didnt realize existed. People can always made the metrics folder hidden if they want to.