### PR TITLE
shortened rename of image pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ behaviors above for docker.
 
 ```shell
 # Pull the image
-ch-image pull ghcr.io/lanl/ursa
+ch-image pull ghcr.io/lanl/ursa ursa
 
 # Convert image to sqfs, for use on another system
 ch-convert ursa ursa.sqfs


### PR DESCRIPTION
this is necessary for the subsequent line to work:

`ch-convert ursa ursa.sqfs`

otherwise, you need:

`ch-convert ghcr.io/lanl/ursa ursa.sqfs`