### PR TITLE
Updating the pricing to include the GPT 5.1 OpenAI models.

### DIFF
--- a/src/ursa/observability/pricing.json
+++ b/src/ursa/observability/pricing.json
@@ -29,8 +29,8 @@
   "gpt-5-codex":                 { "input_per_1k": 0.00125, "output_per_1k": 0.01,   "cached_input_multiplier": 0.1 },
   "openai:gpt-5-codex":          { "input_per_1k": 0.00125, "output_per_1k": 0.01,   "cached_input_multiplier": 0.1 },
 
-  "gpt-4.1":                     { "input_per_1k": 0.002,   "output_per_1k": 0.016,  "cached_input_multiplier": 0.25 },
-  "openai:gpt-4.1":              { "input_per_1k": 0.002,   "output_per_1k": 0.016,  "cached_input_multiplier": 0.25 },
+  "gpt-4.1":                     { "input_per_1k": 0.002,   "output_per_1k": 0.008,  "cached_input_multiplier": 0.25 },
+  "openai:gpt-4.1":              { "input_per_1k": 0.002,   "output_per_1k": 0.008,  "cached_input_multiplier": 0.25 },
 
   "gpt-4.1-mini":                { "input_per_1k": 0.0004,  "output_per_1k": 0.0016, "cached_input_multiplier": 0.25 },
   "openai:gpt-4.1-mini":         { "input_per_1k": 0.0004,  "output_per_1k": 0.0016, "cached_input_multiplier": 0.25 },


### PR DESCRIPTION
Small update to include the GPT 5.1 models in the pricing JSON.

At some point we should add popular non-OpenAI models like Gemini and Claude, but for now its good just to be updated to the new OpenAI models.