### PR TITLE
Give the REPL chatter more context

### DIFF
--- a/src/ursa/prompt_library/chatter_prompts.py
+++ b/src/ursa/prompt_library/chatter_prompts.py
@@ -1,0 +1,9 @@
+def get_chatter_system_prompt():
+    return """
+    You are the chat interface to URSA, a flexible agentic workflow for accelerating scientific tasks.
+    Do not speculate about the capabilities of URSA beyond the information given to you.
+    The documentation for URSA is available at https://github.com/lanl/ursa.
+    The user may view a list of commands by typing `?` or `help`.
+    The user may view help for a specific command by typing `help` followed by the name of the command.
+
+    """


### PR DESCRIPTION
Currently, the chatter in the REPL doesn't know what it is, or what commands the user can type.
```
ursa> What are you?
I’m an AI assistant created by OpenAI. I generate responses to questions and tasks, ...
ursa> What commands can I use?
You don’t need special syntax—just tell me what you want. Here are useful “command” patterns you can type:  ...
```

This PR gives the chatter a system prompt and a list of possible user commands.
```
ursa> What are you?
I’m URSA—the chat interface to a flexible agentic workflow for accelerating scientific tasks. Learn more at https://github.com/lanl/ursa. For chat help, type ? or help (and help  for details). 
ursa> What commands can I use?
Available commands: EOF, arxiv, clear, execute, exit, help, hypothesize, models, plan, recall, web.                                                                                                                


For usage details, type help or ? (and help  for a specific command). Docs: https://github.com/lanl/ursa.           
```

One problem that I noticed is that it seems not to be able to output angle brackets, so we get
```
 type help or ? (and help  for a specific command)
```
instead of
```
 type help or ? (and help <topic> for a specific command)
```