### PR TITLE
feat: add native Groq LLM provider support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "langchain-chroma>=1.0.0",
     "langchain-community>=0.4.1",
     "langchain-openai>=1.0.1",
+    "langchain-groq>=0.3.0",
     "langgraph-checkpoint-sqlite>=3.0.0",
     "langchain-text-splitters>=1.0.0",
     "langchain-ollama>=1.0.0",


### PR DESCRIPTION
## Summary
Adds native Groq support by including `langchain-groq` as a dependency.

## Changes
- Added `langchain-groq>=0.3.0` to dependencies in `pyproject.toml`

## Usage
After this change, users can run URSA with Groq models natively:

```bash
export GROQ_API_KEY="your-api-key"
ursa run --llm-model-name groq:llama-3.3-70b-versatile
```

This eliminates the need to route through OpenAI-compatible `base_url` workaround for Groq models.