### PR TITLE
use `__version__`

### DIFF
--- a/src/ursa/cli/__init__.py
+++ b/src/ursa/cli/__init__.py
@@ -147,9 +147,9 @@ def run(
 
 @app.command()
 def version() -> None:
-    from importlib.metadata import version as get_version
+    from ursa import __version__
 
-    print(get_version("ursa-ai"))
+    print(__version__)
 
 
 @app.command(help="Start MCP server to serve ursa agents")

--- a/src/ursa/cli/hitl_api.py
+++ b/src/ursa/cli/hitl_api.py
@@ -1,13 +1,14 @@
-from importlib.metadata import version as get_version
 from typing import Annotated, Literal
 
 from fastapi import Depends, FastAPI, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from ursa import __version__
+
 mcp_app = FastAPI(
     title="URSA Server",
     description="Micro-service for hosting URSA to integrate as an MCP tool.",
-    version=get_version("ursa-ai"),
+    version=__version__,
 )
 
 


### PR DESCRIPTION
Replace redundant fetches of version metadata with `__version__`.