### PR TITLE
Fixing a bug where the wall time was added to the on_llm_end function…

### DIFF
--- a/src/ursa/observability/timing.py
+++ b/src/ursa/observability/timing.py
@@ -745,7 +745,7 @@ class PerLLMTimer(BaseCallbackHandler):
             "metadata": metadata,
             "metrics": metrics,
             "t_start": wall_t0,
-            "t_end": wall_t1,  # <— add these
+            "t_end": wall_t1,
         })
 
     def on_llm_error(self, error, *, run_id, **kwargs):
@@ -763,7 +763,7 @@ class PerLLMTimer(BaseCallbackHandler):
             "metadata": metadata,
             "metrics": {"error": repr(error)},
             "t_start": wall_t0,
-            "t_end": wall_t1,  # <— add these
+            "t_end": wall_t1,
         })
 
 


### PR DESCRIPTION
… in observability but not on_llm_error

Fixing the occasional warning that looks like:
`Error in PerLLMTimer.on_llm_error callback: ValueError('too many values to unpack (expected 4)')`