### PR TITLE
tiny fix to openai model string in YAML py

### DIFF
--- a/examples/two_agent_examples/plan_execute/plan_execute_from_yaml.py
+++ b/examples/two_agent_examples/plan_execute/plan_execute_from_yaml.py
@@ -1487,9 +1487,10 @@ def parse_args_and_user_inputs():
     DEFAULT_MODELS = tuple(
         models_cfg.get("choices")
         or (
+            "openai:gpt-5",
             "openai:gpt-5-mini",
-            "openai:gpt-5-mini",
-            "openai:gpt-5-mini",
+            "openai:o3",
+            "openai:o3-mini",
         )
     )
     DEFAULT_MODEL = models_cfg.get("default")  # may be None


### PR DESCRIPTION
Someone that had fixed the YAML py had just repeatedly in this `or` block said gpt-5-mini over and over again.  fixed.