### PR TITLE
hypothesizer updates, refactoring yaml stuff

### DIFF
--- a/examples/single_agent_examples/hypothesizer_agent/README.md
+++ b/examples/single_agent_examples/hypothesizer_agent/README.md
@@ -1,6 +1,13 @@
 For the Sci-Fi Bill of Rights demo, see sci_fi_bill_of_rights_inputs/README.txt.
 It requires downloading some public TXT files.
 
+Then try:
+`python ./doc_critique_writer.py --config ./sci_fi_bill_of_rights.yaml`
+
+It'll create a unique directory name where a `.txt` and `.tex` file will
+appear after it's done.  You can run `xelatex` on the `.tex` file if you
+want to turn that into a PDF for viewing.
+
 If you want to use this on PDFs, particularly ones that need OCR, then you
 need to install some additional Python libraries.  At this time we haven't
 required those baked into URSA.

--- a/examples/single_agent_examples/hypothesizer_agent/doc_critique_writer.py
+++ b/examples/single_agent_examples/hypothesizer_agent/doc_critique_writer.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""
+Run the Hypothesizer agent on the YAML config/problem + local input docs.
+
+Usage:
+    python doc_critique_writer.py --config path/to/config.yaml [--workspace my_ws]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+# LLM + agent helpers from your refactor
+from rich import get_console
+from rich.panel import Panel
+
+# Hypothesizer agent class (your codebase)
+from ursa.agents import HypothesizerAgent
+from ursa.cli.config import UrsaConfig, deep_interp_env
+from ursa.util.llm_factory import setup_llm
+from ursa.util.run_meta import save_run_meta
+from ursa.util.workspace import ensure_symlink, setup_workspace
+
+console = get_console()
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Run Hypothesizer using YAML config"
+    )
+    p.add_argument(
+        "--config",
+        required=True,
+        help="YAML config file (same format as runner)",
+    )
+    p.add_argument(
+        "--workspace", required=False, help="Workspace path (optional)"
+    )
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    try:
+        with open(args.config, "r", encoding="utf-8") as f:
+            raw_cfg = yaml.safe_load(f) or {}
+        raw_cfg = deep_interp_env(raw_cfg)
+        cfg = UrsaConfig.model_validate(raw_cfg, extra="ignore")
+    except FileNotFoundError:
+        console.print("[red]Config file not found[/]")
+        sys.exit(2)
+
+    model_choice = cfg.llm_model.model
+
+    # workspace
+    project = raw_cfg.get("project", "run")
+    workspace = setup_workspace(
+        user_specified_workspace=args.workspace,
+        project=project,
+        model_name=model_choice,
+        console=console,
+    )
+    # --- apply symlink into the NEW workspace (so any input docs exists there) ---
+    symlink_cfg = raw_cfg.get("symlink")
+    if (
+        isinstance(symlink_cfg, dict)
+        and symlink_cfg.get("source")
+        and symlink_cfg.get("dest")
+    ):
+        ensure_symlink(workspace=workspace, symlink_cfg=symlink_cfg)
+
+    # --- prepare Hypothesizer agent ---
+    llm = setup_llm(
+        model_config=cfg.llm_model,
+        agent_name="hypothesizer",
+        console=console,
+    )
+
+    # max_iterations: look in YAML under a top-level 'hypothesizer' key or fallback
+    hs_cfg = raw_cfg.get("hypothesizer", {}) or {}
+    max_iters = hs_cfg
+    max_iterations = (
+        max_iters.get("max_iterations") if isinstance(max_iters, dict) else None
+    )
+    if max_iterations is None:
+        max_iterations = raw_cfg.get("max_iterations", 2)
+    try:
+        max_iterations = int(max_iterations)
+    except Exception:
+        max_iterations = 2
+
+    # whether to use web search (default False for privacy/local-docs workflows)
+    use_search = False
+    if isinstance(hs_cfg, dict):
+        use_search = bool(hs_cfg.get("use_search", False))
+
+    # instantiate agent
+    agent = HypothesizerAgent(
+        llm=llm,
+        max_iterations=max_iterations,
+        workspace=workspace,
+        enable_web_search=use_search,
+    )
+
+    prompts_cfg = hs_cfg.get("prompts", {}) if isinstance(hs_cfg, dict) else {}
+
+    if isinstance(prompts_cfg, dict):
+        p1 = prompts_cfg.get("agent1_hypothesizer")
+        p2 = prompts_cfg.get("agent2_critic")
+        p3 = prompts_cfg.get("agent3_competitor")
+
+        # Override only if provided (otherwise keep defaults from prompt_library)
+        if p1:
+            agent.hypothesizer_prompt = p1
+        if p2:
+            agent.critic_prompt = p2
+        if p3:
+            agent.competitor_prompt = p3
+
+        if any([p1, p2, p3]):
+            console.print("[dim]Loaded prompt overrides from YAML.[/]")
+
+    # save run meta fingerprint so other tools can find this run
+    save_run_meta(workspace, tool="hypothesizer_agent", model=model_choice)
+
+    # --- problem text from YAML ---
+    problem_text = raw_cfg.get("problem")
+    if not problem_text:
+        console.print(
+            "[yellow]No 'problem' found in config; using default test question.[/]"
+        )
+        problem_text = "Why did the test server intermittently fail health checks after the 02:00 deploy?"
+
+    # --- derive local docs directory from YAML symlink.dest if present ---
+    symlink_cfg = raw_cfg.get("symlink", {}) or {}
+    # --- derive local docs directory from YAML symlink.dest (INSIDE workspace) ---
+    input_docs_dir = None
+    if isinstance(symlink_cfg, dict):
+        dest = symlink_cfg.get("dest")
+        if dest:
+            input_docs_dir = str((Path(workspace) / dest).resolve())
+
+    # If there is no symlink, allow explicit hypothesizer.input_docs_dir (also treat as inside workspace if relative)
+    if isinstance(hs_cfg, dict) and not input_docs_dir:
+        explicit = hs_cfg.get("input_docs_dir")
+        if explicit:
+            p = Path(explicit).expanduser()
+            input_docs_dir = (
+                str((Path(workspace) / p).resolve())
+                if not p.is_absolute()
+                else str(p)
+            )
+
+    # sanity: if still None, leave it None (agent will behave without docs)
+    console.print(
+        Panel.fit(
+            f"[bold]Problem:[/] {problem_text}",
+            title="[bold green]Hypothesizer Input[/]",
+        )
+    )
+    if input_docs_dir:
+        console.print(f"[dim]Using local docs dir: {input_docs_dir}[/]")
+
+    # build the initial state for the agent
+    initial_state = {
+        "question": problem_text,
+        "question_search_query": "",
+        "current_iteration": 0,
+        "max_iterations": max_iterations,
+        "agent1_solution": [],
+        "agent2_critiques": [],
+        "agent3_perspectives": [],
+        "solution": "",
+        "summary_report": "",
+        "visited_sites": set(),
+        # custom
+        "input_docs_dir": input_docs_dir,
+    }
+
+    console.print(
+        f"[blue]Invoking Hypothesizer (max_iterations={max_iterations}, use_search={use_search})...[/]"
+    )
+
+    result = asyncio.run(
+        agent.ainvoke(
+            initial_state,
+            config={
+                "recursion_limit": 999999,
+                "configurable": {"thread_id": agent.thread_id},
+            },
+        )
+    )
+
+    # Print results
+    solution = result.get("solution", "")
+    summary = result.get("summary_report", "")
+
+    console.print(
+        Panel.fit(
+            f"[bold green]Hypothesizer Final Solution[/]\n\n{solution[:400]}",
+            title="[bold green]Result Preview[/]",
+        )
+    )
+    # If model returned JSON-ish content, try to pretty print it
+    try:
+        parsed = json.loads(solution)
+        console.print(Panel.fit("[bold]Structured output (JSON)[/]\n"))
+        console.print_json(data=parsed)
+    except Exception:
+        # not JSON - show full solution in truncated form and write to disk
+        out_path = Path(workspace) / "hypothesizer_solution.txt"
+        out_path.write_text(solution, encoding="utf-8")
+        console.print(f"[dim]Full solution written to {out_path}[/]")
+
+    # write summary/latex preview if present
+    if summary:
+        summary_path = Path(workspace) / "hypothesizer_summary.tex"
+        summary_path.write_text(summary, encoding="utf-8")
+        console.print(
+            f"[dim]LaTeX summary written to {summary_path} (preview saved)[/]"
+        )
+
+    console.print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/single_agent_examples/hypothesizer_agent/sci_fi_bill_of_rights.yaml
+++ b/examples/single_agent_examples/hypothesizer_agent/sci_fi_bill_of_rights.yaml
@@ -1,0 +1,167 @@
+project: sci_fi_bill_of_rights_run
+
+# omit if not needed
+# this is where you might link in a local dataset you want the agents
+# to have access to, or a program (simulation, executable, etc) or
+# libraries you have locally that you want the agent to use.
+# to be clear, you'd then tell the agent (below) that it has
+# access to the files you describe in 'dest' in the symlink
+# below.
+symlink:
+  # NOTE:
+  # please go into ./sci_fi_bill_of_rights_inputs/, read the README.txt and
+  # download the files for this example to work
+  source: ./sci_fi_bill_of_rights_inputs/
+  dest: ./input_docs/
+
+models:
+  choices:
+    - openai:gpt-5.2
+    - openai:gpt-5
+    - openai:o3
+    - openai:o3-mini
+    - my_endpoint:openai/gpt-oss-120b # <— example external endpoint + model
+  default: openai:gpt-5.2
+
+  # map provider aliases to connection details
+  providers:
+    openai:
+      model_provider: openai             # LangChain provider to use
+      base_url: null                     # use OpenAI default
+      api_key_env: OPENAI_API_KEY
+
+    my_endpoint:
+      model_provider: openai             # uses ChatOpenAI client under the hood
+      base_url: "https://some.example.model.endpoint.url/vllm/v1" 
+      api_key_env: SOME_API_KEY_HERE_THIS_PROVIDER_WILL_LOOK_FOR_IN_YOUR_USER_ENVIRONMENT
+
+  # this profiles section is optional, if you don't include it the LLM model will manage
+  # defaults, which might not be what you want.
+  profiles:
+    fast:
+      # i'm not confident temperature is even used in reasoning models anymore, i think this
+      # is entirely ignored
+      temperature: 0.2
+      max_completion_tokens: 6000
+      reasoning:
+        effort: low
+    balanced:
+      temperature: 0.2
+      max_completion_tokens: 15000
+      reasoning:
+        effort: medium
+    deep: 
+      temperature: 0.2 
+      max_completion_tokens: 50000
+      reasoning: 
+        effort: high
+
+  # defaults are the, well, default profiles
+  defaults: 
+    profile: fast 
+    params: {} # optional extra kwargs always applied
+    # Per-agent overrides (planner vs executor) 
+    
+  agents: 
+    hypothesizer: 
+      profile: fast 
+
+# planning_mode must either be 'single' or 'heirarchical'
+# single is one pass through planning and then it executes each
+#   step of the plan sequentially
+# heirarchical starts w/ a single plan, and THEN, for each step it
+#   plans that step again (effectively steps 1-10 might turn into
+#   1.1 -> 1.5, 2.1 -> 2.3, . . . 10.0 -> 10.7).  This can both
+#   increase runtime and result quality substantially
+# if you leave it empty, it will just prompt you
+planning_mode: # single
+
+# logos are a fun little thing where we use a vision model to generate 'logos' for your
+# project based on the project name and the randomly generated workspace name
+# 'scene' is a wide scene and 'stickers' are a logo-like mascot sticker for your
+# project.  
+logo:
+  enabled: false    # on/off
+  scene: random     # e.g., noir, sci-fi, horror, fantasy, etc. ("random" by default)
+  stickers: true    # also make sticker variants
+  n: 2              # how many variants for each batch
+  model: openai:gpt-image-1 # warning: most 'vision' models do not support image *GENERATION*, this one does
+
+hypothesizer:
+  use_search: true # true/false = on/off
+  max_iterations: 1
+  # input_docs_dir: ./input_docs
+  # input_docs_dir isn't necessary if you symlink a dir in (above), but you can do it this way as well
+
+  prompts:
+    agent1_hypothesizer: |
+      You are Agent 1 (Hypothesizer).
+
+      You MUST ground your work in the provided local document context (the concatenated .txt files).
+      Do not rely on prior knowledge of famous/public texts; treat the provided excerpts as the source of truth.
+
+      Output format (must follow exactly):
+
+      DOC_FINGERPRINTS:
+      - <filename> | chars=<int> | sha256_8=<8hex> | sentinel=<value or NONE>
+
+      EVIDENCE_EXCERPTS:
+      - E1: <filename>:L<start>-L<end> "<short quote>"
+      - E2: ...
+
+      PROPOSED_AMENDMENTS:
+      - A1 (New): <one-sentence amendment text>
+        Evidence: [E1, E3]
+      - A2 (Modify <existing amendment #>): <one-sentence modification>
+        Evidence: [E2]
+
+      Rules:
+      - Every amendment MUST cite at least one Evidence excerpt ID.
+      - Every Evidence excerpt MUST be a verbatim quote from the provided context.
+      - Keep amendments concise (1–3 sentences each). No filler.
+
+      If this is not the first iteration:
+      - First list "CHANGES_FROM_LAST_ITERATION:" with bullet points describing updates made in response to critique and competitor perspective.
+    agent2_critic: |
+      You are Agent 2 (Critic). Be rigorous and specific.
+
+      You MUST critique using ONLY:
+      - The proposed amendments
+      - The DOC_FINGERPRINTS and EVIDENCE_EXCERPTS provided
+      - The original question
+
+      Do NOT perform web searches. Do NOT introduce outside facts.
+
+      Output:
+      CRITIQUE:
+      - List concrete issues (ambiguity, missing edge cases, weak evidence mapping, conflicts with existing rights, enforcement problems).
+      - For each issue, cite the relevant amendment ID (A#) and (if applicable) evidence IDs (E#).
+      RECOMMENDATIONS:
+      - Bullet list of improvements. Must be actionable.
+    agent3_competitor: |
+      You are Agent 3 (Competitor/Stakeholder). Provide a realistic adversarial response.
+
+      You MUST use ONLY what is in:
+      - Proposed amendments (A#)
+      - Evidence excerpts (E#)
+      - The question
+
+      No web search. No outside facts.
+
+      Output:
+      COUNTERARGUMENTS:
+      - For each A#, describe how an opposing stakeholder would exploit ambiguity, challenge legitimacy, or cause unintended consequences.
+      - Cite A# and any E# you are responding to.
+
+problem: |
+  * TITLE: Sci Fi Bill of Rights
+
+  You have a directory in your workspace named: ./input_docs/
+  In there, you will find 2 text documents - the US Bill of Rights and
+  one science fiction document.  Both are freely available docs from
+  Project Gutenberg.
+
+  Using the U.S. Bill of Rights as the baseline, and treating the sci-fi doc
+  as a cautionary future scenario, identify rights that are missing, insufficient, 
+  or dangerously ambiguous. Propose new constitutional amendments or 
+  modifications to existing ones to address those gaps.

--- a/examples/single_agent_examples/hypothesizer_agent/sci_fi_bill_of_rights_inputs/README.txt
+++ b/examples/single_agent_examples/hypothesizer_agent/sci_fi_bill_of_rights_inputs/README.txt
@@ -1,0 +1,15 @@
+README.txt
+==========
+
+This directory expects two public-domain text files.
+They are NOT included in the repo.
+
+Download them with:
+
+    wget https://www.gutenberg.org/ebooks/2.txt.utf-8 -O us_bill_of_rights.txt
+    wget https://www.gutenberg.org/files/35/35-0.txt -O the_time_machine.txt
+
+After downloading, this directory should contain:
+
+    us_bill_of_rights.txt
+    the_time_machine.txt

--- a/examples/two_agent_examples/plan_execute/hello_world.yaml
+++ b/examples/two_agent_examples/plan_execute/hello_world.yaml
@@ -1,0 +1,40 @@
+project: hello_world
+
+models:
+  choices:
+    - openai:gpt-5-mini
+    # - my_endpoint:openai/gpt-oss-120b # <— example external endpoint + model
+  default: openai:gpt-5-mini
+
+  # map provider aliases to connection details
+  providers:
+    openai:
+      model_provider: openai             # LangChain provider to use
+      base_url: null                     # use OpenAI default
+      api_key_env: OPENAI_API_KEY
+    # for other options, see other YAML file examples
+
+planning_mode: single
+
+logo:
+  enabled: false    # on/off
+
+problem: |
+  * TITLE: Hello World 
+
+  Your task is to write a Python hello world file.  
+
+  You are to use the Rich console functionality to write out a Hello World
+  example.  It should (1) demonstrate some features of Rich (at least several,
+  including colors), (2) include at least 1 emoji (bonus points for more, if
+  you can make them relevant), and (3) include some sort of ASCII art.
+  Finally (4) include some sort of meme or humor into this, at your
+  discretion.  Dealer's Choice!
+
+  CONSTRAINTS:
+     * There should be a single hello_world.py file created and modified
+       if necessary.
+     * You must run hello_world.py, which will display to the user.
+     * Do not install any additional packages.
+     * Do not use git for any reason.
+     * Make sure you make it colorful and fun!

--- a/examples/two_agent_examples/plan_execute/plan_execute_from_yaml.py
+++ b/examples/two_agent_examples/plan_execute/plan_execute_from_yaml.py
@@ -620,7 +620,7 @@ def main(
             sys.exit(1)
 
         # lock planning_mode per workspace
-        planning_mode, mode_locked = lock_or_warn_planning_mode(
+        planning_mode, _ = lock_or_warn_planning_mode(
             workspace, planning_mode, console=console
         )
         console.print(
@@ -750,7 +750,7 @@ def main(
         save_run_meta(workspace, thread_id=thread_id, model_name=model_name)
 
         # do the main planning step, or load it from checkpoint
-        plan_dict, plan_steps, plan_sig = main_plan_load_or_perform(
+        _, plan_steps, plan_sig = main_plan_load_or_perform(
             planner,
             planner_checkpointer,
             pdb_path,

--- a/examples/two_agent_examples/plan_execute/plan_execute_from_yaml.py
+++ b/examples/two_agent_examples/plan_execute/plan_execute_from_yaml.py
@@ -1,19 +1,16 @@
 import argparse
 
 # needed for checkpoint / restart
-import hashlib
-import importlib
 import json
-import os
 import sqlite3
 import sys
 from pathlib import Path
-from types import SimpleNamespace as NS
 from typing import Any
 
-import randomname
+#########################################################################
+# BEGIN: URSA utilities imports
+#########################################################################
 import yaml
-from langchain.chat_models import init_chat_model
 from langchain_core.messages import HumanMessage
 from langgraph.checkpoint.sqlite import SqliteSaver
 
@@ -24,9 +21,41 @@ from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn
 from rich.text import Text
 
 from ursa.agents import ExecutionAgent, PlanningAgent
+from ursa.cli.config import (
+    UrsaConfig,
+    deep_interp_env,
+    get_config_planning_mode,
+    get_default_model,
+    get_default_models,
+    get_models_cfg,
+)
 from ursa.observability.timing import render_session_summary
+from ursa.util.checkpoint_fs import (
+    ckpt_dir,
+    hash_plan,
+    load_exec_progress,
+    parse_snapshot_indices,
+    resolve_resume_checkpoint,
+    restore_executor_from_snapshot,
+    save_exec_progress,
+    snapshot_sqlite_db,
+    sync_progress_for_snapshot_single,
+)
+from ursa.util.interactive import timed_input_with_countdown
+from ursa.util.llm_factory import setup_llm
 from ursa.util.logo_generator import kickoff_logo
 from ursa.util.plan_renderer import render_plan_steps_rich
+from ursa.util.run_meta import (
+    load_run_meta,
+    lock_or_warn_planning_mode,
+    save_run_meta,
+)
+from ursa.util.workspace import setup_workspace
+
+#########################################################################
+# END: URSA utilities imports
+#########################################################################
+
 
 console = get_console()  # always returns the same instance
 
@@ -126,82 +155,6 @@ def _last_message_text(messages) -> str:
 #########################################################################
 
 
-#########################################################################
-# BEGIN: Helpers for execution agent checkpoint/restart
-#########################################################################
-
-
-def _ckpt_dir(workspace: str) -> Path:
-    p = Path(workspace) / "checkpoints"
-    p.mkdir(parents=True, exist_ok=True)
-    return p
-
-
-# --- execution progress tracking (per workspace) ---
-def _progress_file(workspace: str) -> Path:
-    return Path(workspace) / "executor_progress.json"
-
-
-def _hash_plan(plan_steps) -> str:
-    # hash the structure so we can detect if the plan changed between runs
-    return hashlib.sha256(
-        json.dumps(plan_steps, sort_keys=True, default=str).encode("utf-8")
-    ).hexdigest()
-
-
-def load_exec_progress(workspace: str) -> dict:
-    p = _progress_file(workspace)
-    if p.exists():
-        try:
-            return json.loads(p.read_text())
-        except Exception:
-            return {}
-    return {}
-
-
-# we have to save the last step in here too
-def save_exec_progress(
-    workspace: str,
-    next_index: int,
-    plan_hash: str,
-    last_summary: str | None = None,
-) -> None:
-    p = _progress_file(workspace)
-    payload = {"next_index": int(next_index), "plan_hash": plan_hash}
-    if last_summary is not None:
-        payload["last_summary"] = last_summary
-    p.write_text(json.dumps(payload, indent=2))
-
-
-# --- snapshot a consistent copy of a SQLite db (works even in WAL mode) ---
-def snapshot_sqlite_db(src_path: Path, dst_path: Path) -> None:
-    """
-    Make a consistent copy of the SQLite database at src_path into dst_path,
-    using the sqlite3 backup API. Safe with WAL; no need to copy -wal/-shm.
-    """
-    import sqlite3
-
-    dst_path.parent.mkdir(parents=True, exist_ok=True)
-    src_uri = f"file:{Path(src_path).resolve().as_posix()}?mode=ro"
-    src = dst = None
-    try:
-        src = sqlite3.connect(src_uri, uri=True)
-        dst = sqlite3.connect(str(dst_path))
-        with dst:
-            src.backup(dst)
-    finally:
-        try:
-            if dst:
-                dst.close()
-        except Exception:
-            pass
-        try:
-            if src:
-                src.close()
-        except Exception:
-            pass
-
-
 def step_to_text(step) -> str:
     if isinstance(step, dict):
         name = (
@@ -213,243 +166,6 @@ def step_to_text(step) -> str:
         desc = step.get("description") or ""
         return f"{name}\n{desc}" if desc else name
     return str(step)
-
-
-# --- parse snapshot filename to indices ---
-def parse_snapshot_indices(p: Path) -> tuple[int | None, int | None]:
-    """
-    executor_5.db / executor_checkpoint_5.db => (5, None)
-    executor_3_2.db / executor_checkpoint_3_2.db => (3, 2)
-    """
-    import re
-
-    m = re.match(
-        r"(?:executor|executor_checkpoint)_(\d+)(?:_(\d+))?\.db$", p.name
-    )
-    if not m:
-        return None, None
-    a = int(m.group(1))
-    b = int(m.group(2)) if m.group(2) else None
-    return a, b
-
-
-def sync_progress_for_snapshot_single(
-    workspace: str, snapshot: Path, plan_sig: str
-) -> None:
-    """
-    For SINGLE mode snapshots, set executor_progress.json so the engine resumes at the right step.
-    executor_<k>.db means 'k' steps completed ⇒ next_index = k (0-based start from k).
-    """
-    k, _ = parse_snapshot_indices(snapshot)
-    if not k:
-        # Not a numbered snapshot (e.g., executor_checkpoint.db) — leave JSON as-is
-        print(
-            "[resume] Using live/default checkpoint; not altering executor_progress.json."
-        )
-        return
-    prog_path = _progress_file(workspace)
-    payload = {
-        "next_index": int(
-            k
-        ),  # start loop at idx=k (i.e., step k+1 in 1-based terms)
-        "plan_hash": str(plan_sig),
-        "last_summary": f"Resumed from snapshot {snapshot.name}",
-    }
-    prog_path.write_text(json.dumps(payload, indent=2))
-    print(
-        f"[resume] Wrote {prog_path.name}: next_index={k}, plan_hash={plan_sig[:8]}. . ."
-    )
-
-
-# --- discover & sort checkpoints in a workspace ---
-def _ckpt_sort_key(p: Path):
-    import re
-
-    name = p.name
-    pat = r"executor_checkpoint_(\d+)(?:_(\d+))?\.db$"
-    m = re.match(pat, name)
-    if m:
-        a = int(m.group(1))
-        b = int(m.group(2) or 0)
-        return (0, a, b, name)  # numbered snapshots first
-    if name == "executor_checkpoint.db":
-        return (1, float("inf"), float("inf"), name)  # live default next
-    # anything else sinks to the bottom (shouldn't appear in our glob)
-    return (2, float("inf"), float("inf"), name)
-
-
-# --- timed input with countdown (POSIX-friendly; auto-fallback if non-interactive) ---
-def timed_input_with_countdown(prompt: str, timeout: int) -> str | None:
-    """
-    Read a line with a per-second countdown. Returns:
-      - the user's input (str) if provided,
-      - None if timeout expires,
-      - None if non-interactive or timeout<=0.
-    No bracketed prefixes are printed (clean output for all prompts).
-    """
-    import sys
-    import time
-
-    # Non-interactive or disabled timeout → default immediately (no noisy prefix)
-    try:
-        is_tty = sys.stdin.isatty()
-    except Exception:
-        is_tty = False
-
-    if not is_tty:
-        print("(non-interactive) selecting default . . .")
-        return None
-    if timeout <= 0:
-        print("(timeout disabled) selecting default . . .")
-        return None
-
-    # Show prompt and run a 1s polling loop
-    deadline = time.time() + timeout
-    print(prompt, end="", flush=True)
-
-    try:
-        import select
-
-        while True:
-            remaining = int(max(0, deadline - time.time()))
-            if remaining in {30, 10, 5, 4, 3, 2, 1}:
-                # print a short tick line, then reprint the prompt
-                print(
-                    f"\n{remaining} seconds left . . .  (Ctrl-C to abort)",
-                    flush=True,
-                )
-                print(prompt, end="", flush=True)
-            if remaining <= 0:
-                print()  # newline after prompt
-                return None
-
-            rlist, _, _ = select.select([sys.stdin], [], [], 1.0)
-            if rlist:
-                line = sys.stdin.readline()
-                return None if line is None else line.strip()
-
-    except Exception:
-        # Fallback if select is unavailable
-        try:
-            return input()
-        except KeyboardInterrupt:
-            raise
-
-
-def list_executor_checkpoints(workspace: str) -> list[Path]:
-    ws = Path(workspace)
-    ckdir = _ckpt_dir(workspace)
-    seen = {}
-    # Prefer new location
-    for base in (ckdir, ws):
-        for pat in ("executor_checkpoint_*.db", "executor_checkpoint.db"):
-            for p in base.glob(pat):
-                seen[p.resolve()] = p
-    return sorted(seen.values(), key=_ckpt_sort_key)
-
-
-def choose_checkpoint(workspace: str, timeout: int = 60) -> Path | None:
-    ckpts = list_executor_checkpoints(workspace)
-    default = _ckpt_dir(workspace) / "executor_checkpoint.db"
-
-    print("\nAvailable executor checkpoints:")
-    if ckpts:
-        for i, p in enumerate(ckpts, 1):
-            tag = " (default)" if p.resolve() == default.resolve() else ""
-            print(f"  {i}. {p.name}{tag}")
-        prompt = (
-            f"Select checkpoint [1-{len(ckpts)} or filename] "
-            f"(Enter for default: {default.name}; auto in {timeout}s) > "
-        )
-        sel = timed_input_with_countdown(prompt, timeout)
-    else:
-        print("  (none found)")
-        prompt = (
-            f"Press Enter to start fresh ({default.name}; auto in {timeout}s), "
-            f"or type a checkpoint filename to restore > "
-        )
-        sel = timed_input_with_countdown(prompt, timeout)
-
-    if not sel:
-        return default
-
-    if sel.isdigit() and ckpts:
-        idx = int(sel)
-        if 1 <= idx <= len(ckpts):
-            return ckpts[idx - 1]
-        print(f"[warn] Invalid selection {sel}; using default.")
-        return default
-
-    # If they type a filename, accept it whether or not it matches our filters
-    cand = Path(sel)
-    if not cand.is_absolute():
-        cand = Path(workspace) / sel
-    if cand.exists():
-        # (Optional) warn if it’s a legacy name
-        if cand.name.startswith("executor_") and not cand.name.startswith(
-            "executor_checkpoint_"
-        ):
-            print(
-                f"[warn] Using legacy snapshot name '{cand.name}'. "
-                f"Future runs will prefer 'executor_checkpoint_*.db'."
-            )
-        return cand
-
-    print(f"[warn] '{sel}' not found; using default.")
-    return default
-
-
-# --- resolve resume target (CLI override or interactive) ---
-def resolve_resume_checkpoint(
-    workspace: str, resume_from: str | None, timeout: int
-) -> Path | None:
-    if resume_from:
-        p = Path(resume_from)
-        if not p.is_absolute():
-            # try checkpoints/ first, then root (legacy)
-            cand = _ckpt_dir(workspace) / p
-            if cand.exists():
-                print(
-                    f"[resume] Using checkpoint from CLI (checkpoints): {cand.name}"
-                )
-                return cand
-            p = Path(workspace) / p
-        if p.exists():
-            print(f"[resume] Using checkpoint from CLI: {p.name}")
-            return p
-        print(
-            f"[warn] --resume-from '{resume_from}' not found; falling back to interactive/default."
-        )
-    return choose_checkpoint(workspace, timeout=timeout)
-
-
-# --- restore selected snapshot into live executor DB (prior to opening it) ---
-def restore_executor_from_snapshot(workspace: str, snapshot: Path) -> None:
-    live = _ckpt_dir(workspace) / "executor_checkpoint.db"
-    if not snapshot.exists():
-        print(
-            f"[resume] No snapshot to restore (missing: {snapshot}); starting fresh."
-        )
-        return
-    if snapshot.resolve() == live.resolve():
-        print(f"[resume] Live DB already at desired checkpoint: {live.name}")
-        return
-    try:
-        snapshot_sqlite_db(snapshot, live)  # copy snapshot → live
-        for suffix in ("-wal", "-shm"):
-            side = live.with_name(live.name + suffix)
-            if side.exists():
-                side.unlink()
-        print(f"[resume] Restored: {snapshot.name} → {live.name}")
-    except Exception as e:
-        print(
-            f"[warn] Failed to restore '{snapshot}': {e}. Continuing with current live DB."
-        )
-
-
-#########################################################################
-# END: Helpers for execution agent checkpoint/restart
-#########################################################################
 
 
 #########################################################################
@@ -526,65 +242,6 @@ def save_hier_sub_progress(
 
 
 #########################################################################
-# BEGIN: Helpers for locking user choice - after they pick single/hierarchal, etc
-#        for subsequent runs
-#########################################################################
-# ========= Run metadata (locks planning_mode per workspace) =========
-def _run_meta_file(workspace: str) -> Path:
-    return Path(workspace) / "run_meta.json"
-
-
-def load_run_meta(workspace: str) -> dict:
-    p = _run_meta_file(workspace)
-    if p.exists():
-        try:
-            return json.loads(p.read_text())
-        except Exception:
-            return {}
-    return {}
-
-
-def save_run_meta(workspace: str, **fields) -> dict:
-    p = _run_meta_file(workspace)
-    p.parent.mkdir(parents=True, exist_ok=True)  # <-- ensure dir exists
-    meta = load_run_meta(workspace)
-    meta.update({k: v for k, v in fields.items() if v is not None})
-    p.write_text(json.dumps(meta, indent=2))
-    return meta
-
-
-def lock_or_warn_planning_mode(
-    workspace: str, chosen_mode: str
-) -> tuple[str, bool]:
-    """
-    Ensure a workspace has a fixed planning_mode.
-    Returns (effective_mode, locked_already).
-    """
-    meta = load_run_meta(workspace)
-    existing = meta.get("planning_mode")
-    if existing:
-        if existing != chosen_mode:
-            # warn and stick with existing
-            console.print(
-                Panel.fit(
-                    f"[bold yellow]Workspace already locked to planning_mode={existing}[/]\n"
-                    f"Ignoring requested mode '{chosen_mode}'. Use a new --workspace if you want a different mode.",
-                    border_style="yellow",
-                )
-            )
-        return existing, True
-    # first run for this workspace: lock it
-    save_run_meta(workspace, planning_mode=chosen_mode)
-    return chosen_mode, False
-
-
-#########################################################################
-# END: Helpers for locking user choice - after they pick single/hierarchal, etc
-#      for subsequent runs
-#########################################################################
-
-
-#########################################################################
 # BEGIN: Assorted other helpers
 #########################################################################
 def _print_next_step(prefix: str, next_zero: int, total: int, workspace: str):
@@ -607,71 +264,30 @@ def _print_next_step(prefix: str, next_zero: int, total: int, workspace: str):
 #########################################################################
 # END: Assorted other helpers
 #########################################################################
-_SECRET_KEY_SUBSTRS = (
-    "api_key",
-    "apikey",
-    "access_token",
-    "refresh_token",
-    "secret",
-    "password",
-    "bearer",
-)
-
-
-def _looks_like_secret_key(name: str) -> bool:
-    n = name.lower()
-    return any(s in n for s in _SECRET_KEY_SUBSTRS)
-
-
-def _mask_secret(value: str, keep_start: int = 6, keep_end: int = 4) -> str:
-    """
-    Mask a secret-like string, keeping only the beginning and end.
-    Example: sk-proj-abc123456789xyz -> sk-proj-…9xyz
-    """
-    if not isinstance(value, str):
-        return value
-    if len(value) <= keep_start + keep_end + 3:
-        return "…"  # too short to safely show anything
-    return f"{value[:keep_start]}...{value[-keep_end:]}"
-
-
-def _sanitize_for_logging(obj):
-    if isinstance(obj, dict):
-        out = {}
-        for k, v in obj.items():
-            if _looks_like_secret_key(str(k)):
-                out[k] = _mask_secret(v) if isinstance(v, str) else "..."
-            else:
-                out[k] = _sanitize_for_logging(v)
-        return out
-    if isinstance(obj, list):
-        return [_sanitize_for_logging(v) for v in obj]
-    return obj
 
 
 def setup_agents(
     workspace: str,
-    model_choice: str,
-    models_cfg: dict | None,
+    planner_llm_cfg,
+    executor_llm_cfg,
 ) -> tuple[str, tuple, tuple]:
-    # --- checkpoint plumbing (unchanged) ---
-    edb_path = _ckpt_dir(workspace) / "executor_checkpoint.db"
+    edb_path = ckpt_dir(workspace) / "executor_checkpoint.db"
     econn = sqlite3.connect(str(edb_path), check_same_thread=False)
     executor_checkpointer = SqliteSaver(econn)
 
-    pdb_path = _ckpt_dir(workspace) / "planner_checkpoint.db"
+    pdb_path = ckpt_dir(workspace) / "planner_checkpoint.db"
     pconn = sqlite3.connect(str(pdb_path), check_same_thread=False)
     planner_checkpointer = SqliteSaver(pconn)
 
     planner_llm = setup_llm(
-        model_choice=model_choice,
-        models_cfg=models_cfg or {},
+        model_config=planner_llm_cfg,
         agent_name="planner",
+        console=console,
     )
     executor_llm = setup_llm(
-        model_choice=model_choice,
-        models_cfg=models_cfg or {},
+        model_config=executor_llm_cfg,
         agent_name="executor",
+        console=console,
     )
 
     # Initialize the agents
@@ -704,273 +320,6 @@ def setup_agents(
         (planner, planner_checkpointer, pdb_path),
         (executor, executor_checkpointer, edb_path),
     )
-
-
-def _deep_merge_dicts(base: dict, override: dict) -> dict:
-    """
-    Recursively merge override into base and return a new dict.
-    - dict + dict => deep merge
-    - otherwise => override wins
-    """
-    base = dict(base or {})
-    override = dict(override or {})
-    out = dict(base)
-    for k, v in override.items():
-        if k in out and isinstance(out[k], dict) and isinstance(v, dict):
-            out[k] = _deep_merge_dicts(out[k], v)
-        else:
-            out[k] = v
-    return out
-
-
-def _resolve_llm_kwargs_for_agent(
-    models_cfg: dict | None, agent_name: str | None
-) -> dict:
-    """
-    Given the YAML `models:` dict, compute merged kwargs for init_chat_model(...)
-    for a specific agent ('planner' or 'executor').
-
-    Merge order (later wins):
-      1) {} (empty)
-      2) models.defaults.params (optional)
-      3) models.profiles[defaults.profile] (optional)
-      4) models.agents[agent_name].profile (optional; merges that profile on top)
-      5) models.agents[agent_name].params (optional)
-    """
-    models_cfg = models_cfg or {}
-    profiles = models_cfg.get("profiles") or {}
-    defaults = models_cfg.get("defaults") or {}
-    agents = models_cfg.get("agents") or {}
-
-    # Start with global defaults
-    merged = {}
-    merged = _deep_merge_dicts(merged, defaults.get("params") or {})
-
-    # Apply default profile
-    default_profile_name = defaults.get("profile")
-    if default_profile_name and default_profile_name in profiles:
-        merged = _deep_merge_dicts(merged, profiles[default_profile_name] or {})
-
-    # Apply agent-specific profile + params
-    if agent_name and isinstance(agents, dict) and agent_name in agents:
-        a = agents.get(agent_name) or {}
-        agent_profile_name = a.get("profile")
-        if agent_profile_name and agent_profile_name in profiles:
-            merged = _deep_merge_dicts(
-                merged, profiles[agent_profile_name] or {}
-            )
-        merged = _deep_merge_dicts(merged, a.get("params") or {})
-
-    return merged
-
-
-def _print_llm_init_banner(
-    agent_name: str | None,
-    provider: str,
-    model_name: str,
-    provider_extra: dict,
-    llm_kwargs: dict,
-    model_obj=None,
-) -> None:
-    who = agent_name or "llm"
-
-    safe_provider_extra = _sanitize_for_logging(provider_extra or {})
-    safe_llm_kwargs = _sanitize_for_logging(llm_kwargs or {})
-
-    console.print(
-        Panel.fit(
-            Text.from_markup(
-                f"[bold cyan]LLM init ({who})[/]\n"
-                f"[bold]provider[/]: {provider}\n"
-                f"[bold]model[/]: {model_name}\n\n"
-                f"[bold]provider kwargs[/]: {json.dumps(safe_provider_extra, indent=2)}\n\n"
-                f"[bold]llm kwargs (merged)[/]: {json.dumps(safe_llm_kwargs, indent=2)}"
-            ),
-            border_style="cyan",
-        )
-    )
-
-    # Best-effort readback from the LangChain model object
-    if model_obj is None:
-        return
-
-    readback = {}
-    for attr in (
-        "model_name",
-        "model",
-        "reasoning",
-        "temperature",
-        "max_completion_tokens",
-        "max_tokens",
-    ):
-        if hasattr(model_obj, attr):
-            try:
-                readback[attr] = getattr(model_obj, attr)
-            except Exception:
-                pass
-
-    for attr in ("model_kwargs", "kwargs"):
-        if hasattr(model_obj, attr):
-            try:
-                readback[attr] = getattr(model_obj, attr)
-            except Exception:
-                pass
-
-    if readback:
-        console.print(
-            Panel.fit(
-                Text.from_markup(
-                    "[bold green]LLM readback (best-effort from LangChain object)[/]\n"
-                    + json.dumps(_sanitize_for_logging(readback), indent=2)
-                ),
-                border_style="green",
-            )
-        )
-
-    effort = None
-    try:
-        effort = (llm_kwargs or {}).get("reasoning", {}).get("effort")
-    except Exception:
-        effort = None
-
-    if effort:
-        console.print(
-            Panel.fit(
-                Text.from_markup(
-                    f"[bold yellow]Reasoning effort requested[/]: {effort}\n"
-                    "Note: This confirms what we sent to init_chat_model; actual enforcement is provider-side."
-                ),
-                border_style="yellow",
-            )
-        )
-
-
-def _resolve_model_choice(model_choice: str, models_cfg: dict):
-    """
-    Accepts strings like 'openai:gpt-5.2' or 'my_endpoint:openai/gpt-oss-120b'.
-    Looks up per-provider settings from cfg.models.providers.
-
-    Returns: (model_provider, pure_model, provider_extra_kwargs_for_init)
-    """
-    if ":" in model_choice:
-        alias, pure_model = model_choice.split(":", 1)
-    else:
-        alias, pure_model = "openai", model_choice  # back-compat default
-
-    providers = (models_cfg or {}).get("providers", {})
-    prov = providers.get(alias, {})
-
-    # Which LangChain integration to use (e.g. "openai", "mistral", etc.)
-    model_provider = prov.get("model_provider", alias)
-
-    # auth: prefer env var; optionally load via function if configured
-    api_key = None
-    if prov.get("api_key_env"):
-        api_key = os.getenv(prov["api_key_env"])
-    if not api_key and prov.get("token_loader"):
-        mod, fn = prov["token_loader"].rsplit(".", 1)
-        api_key = getattr(importlib.import_module(mod), fn)()
-
-    provider_extra = {}
-    if prov.get("base_url"):
-        provider_extra["base_url"] = prov["base_url"]
-    if api_key:
-        provider_extra["api_key"] = api_key
-
-    return model_provider, pure_model, provider_extra
-
-
-def setup_llm(
-    model_choice: str,
-    models_cfg: dict | None = None,
-    agent_name: str | None = None,
-):
-    """
-    Build a LangChain chat model via init_chat_model(...), optionally applying
-    YAML-driven params:
-      models.profiles
-      models.defaults
-      models.agents.<agent_name>
-
-    Back-compat: if those blocks don't exist, you get your previous behavior.
-    """
-    models_cfg = models_cfg or {}
-
-    provider, pure_model, provider_extra = _resolve_model_choice(
-        model_choice, models_cfg
-    )
-
-    # Your existing hardcoded defaults (keep these so older YAML behaves the same)
-    base_llm_kwargs = {
-        "max_completion_tokens": 10000,
-        "max_retries": 2,
-    }
-
-    # YAML-driven kwargs (safe if absent)
-    yaml_llm_kwargs = _resolve_llm_kwargs_for_agent(models_cfg, agent_name)
-
-    # Merge: base defaults < YAML overrides
-    llm_kwargs = _deep_merge_dicts(base_llm_kwargs, yaml_llm_kwargs)
-
-    # Initialize
-    model = init_chat_model(
-        model=pure_model,
-        model_provider=provider,
-        **llm_kwargs,
-        **(provider_extra or {}),
-    )
-
-    # Print confirmation early
-    _print_llm_init_banner(
-        agent_name=agent_name,
-        provider=provider,
-        model_name=pure_model,
-        provider_extra=provider_extra,
-        llm_kwargs=llm_kwargs,
-        model_obj=model,
-    )
-
-    return model
-
-
-def setup_workspace(
-    user_specified_workspace: str | None,
-    project: str = "run",
-    model_name: str = "openai:gpt-5-mini",
-) -> str:
-    if user_specified_workspace is None:
-        print("No workspace specified, creating one for this project!")
-        print(
-            "Make sure to pass this string to restart using --workspace <this workspace string>"
-        )
-        # https://pypi.org/project/randomname/
-        workspace = f"{project}_{randomname.get_name(adj=('colors', 'emotions', 'character', 'speed', 'size', 'weather', 'appearance', 'sound', 'age', 'taste'), noun=('cats', 'dogs', 'apex_predators', 'birds', 'fish', 'fruit'))}"
-    else:
-        workspace = user_specified_workspace
-        print(f"User specified workspace: {workspace}")
-
-    Path(workspace).mkdir(parents=True, exist_ok=True)
-
-    # Choose a fun emoji based on the model family (swap / extend as you add more)
-    if model_name.startswith("openai"):
-        model_emoji = "🤖"  # OpenAI
-    elif "llama" in model_name.lower():
-        model_emoji = "🦙"  # Llama
-    else:
-        model_emoji = "🧠"  # Fallback / generic LLM
-
-    # Print the panel with model info
-    console.print(
-        Panel.fit(
-            f":rocket:  [bold bright_blue]{workspace}[/bold bright_blue]  :rocket:\n"
-            f"{model_emoji}  [bold cyan]{model_name}[/bold cyan]",
-            title="[bold green]ACTIVE WORKSPACE[/bold green]",
-            border_style="bright_magenta",
-            padding=(1, 4),
-        )
-    )
-
-    return workspace
 
 
 def main_plan_load_or_perform(
@@ -1049,7 +398,7 @@ def main_plan_load_or_perform(
     # we are on
     # unify the plan dict for both fresh and resumed paths
     plan_steps = plan_dict.get("plan_steps") or []
-    plan_sig = _hash_plan(plan_steps)
+    plan_sig = hash_plan(plan_steps)
     save_run_meta(
         workspace, plan_sig=plan_sig, plan_steps_count=len(plan_steps)
     )
@@ -1070,7 +419,7 @@ def get_or_create_subplan(
 ):
     if not hierarchical:
         # Single mode: 1-item synthetic sub-plan
-        return {"plan_steps": [main_step]}, _hash_plan([main_step]), None, None
+        return {"plan_steps": [main_step]}, hash_plan([main_step]), None, None
 
     sub_tid = f"{thread_id}::detail::{m_idx}"
     sub_values, _, dbg = load_latest_planner_state_from_sqlite(
@@ -1080,7 +429,7 @@ def get_or_create_subplan(
 
     if sub_values:
         sub_steps = sub_values.get("plan_steps") or []
-        return sub_values, _hash_plan(sub_steps), sub_tid, None
+        return sub_values, hash_plan(sub_steps), sub_tid, None
 
     # Need to plan sub-steps
     detail_planner_prompt = "Flesh out this main step into concrete sub-steps to fully accomplish it."
@@ -1115,7 +464,7 @@ def get_or_create_subplan(
     ]
 
     sub_steps = sub_output.get("plan_steps") or []
-    sub_sig = _hash_plan(sub_steps)
+    sub_sig = hash_plan(sub_steps)
 
     # persist initial sub-progress (index=0)
     save_hier_sub_progress(
@@ -1235,14 +584,19 @@ def main(
     interactive_timeout: int = 60,
 ):
     try:
-        problem = getattr(config, "problem", "")
-        project = getattr(config, "project", "run")
-        symlinkdict = getattr(config, "symlink", {}) or None
+        problem = config.get("problem", "")
+        project = config.get("project", "run")
+        symlinkdict = config.get("symlink", {}) or None
 
         # sets up the workspace, run config json, etc.
+
         workspace = setup_workspace(
-            user_specified_workspace, project, model_name
+            user_specified_workspace=user_specified_workspace,
+            project=project,
+            model_name=model_name,
+            console=console,
         )
+
         print(workspace)
         print(user_specified_workspace)
 
@@ -1252,6 +606,8 @@ def main(
                 workspace=workspace,
                 resume_from=resume_from,
                 timeout=interactive_timeout,
+                choose_fn=None,  # leave None to use default choose_checkpoint
+                input_fn=timed_input_with_countdown,
             )
             if chosen_ckpt:
                 restore_executor_from_snapshot(workspace, chosen_ckpt)
@@ -1265,7 +621,7 @@ def main(
 
         # lock planning_mode per workspace
         planning_mode, mode_locked = lock_or_warn_planning_mode(
-            workspace, planning_mode
+            workspace, planning_mode, console=console
         )
         console.print(
             Panel.fit(
@@ -1276,7 +632,7 @@ def main(
 
         # ---- One-time project logo kickoff (per workspace) -----------------
         meta = load_run_meta(workspace)
-        logo_cfg = getattr(cfg, "logo", {}) or {}
+        logo_cfg = config.get("logo", {}) or {}
         logo_enabled = bool(logo_cfg.get("enabled", True))
 
         if logo_enabled and not meta.get("logo_created"):
@@ -1348,13 +704,34 @@ def main(
             finally:
                 save_run_meta(workspace, logo_created=True)
 
-        models_cfg = getattr(config, "models", {}) or {}
+        models_cfg = get_models_cfg(config)
+
+        base_llm_cfg = UrsaConfig.model_validate(
+            config, extra="ignore"
+        ).llm_model
+
+        planner_llm_cfg = base_llm_cfg
+        executor_llm_cfg = base_llm_cfg
+
+        if models_cfg is not None:
+            from ursa.cli.config import resolve_llm_model_config
+
+            planner_llm_cfg = resolve_llm_model_config(
+                models_cfg,
+                base_llm_model=base_llm_cfg,
+                agent_name="planner",
+            )
+            executor_llm_cfg = resolve_llm_model_config(
+                models_cfg,
+                base_llm_model=base_llm_cfg,
+                agent_name="executor",
+            )
 
         # gets the agents we'll use for this example including their checkpointer handles and database
         thread_id, planner_tuple, executor_tuple = setup_agents(
             workspace=workspace,
-            model_choice=model_name,
-            models_cfg=models_cfg,
+            planner_llm_cfg=planner_llm_cfg,
+            executor_llm_cfg=executor_llm_cfg,
         )
         planner, planner_checkpointer, pdb_path = planner_tuple
         executor, _, edb_path = executor_tuple
@@ -1533,7 +910,7 @@ def main(
                             next_idx
                         )  # just-finished sub-step (1-based)
                         snapshot_path = (
-                            _ckpt_dir(workspace)
+                            ckpt_dir(workspace)
                             / f"executor_checkpoint_{main_no}_{sub_no}.db"
                         )
                         snapshot_sqlite_db(edb_path, snapshot_path)
@@ -1645,7 +1022,7 @@ def main(
                         try:
                             step_no = m + 1
                             snapshot_path = (
-                                _ckpt_dir(workspace)
+                                ckpt_dir(workspace)
                                 / f"executor_checkpoint_{step_no}.db"
                             )
                             snapshot_sqlite_db(edb_path, snapshot_path)
@@ -1717,32 +1094,18 @@ def parse_args_and_user_inputs():
     )
     args = parser.parse_args()
 
-    # --- load YAML -> dict -> shallow namespace (top-level keys only) ---
     try:
         with open(args.config, "r", encoding="utf-8") as f:
-            raw_cfg = yaml.safe_load(f) or {}
-            if not isinstance(raw_cfg, dict):
-                raise ValueError("Top-level YAML must be a mapping/object.")
-            cfg = NS(**raw_cfg)  # top-level attrs; nested remain dicts
+            cfg = yaml.safe_load(f) or {}
+        cfg = deep_interp_env(cfg)
     except FileNotFoundError:
-        print(f"Config file not found: {args.config}", file=sys.stderr)
         sys.exit(2)
-    except Exception as e:
-        print(f"Error loading YAML: {e}", file=sys.stderr)
+    except Exception:
         sys.exit(2)
 
-    # ── config-driven model choices ────────────
-    models_cfg = getattr(cfg, "models", {}) or {}
-    DEFAULT_MODELS = tuple(
-        models_cfg.get("choices")
-        or (
-            "openai:gpt-5",
-            "openai:gpt-5-mini",
-            "openai:o3",
-            "openai:o3-mini",
-        )
-    )
-    DEFAULT_MODEL = models_cfg.get("default")  # may be None
+    models_cfg = get_models_cfg(cfg)
+    DEFAULT_MODELS = get_default_models(models_cfg)
+    DEFAULT_MODEL = get_default_model(models_cfg)
 
     # ── timeout-aware interactive helpers ────────────
     def _choose_model_interactive(
@@ -1816,12 +1179,7 @@ def parse_args_and_user_inputs():
         )
 
         # Planning mode resolution: CLI > config > interactive > default('single')
-        config_mode = None
-        planning_cfg = getattr(cfg, "planning", None)
-        if isinstance(planning_cfg, dict):
-            config_mode = planning_cfg.get("mode")
-        if not config_mode:
-            config_mode = getattr(cfg, "planning_mode", None)
+        config_mode = get_config_planning_mode(cfg)
 
         planning_mode = (
             args.planning_mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "jsonargparse>=4.45.0",
     "fastmcp~=3.0",
     "pyyaml>=6.0.3",
+    "truststore>=0.10.0",
 ]
 classifiers = [
     "Operating System :: OS Independent",

--- a/src/ursa/agents/hypothesizer_agent.py
+++ b/src/ursa/agents/hypothesizer_agent.py
@@ -2,11 +2,26 @@ import ast
 from datetime import datetime
 from operator import add, or_
 from pathlib import Path
-from typing import Annotated, Literal, TypedDict, cast
+from typing import (
+    Annotated,
+    Literal,
+    Optional,
+    TypedDict,
+    cast,
+)
 
 from langchain.chat_models import BaseChatModel
-from langchain_core.messages import HumanMessage, SystemMessage
-from langchain_core.output_parsers import StrOutputParser
+from langchain_core.messages import (
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+)
+from langchain_core.tools import BaseTool, tool
+from langgraph.graph.message import add_messages
+from langgraph.prebuilt import InjectedState, ToolNode, tools_condition
+from langgraph.types import Overwrite
+
+from ursa.tools import read_file
 
 try:
     from ddgs import DDGS  # pip install duckduckgo-search
@@ -14,20 +29,105 @@ except Exception:
     DDGS = None
 
 
+# from langchain_core.runnables.graph import MermaidDrawMethod
+from ursa.agents.base import AgentWithTools, BaseAgent
 from ursa.prompt_library.hypothesizer_prompts import (
     competitor_prompt,
     critic_prompt,
     hypothesizer_prompt,
 )
 
-# from langchain_core.runnables.graph import MermaidDrawMethod
-from .base import BaseAgent
-
 # --- ANSI color codes ---
 GREEN = "\033[92m"
 BLUE = "\033[94m"
 RED = "\033[91m"
 RESET = "\033[0m"
+
+
+# add this as a LangChain tool so the LLM can figure out what docs there are if it wants to
+@tool(
+    description="List filenames (and sizes) in input_docs_dir (or workspace)."
+)
+def list_input_docs(state: Annotated[dict, InjectedState]) -> str:
+    from pathlib import Path
+
+    print(f"{BLUE}[list_input_docs] called{RESET}")
+
+    root = state.get("input_docs_dir")
+    if not root:
+        msg = "[Error]: no input_docs_dir set in state."
+        print(f"{RED}[list_input_docs] {msg}{RESET}")
+        return msg
+
+    print(f"{BLUE}[list_input_docs] root:{RESET} {root}")
+
+    p = Path(root).resolve()
+    if not p.exists() or not p.is_dir():
+        msg = f"[Error]: input_docs_dir not a directory: {p}"
+        print(f"{RED}[list_input_docs] {msg}{RESET}")
+        return msg
+
+    rows = []
+    for f in sorted([x for x in p.iterdir() if x.is_file()]):
+        try:
+            rows.append(f"{f.name} ({f.stat().st_size} bytes)")
+        except Exception:
+            rows.append(f"{f.name} (size unknown)")
+
+    ret = "\n".join(rows) if rows else "No files found."
+
+    print(f"{GREEN}[list_input_docs] found {len(rows)} file(s){RESET}")
+    if rows:
+        preview = "\n".join(rows[:5])
+        print(f"{GREEN}[list_input_docs] preview:{RESET}\n{preview}")
+
+    return ret
+
+
+@tool(
+    description="Search the web for relevant information and return concise results."
+)
+def web_search(query: str) -> str:
+    print(f"{BLUE}[web_search] called{RESET}")
+    print(f"{BLUE}[web_search] query:{RESET} {query}")
+
+    if DDGS is None:
+        msg = (
+            "[Error]: web search is unavailable because ddgs is not installed."
+        )
+        print(f"{RED}[web_search] {msg}{RESET}")
+        return msg
+
+    try:
+        results = []
+        with DDGS() as ddgs:
+            for i, r in enumerate(ddgs.text(query, max_results=5), start=1):
+                title = r.get("title", "")
+                body = r.get("body", "")
+                href = r.get("href", "")
+                results.append(f"Title: {title}\nSnippet: {body}\nURL: {href}")
+
+                if i == 1:
+                    preview = (
+                        f"Title: {title}\nSnippet: {body[:200]}\nURL: {href}"
+                    )
+                    print(
+                        f"{GREEN}[web_search] first result preview:{RESET}\n{preview}"
+                    )
+
+        if results:
+            print(
+                f"{GREEN}[web_search] returned {len(results)} result(s){RESET}"
+            )
+            return "\n\n".join(results)
+
+        print(f"{BLUE}[web_search] no results found{RESET}")
+        return "No results found."
+
+    except Exception as e:
+        msg = f"[Error performing web search: {type(e).__name__}: {e}]"
+        print(f"{RED}[web_search] {msg}{RESET}")
+        return msg
 
 
 # Define our state schema
@@ -37,23 +137,49 @@ class HypothesizerState(TypedDict, total=False):
     current_iteration: int
     max_iterations: int
     agent1_solution: Annotated[list[str], add]
-    agent2_critiques: list[str]
-    agent3_perspectives: list[str]
+    agent2_critiques: Annotated[list[str], add]
+    agent3_perspectives: Annotated[list[str], add]
     solution: str
     summary_report: str
     visited_sites: Annotated[set[str], or_]
+    input_docs_dir: str
+    messages: Annotated[list[BaseMessage], add_messages]
 
 
-class HypothesizerAgent(BaseAgent[HypothesizerState]):
+class HypothesizerAgent(AgentWithTools, BaseAgent[HypothesizerState]):
     state_type = HypothesizerState
 
-    def __init__(self, llm: BaseChatModel, max_iterations: int = 2, **kwargs):
-        super().__init__(llm, **kwargs)
+    def __init__(
+        self,
+        llm: BaseChatModel,
+        max_iterations: int = 3,
+        extra_tools: Optional[list[BaseTool] | None] = None,
+        enable_web_search: bool = False,
+        **kwargs,
+    ):
+        default_tools = [read_file, list_input_docs]
+
+        # add web search tool if 'enable_web_search' is on
+        if enable_web_search:
+            default_tools.append(web_search)
+
+        if extra_tools:
+            default_tools.extend(extra_tools)
+
+        super().__init__(llm=llm, tools=default_tools, **kwargs)
+
+        # debug print tools enabled
+        print("[HypothesizerAgent] Tools enabled:")
+        for t in self.tools.values():
+            try:
+                print(f"  - {t.name}")
+            except Exception:
+                print(f"  - (unnamed tool) {t}")
+
+        # keep existing setup
         self.hypothesizer_prompt = hypothesizer_prompt
         self.critic_prompt = critic_prompt
         self.competitor_prompt = competitor_prompt
-        self.search_tool = DDGS()
-        self.strllm = self.llm | StrOutputParser()
         self.max_iterations = max_iterations
 
     def _normalize_inputs(self, inputs) -> HypothesizerState:
@@ -89,25 +215,34 @@ class HypothesizerAgent(BaseAgent[HypothesizerState]):
 
         return visited_sites
 
-    def agent1_generate_solution(
+    async def agent1_generate_solution(
         self, state: HypothesizerState
     ) -> HypothesizerState:
-        """Agent 1: Hypothesizer."""
+        """Agent 1: Hypothesizer. One LLM step only; tool routing is handled by the graph."""
         print(
             f"[iteration {state['current_iteration'] + 1}] Entering agent1_generate_solution. Iteration: {state['current_iteration'] + 1}"
         )
+
+        messages = list(state.get("messages", []))
+
+        # If messages already exist, we are returning from a tool call.
+        # Invoke once more using the accumulated state messages, but return only the new AI message.
+        if messages:
+            ai_msg = await self.llm_with_tools.ainvoke(messages)
+            return {"messages": [ai_msg]}
 
         current_iter = state["current_iteration"]
         user_content = f"Question: {state['question']}\n"
 
         if current_iter > 0:
-            user_content += (
-                f"\nPrevious solution: {state['agent1_solution'][-1]}"
-            )
-            user_content += f"\nCritique: {state['agent2_critiques'][-1]}"
-            user_content += (
-                f"\nCompetitor perspective: {state['agent3_perspectives'][-1]}"
-            )
+            if state.get("agent1_solution"):
+                user_content += (
+                    f"\nPrevious solution: {state['agent1_solution'][-1]}"
+                )
+            if state.get("agent2_critiques"):
+                user_content += f"\nCritique: {state['agent2_critiques'][-1]}"
+            if state.get("agent3_perspectives"):
+                user_content += f"\nCompetitor perspective: {state['agent3_perspectives'][-1]}"
 
             user_content += (
                 "\n\n**You must explicitly list how this new solution differs from the previous solution,** "
@@ -117,42 +252,82 @@ class HypothesizerAgent(BaseAgent[HypothesizerState]):
         else:
             user_content += "Research this problem and generate a solution."
 
-        search_query = self.strllm.invoke(
-            f"Here is a problem description: {state['question']}. Turn it into a short query to be fed into a search engine."
+        user_content += (
+            "\n\nTOOLING RULES:\n"
+            "- You have tools: list_input_docs and read_file.\n"
+            "- First call list_input_docs to discover what local files are available.\n"
+            "- Then use read_file only on the files you think are relevant.\n"
+            "- Before citing or relying on ANY local file content, you MUST call read_file on that file.\n"
+            "- Read only the minimum set of files needed (start with README if present).\n"
+            "- If a PDF looks relevant, explicitly read it with read_file.\n"
         )
-        if '"' in search_query:
-            search_query = search_query.split('"')[1]
-        raw_search_results = self.search_tool.text(
-            search_query or state["question"]
-        )
-        user_content += f"\nSearch results: {raw_search_results}"
 
-        # Parse the results if possible, so we can collect URLs
-        visited_sites = self.parse_visited_sites(raw_search_results)
+        search_query = ""
+        visited_sites = set()
 
-        # Provide a system message to define this agent's role
-        messages = [
+        if state.get("input_docs_dir"):
+            user_content += "\n\nNOTE: Use the local documents in input_docs_dir for evidence and context unless asked otherwise."
+        elif "web_search" in self.tools:
+            user_content += "\n\nNOTE: Web search is enabled if needed. Use the web_search tool only when local documents are insufficient."
+        else:
+            user_content += "\n\nNOTE: No local documents provided and web search disabled; rely on model knowledge."
+
+        prompt_messages = [
             SystemMessage(content=self.hypothesizer_prompt),
             HumanMessage(content=user_content),
         ]
-        solution = self.strllm.invoke(messages)
 
-        # Print the entire solution in green
-        print(f"{GREEN}[Agent1 - Hypothesizer solution]\n{solution}{RESET}")
+        ai_msg = await self.llm_with_tools.ainvoke(prompt_messages)
+
         print(
             f"[iteration {state['current_iteration'] + 1}] Exiting agent1_generate_solution."
         )
+
         return {
-            "agent1_solution": [solution],
+            "messages": prompt_messages + [ai_msg],
             "question_search_query": search_query,
             "visited_sites": visited_sites,
         }
 
-    def agent2_critique(self, state: HypothesizerState) -> HypothesizerState:
-        """Agent 2: Critic."""
+    def finalize_agent1_solution(
+        self, state: HypothesizerState
+    ) -> HypothesizerState:
+        messages = list(state.get("messages", []))
+
+        last_ai = None
+        for m in reversed(messages):
+            if getattr(m, "type", None) == "ai":
+                last_ai = m
+                break
+
+        solution = (
+            (getattr(last_ai, "text", "") or "").strip() if last_ai else ""
+        )
+
+        print(f"{GREEN}[Agent1 - Hypothesizer solution]\n{solution}{RESET}")
+        print(
+            f"[iteration {state['current_iteration'] + 1}] Finalized agent1 solution."
+        )
+
+        return {
+            "agent1_solution": [solution],
+            "messages": Overwrite([]),
+        }
+
+    async def agent2_critique(
+        self, state: HypothesizerState
+    ) -> HypothesizerState:
+        """Agent 2: Critic. One LLM step only; tool routing is handled by the graph."""
         print(
             f"[iteration {state['current_iteration'] + 1}] Entering agent2_critique."
         )
+
+        messages = list(state.get("messages", []))
+
+        # If messages already exist, we are returning from a tool call.
+        if messages:
+            ai_msg = await self.llm_with_tools.ainvoke(messages)
+            return {"messages": [ai_msg]}
 
         solution = state["agent1_solution"][-1]
         user_content = (
@@ -161,35 +336,74 @@ class HypothesizerAgent(BaseAgent[HypothesizerState]):
             "Provide a detailed critique of this solution. Identify potential flaws, assumptions, and areas for improvement."
         )
 
-        fact_check_query = f"fact check {state['question_search_query']} solution effectiveness"
+        user_content += (
+            "\n\nYou have tools to list and read local documents. "
+            "If any claim in the proposed solution depends on the documents, "
+            "you MUST verify by reading the relevant file sections and cite them."
+        )
 
-        fact_check_results = self.search_tool.text(fact_check_query)
-        visited_sites = self.parse_visited_sites(fact_check_results)
-        user_content += f"\nFact check results: {fact_check_results}"
+        visited_sites = set()
+
+        if "web_search" in self.tools:
+            user_content += "\nNOTE: Web search is enabled if needed. Use the web_search tool if local documents are insufficient for fact-checking."
+        else:
+            user_content += "\nNOTE: Web search disabled; critique must rely on local docs + reasoning only."
 
         messages = [
             SystemMessage(content=self.critic_prompt),
             HumanMessage(content=user_content),
         ]
-        critique = self.strllm.invoke(messages)
 
-        # Print the entire critique in blue
-        print(f"{BLUE}[Agent2 - Critic]\n{critique}{RESET}")
+        ai_msg = await self.llm_with_tools.ainvoke(messages)
+
         print(
             f"[iteration {state['current_iteration'] + 1}] Exiting agent2_critique."
         )
+
         return {
-            "agent2_critiques": [critique],
+            "messages": messages + [ai_msg],
             "visited_sites": visited_sites,
         }
 
-    def agent3_competitor_perspective(
+    def finalize_agent2_critique(
         self, state: HypothesizerState
     ) -> HypothesizerState:
-        """Agent 3: Competitor/Stakeholder Simulator."""
+        messages = list(state.get("messages", []))
+
+        last_ai = None
+        for m in reversed(messages):
+            if getattr(m, "type", None) == "ai":
+                last_ai = m
+                break
+
+        critique = (
+            (getattr(last_ai, "text", "") or "").strip() if last_ai else ""
+        )
+
+        print(f"{BLUE}[Agent2 - Critic]\n{critique}{RESET}")
+        print(
+            f"[iteration {state['current_iteration'] + 1}] Finalized agent2 critique."
+        )
+
+        return {
+            "agent2_critiques": [critique],
+            "messages": Overwrite([]),
+        }
+
+    async def agent3_competitor_perspective(
+        self, state: HypothesizerState
+    ) -> HypothesizerState:
+        """Agent 3: Competitor/Stakeholder Simulator. One LLM step only; tool routing is handled by the graph."""
         print(
             f"[iteration {state['current_iteration'] + 1}] Entering agent3_competitor_perspective."
         )
+
+        messages = list(state.get("messages", []))
+
+        # If messages already exist, we are returning from a tool call.
+        if messages:
+            ai_msg = await self.llm_with_tools.ainvoke(messages)
+            return {"messages": [ai_msg]}
 
         solution = state["agent1_solution"][-1]
         critique = state["agent2_critiques"][-1]
@@ -201,30 +415,59 @@ class HypothesizerAgent(BaseAgent[HypothesizerState]):
             "Simulate how a competitor, government agency, or other stakeholder might respond to this solution."
         )
 
-        competitor_search_query = (
-            f"competitor responses to {state['question_search_query']}"
+        user_content += (
+            "\n\nYou have tools to list and read local documents. "
+            "Use them to ground the stakeholder response in the provided materials."
         )
 
-        competitor_info = self.search_tool.text(competitor_search_query)
-        visited_sites = self.parse_visited_sites(competitor_info)
-        user_content += f"\nCompetitor information: {competitor_info}"
+        visited_sites = set()
+
+        if "web_search" in self.tools:
+            user_content += "\nNOTE: Web search is enabled if needed. Use the web_search tool if outside information would improve the stakeholder simulation."
+        else:
+            user_content += "\nNOTE: Web search disabled; simulate stakeholder reaction without external web info."
 
         messages = [
             SystemMessage(content=self.competitor_prompt),
             HumanMessage(content=user_content),
         ]
-        perspective = self.strllm.invoke(messages)
 
-        # Print the entire perspective in red
+        ai_msg = await self.llm_with_tools.ainvoke(messages)
+
+        print(
+            f"[iteration {state['current_iteration'] + 1}] Exiting agent3_competitor_perspective."
+        )
+
+        return {
+            "messages": messages + [ai_msg],
+            "visited_sites": visited_sites,
+        }
+
+    def finalize_agent3_perspective(
+        self, state: HypothesizerState
+    ) -> HypothesizerState:
+        messages = list(state.get("messages", []))
+
+        last_ai = None
+        for m in reversed(messages):
+            if getattr(m, "type", None) == "ai":
+                last_ai = m
+                break
+
+        perspective = (
+            (getattr(last_ai, "text", "") or "").strip() if last_ai else ""
+        )
+
         print(
             f"{RED}[Agent3 - Competitor/Stakeholder Perspective]\n{perspective}{RESET}"
         )
         print(
-            f"[iteration {state['current_iteration'] + 1}] Exiting agent3_competitor_perspective."
+            f"[iteration {state['current_iteration'] + 1}] Finalized agent3 perspective."
         )
+
         return {
             "agent3_perspectives": [perspective],
-            "visited_sites": visited_sites,
+            "messages": Overwrite([]),
         }
 
     def increment_iteration(
@@ -259,7 +502,10 @@ class HypothesizerAgent(BaseAgent[HypothesizerState]):
         print(
             f"[iteration {state['current_iteration']}] Generating overall solution with LLM..."
         )
-        solution = self.strllm.invoke(prompt)
+
+        response = self.llm.invoke(prompt)
+        solution = (getattr(response, "text", None) or str(response)).strip()
+
         print(
             f"[iteration {state['current_iteration']}] Overall solution obtained. Preview:",
             solution[:200],
@@ -280,6 +526,84 @@ class HypothesizerAgent(BaseAgent[HypothesizerState]):
         # for s in all_sites:
         #     print("  ", s)
         return new_state
+
+    def _strip_code_fences(self, text: str) -> str:
+        """
+        Normalize model output so it is ready to write as a .tex file.
+        Removes markdown fences and trims any leading junk before \\documentclass.
+        """
+        if not text:
+            return text
+
+        s = text.strip()
+
+        if s.startswith("```"):
+            lines = s.splitlines()
+            if lines:
+                lines = lines[1:]
+            if lines and lines[-1].strip() == "```":
+                lines = lines[:-1]
+            s = "\n".join(lines).strip()
+
+        doc_idx = s.find(r"\documentclass")
+        if doc_idx != -1:
+            s = s[doc_idx:]
+
+        return s.strip()
+
+    def _latex_looks_complete(self, text: str) -> bool:
+        s = text or ""
+        return r"\documentclass" in s and r"\end{document}" in s
+
+    def _complete_latex_document(
+        self,
+        prompt: str,
+        max_rounds: int = 3,
+    ) -> str:
+        """
+        Generate LaTeX, and if the model truncates before \\end{document},
+        ask it to continue from where it left off.
+        """
+        latex_llm = self.llm.bind(max_completion_tokens=20000)
+        response = latex_llm.invoke(prompt)
+        text = self._strip_code_fences(
+            (getattr(response, "text", None) or str(response)).strip()
+        )
+
+        if self._latex_looks_complete(text):
+            return text
+
+        current = text
+
+        for _ in range(max_rounds):
+            continuation_prompt = (
+                "You previously started a LaTeX document but stopped before finishing.\n\n"
+                "Continue exactly from where the document stopped.\n"
+                "Do not restart from \\documentclass.\n"
+                "Do not use markdown code fences.\n"
+                "Finish the document and include \\end{document}.\n\n"
+                "Current partial document:\n\n"
+                f"{current}\n"
+            )
+
+            cont_response = latex_llm.invoke(continuation_prompt)
+            cont_text = self._strip_code_fences(
+                (
+                    getattr(cont_response, "text", None) or str(cont_response)
+                ).strip()
+            )
+
+            if cont_text.startswith(r"\documentclass"):
+                # Model restarted instead of continuing. Keep the longer version.
+                if len(cont_text) > len(current):
+                    current = cont_text
+            else:
+                current = current.rstrip() + "\n" + cont_text.lstrip()
+
+            if self._latex_looks_complete(current):
+                return current
+
+        return current
 
     def summarize_process_as_latex(
         self, state: HypothesizerState
@@ -346,7 +670,10 @@ class HypothesizerAgent(BaseAgent[HypothesizerState]):
             of the full content of the steps.  Finally, include a listing of all of the websites we
             used in our research.
 
-            You must ONLY RETURN LaTeX, nothing else.  It must be valid LaTeX syntax!
+            You must return only raw LaTeX source.
+            Do not use markdown code fences.
+            Your output must be a complete LaTeX document that ends with \\end{{document}}.
+            If the document would be long, still finish it completely.
 
             Your output should start with:
             \\documentclass{{article}}
@@ -379,7 +706,11 @@ class HypothesizerAgent(BaseAgent[HypothesizerState]):
         websites_latex = ""
 
         # Ask the LLM to produce *only* LaTeX content
-        latex_response = self.strllm.invoke(prompt)
+        latex_doc = self._complete_latex_document(prompt)
+        latex_response = latex_doc
+
+        if not isinstance(latex_response, str):
+            latex_response = str(latex_response)
 
         latex_doc = latex_response
 
@@ -415,23 +746,57 @@ class HypothesizerAgent(BaseAgent[HypothesizerState]):
         return {"summary_report": final_latex}
 
     def _build_graph(self):
+        # Bind tools to the LLM used by the three agent stages
+        self.llm_with_tools = self.llm.bind_tools(self.tools.values())
+
         # Add nodes
         self.add_node(self.agent1_generate_solution, "agent1")
+        self.add_node(self.finalize_agent1_solution, "agent1_finalize")
+
         self.add_node(self.agent2_critique, "agent2")
+        self.add_node(self.finalize_agent2_critique, "agent2_finalize")
+
         self.add_node(self.agent3_competitor_perspective, "agent3")
+        self.add_node(self.finalize_agent3_perspective, "agent3_finalize")
+
         self.add_node(self.increment_iteration, "increment_iteration")
         self.add_node(self.generate_solution, "finalize")
         self.add_node(self.print_visited_sites, "print_sites")
         self.add_node(self.summarize_process_as_latex, "summarize_as_latex")
 
-        # Add simple edges for the known flow
-        self.graph.add_edge("agent1", "agent2")
-        self.graph.add_edge("agent2", "agent3")
-        self.graph.add_edge("agent3", "increment_iteration")
+        # Separate tool nodes for each stage
+        self.graph.add_node("agent1_tools", ToolNode(self.tools.values()))
+        self.graph.add_node("agent2_tools", ToolNode(self.tools.values()))
+        self.graph.add_node("agent3_tools", ToolNode(self.tools.values()))
 
-        # Then from increment_iteration, we have a conditional:
-        # If we 'continue', we go back to agent1
-        # If we 'finish', we jump to the finalize node
+        # agent1 -> tools loop or finalize -> agent2
+        self.graph.add_conditional_edges(
+            "agent1",
+            tools_condition,
+            {"tools": "agent1_tools", "__end__": "agent1_finalize"},
+        )
+        self.graph.add_edge("agent1_tools", "agent1")
+        self.graph.add_edge("agent1_finalize", "agent2")
+
+        # agent2 -> tools loop or finalize -> agent3
+        self.graph.add_conditional_edges(
+            "agent2",
+            tools_condition,
+            {"tools": "agent2_tools", "__end__": "agent2_finalize"},
+        )
+        self.graph.add_edge("agent2_tools", "agent2")
+        self.graph.add_edge("agent2_finalize", "agent3")
+
+        # agent3 -> tools loop or finalize -> increment_iteration
+        self.graph.add_conditional_edges(
+            "agent3",
+            tools_condition,
+            {"tools": "agent3_tools", "__end__": "agent3_finalize"},
+        )
+        self.graph.add_edge("agent3_tools", "agent3")
+        self.graph.add_edge("agent3_finalize", "increment_iteration")
+
+        # Existing iteration control flow
         self.graph.add_conditional_edges(
             "increment_iteration",
             should_continue,
@@ -440,10 +805,8 @@ class HypothesizerAgent(BaseAgent[HypothesizerState]):
 
         self.graph.add_edge("finalize", "summarize_as_latex")
         self.graph.add_edge("summarize_as_latex", "print_sites")
-        # self.graph.add_edge("summarize_as_latex", "compile_pdf")
-        # self.graph.add_edge("compile_pdf", "print_sites")
 
-        # Set the entry point
+        # Entry / exit
         self.graph.set_entry_point("agent1")
         self.graph.set_finish_point("print_sites")
 
@@ -521,7 +884,7 @@ if __name__ == "__main__":
         "agent3_perspectives": [],
         "solution": "",
         "summary_report": "",
-        "visited_sites": [],
+        "visited_sites": set(),
     }
 
     print("Invoking the graph...")

--- a/src/ursa/cli/config.py
+++ b/src/ursa/cli/config.py
@@ -51,6 +51,33 @@ class ModelConfig(BaseModel):
         return kwargs
 
 
+class ModelsDefaultsConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    model: str | None = None
+    profile: str | None = None
+    params: dict[str, Any] = Field(default_factory=dict)
+
+
+class ModelsAgentConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    model: str | None = None
+    profile: str | None = None
+    params: dict[str, Any] = Field(default_factory=dict)
+
+
+class ModelsConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    choices: list[str] = Field(default_factory=list)
+    default: str | None = None
+    providers: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    profiles: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    defaults: ModelsDefaultsConfig = Field(default_factory=ModelsDefaultsConfig)
+    agents: dict[str, ModelsAgentConfig] = Field(default_factory=dict)
+
+
 class UrsaConfig(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -75,8 +102,10 @@ class UrsaConfig(BaseModel):
     )
     """Default LLM"""
 
+    models: ModelsConfig | None = None
+    """Optional richer model-selection config."""
+
     emb_model: ModelConfig | None = None
-    """Default Embedding model"""
 
     agent_config: dict[str, dict[str, Any]] | None = None
     """ Configuration options for URSA Agents """
@@ -85,11 +114,17 @@ class UrsaConfig(BaseModel):
     """MCP Servers to connect to Ursa."""
 
     def model_post_init(self, __context):
-        """Handle temporary workspace creation post validation."""
+        """Handle temporary workspace creation and derived model config."""
         if str(self.workspace) == "tmp" and not self.workspace.exists():
             temp_workspace = TemporaryDirectory(prefix="ursa")
             self.workspace = Path(temp_workspace.name)
             self._temp_workspace = temp_workspace
+
+        if self.models is not None:
+            self.llm_model = resolve_llm_model_config(
+                self.models,
+                base_llm_model=self.llm_model,
+            )
 
     @classmethod
     def from_namespace(cls, cfg: Namespace):
@@ -170,6 +205,135 @@ def deep_merge_dicts(
     return merged
 
 
+def get_default_models(models_cfg: ModelsConfig | None) -> tuple[str, ...]:
+    fallback = (
+        "openai:gpt-5",
+        "openai:gpt-5-mini",
+        "openai:o3",
+        "openai:o3-mini",
+    )
+    if models_cfg and models_cfg.choices:
+        return tuple(models_cfg.choices)
+    return fallback
+
+
+def get_default_model(models_cfg: ModelsConfig | None) -> str | None:
+    if models_cfg is None:
+        return None
+    return models_cfg.default
+
+
+def resolve_model_choice_from_models_cfg(
+    model_choice: str, models_cfg: ModelsConfig | None
+) -> ModelConfig:
+    """
+    Resolve a model choice like:
+      - openai:gpt-5.2
+      - my_endpoint:openai/gpt-oss-120b
+
+    using the richer `models:` config block and return a concrete ModelConfig.
+    """
+    if ":" in model_choice:
+        alias, pure_model = model_choice.split(":", 1)
+    else:
+        alias, pure_model = "openai", model_choice
+
+    providers = models_cfg.providers if models_cfg else {}
+    prov = providers.get(alias, {})
+
+    model_provider = prov.get("model_provider", alias)
+
+    model_kwargs: dict[str, Any] = {"model": f"{model_provider}:{pure_model}"}
+
+    if prov.get("base_url"):
+        model_kwargs["base_url"] = prov["base_url"]
+    if prov.get("api_key_env"):
+        model_kwargs["api_key_env"] = prov["api_key_env"]
+
+    return ModelConfig.model_validate(model_kwargs, extra="allow")
+
+
+def resolve_llm_model_config(
+    models_cfg: ModelsConfig | None,
+    base_llm_model: ModelConfig | None = None,
+    agent_name: str | None = None,
+) -> ModelConfig:
+    """
+    Resolve the richer `models:` block into a single concrete ModelConfig.
+
+    Merge order:
+      1) base_llm_model or default fallback
+      2) models.defaults.params
+      3) models.profiles[defaults.profile]
+      4) models.agents[agent_name].profile
+      5) models.agents[agent_name].params
+
+    Model selection:
+      - agent-specific model if present
+      - models.defaults.model if present
+      - models.default if present
+      - base_llm_model.model if present
+      - fallback openai:gpt-5.2
+    """
+    if base_llm_model is None:
+        base_llm_model = ModelConfig(
+            model="openai:gpt-5.2",
+            max_completion_tokens=5000,
+        )
+
+    merged_kwargs = base_llm_model.model_dump(exclude_none=True)
+
+    if not models_cfg:
+        return ModelConfig.model_validate(merged_kwargs, extra="allow")
+
+    merged_kwargs = deep_merge_dicts(
+        merged_kwargs, models_cfg.defaults.params or {}
+    )
+
+    default_profile_name = models_cfg.defaults.profile
+    if default_profile_name and default_profile_name in models_cfg.profiles:
+        merged_kwargs = deep_merge_dicts(
+            merged_kwargs, models_cfg.profiles[default_profile_name] or {}
+        )
+
+    agent_cfg = None
+    if agent_name and agent_name in models_cfg.agents:
+        agent_cfg = models_cfg.agents[agent_name]
+
+    if agent_cfg and agent_cfg.profile:
+        if agent_cfg.profile in models_cfg.profiles:
+            merged_kwargs = deep_merge_dicts(
+                merged_kwargs,
+                models_cfg.profiles[agent_cfg.profile] or {},
+            )
+
+    if agent_cfg:
+        merged_kwargs = deep_merge_dicts(merged_kwargs, agent_cfg.params or {})
+
+    chosen_model = None
+    if agent_cfg and agent_cfg.model:
+        chosen_model = agent_cfg.model
+    elif models_cfg.defaults.model:
+        chosen_model = models_cfg.defaults.model
+    elif models_cfg.default:
+        chosen_model = models_cfg.default
+    elif merged_kwargs.get("model"):
+        chosen_model = merged_kwargs["model"]
+    else:
+        chosen_model = "openai:gpt-5.2"
+
+    resolved_model_cfg = resolve_model_choice_from_models_cfg(
+        chosen_model, models_cfg
+    )
+
+    final_kwargs = deep_merge_dicts(
+        resolved_model_cfg.model_dump(exclude_none=True),
+        {k: v for k, v in merged_kwargs.items() if k != "model"},
+    )
+
+    return ModelConfig.model_validate(final_kwargs, extra="allow")
+
+
 ENV_SUB_REGEX = re.compile(r"\${(?P<env>\w+)(?::(?P<default>.+))?}")
 
 
@@ -209,3 +373,31 @@ def interpolate_env(value: str) -> str:
         return environ.get(groups["env"], default=groups["default"])
 
     return ENV_SUB_REGEX.sub(interpolate_env, value)
+
+
+def get_config_planning_mode(cfg: dict[str, Any] | Any) -> str | None:
+    config_mode = None
+
+    if isinstance(cfg, dict):
+        planning_cfg = cfg.get("planning")
+        if isinstance(planning_cfg, dict):
+            config_mode = planning_cfg.get("mode")
+        if not config_mode:
+            config_mode = cfg.get("planning_mode")
+        return config_mode
+
+    planning_cfg = getattr(cfg, "planning", None)
+    if isinstance(planning_cfg, dict):
+        config_mode = planning_cfg.get("mode")
+    if not config_mode:
+        config_mode = getattr(cfg, "planning_mode", None)
+    return config_mode
+
+
+def get_models_cfg(cfg: dict[str, Any] | UrsaConfig) -> ModelsConfig | None:
+    if isinstance(cfg, dict):
+        raw = cfg.get("models")
+        if not raw:
+            return None
+        return ModelsConfig.model_validate(raw)
+    return cfg.models

--- a/src/ursa/util/checkpoint_fs.py
+++ b/src/ursa/util/checkpoint_fs.py
@@ -1,0 +1,329 @@
+"""
+checkpoint_fs.py
+
+Helpers for filesystem-based checkpoint discovery, snapshotting, and restore.
+
+Tiny utilities used by URSA runners to find and restore executor
+checkpoints, snapshot SQLite DBs in a WAL-safe way, and manage
+executor checkpoint naming conventions.
+
+Public functions:
+  - ckpt_dir(workspace) -> Path
+  - snapshot_sqlite_db(src_path, dst_path) -> None
+  - parse_snapshot_indices(Path) -> (int|None, int|None)
+  - list_executor_checkpoints(workspace) -> list[Path]
+  - choose_checkpoint(workspace, timeout=60, input_fn=None) -> Path|None
+  - resolve_resume_checkpoint(workspace, resume_from, timeout=60, choose_fn=None, input_fn=None) -> Path|None
+  - restore_executor_from_snapshot(workspace, snapshot) -> None
+  - sync_progress_for_snapshot_single(workspace, snapshot, plan_sig, progress_file=None) -> None
+
+Design notes:
+  - `input_fn(prompt, timeout) -> str|None` is injected; pass your interactive
+    timed_input_with_countdown from your runner for the same UX.
+  - Defaults are non-interactive: choose_checkpoint returns the default live DB.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Callable, Optional
+
+
+def ckpt_dir(workspace: str) -> Path:
+    """Return and ensure the checkpoints directory for a workspace."""
+    p = Path(workspace) / "checkpoints"
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def _sqlite_sidecars(db_path: Path) -> list[Path]:
+    """Return existing SQLite sidecar files for a DB path."""
+    sidecars = []
+    for suffix in ("-wal", "-shm"):
+        p = db_path.with_name(db_path.name + suffix)
+        if p.exists():
+            sidecars.append(p)
+    return sidecars
+
+
+def snapshot_sqlite_db(src_path: Path, dst_path: Path) -> None:
+    """
+    Make a consistent copy of the SQLite database at src_path into dst_path,
+    using the sqlite3 backup API. Safe with WAL; no need to copy -wal/-shm files.
+    """
+    dst_path.parent.mkdir(parents=True, exist_ok=True)
+    src_uri = f"file:{Path(src_path).resolve().as_posix()}?mode=ro"
+    src = dst = None
+    try:
+        src = sqlite3.connect(src_uri, uri=True)
+        dst = sqlite3.connect(str(dst_path))
+        with dst:
+            src.backup(dst)
+    finally:
+        try:
+            if dst:
+                dst.close()
+        except Exception:
+            pass
+        try:
+            if src:
+                src.close()
+        except Exception:
+            pass
+
+
+def parse_snapshot_indices(p: Path) -> tuple[Optional[int], Optional[int]]:
+    """
+    Parse snapshot filename to indices.
+
+    Examples:
+      executor_5.db / executor_checkpoint_5.db => (5, None)
+      executor_3_2.db / executor_checkpoint_3_2.db => (3, 2)
+    """
+    import re
+
+    m = re.match(
+        r"(?:executor|executor_checkpoint)_(\d+)(?:_(\d+))?\.db$", p.name
+    )
+    if not m:
+        return None, None
+    a = int(m.group(1))
+    b = int(m.group(2)) if m.group(2) else None
+    return a, b
+
+
+def _ckpt_sort_key(p: Path):
+    """Internal sort key: numbered snapshots first, then live default, then others."""
+    import re
+
+    name = p.name
+    pat = r"executor_checkpoint_(\d+)(?:_(\d+))?\.db$"
+    m = re.match(pat, name)
+    if m:
+        a = int(m.group(1))
+        b = int(m.group(2) or 0)
+        return (0, a, b, name)  # numbered snapshots first
+    if name == "executor_checkpoint.db":
+        return (1, float("inf"), float("inf"), name)  # live default next
+    # anything else sinks to the bottom
+    return (2, float("inf"), float("inf"), name)
+
+
+def list_executor_checkpoints(workspace: str) -> list[Path]:
+    ckdir = ckpt_dir(workspace)
+    return sorted(ckdir.glob("executor_checkpoint*.db"), key=_ckpt_sort_key)
+
+
+def choose_checkpoint(
+    workspace: str,
+    timeout: int = 60,
+    input_fn: Optional[Callable[[str, int], Optional[str]]] = None,
+) -> Optional[Path]:
+    """
+    Present available checkpoints and let user select one.
+
+    - input_fn(prompt, timeout) should return the user's input string or None for timeout/no-input.
+    - If input_fn is None, this will immediately return the default live checkpoint path.
+
+    Returns a Path (possibly the default live DB), or None if nothing is available.
+    """
+    ckpts = list_executor_checkpoints(workspace)
+    default = ckpt_dir(workspace) / "executor_checkpoint.db"
+
+    # Non-interactive default behavior: return the default live DB
+    if input_fn is None:
+        return default
+
+    print("\nAvailable executor checkpoints:")
+    if ckpts:
+        for i, p in enumerate(ckpts, 1):
+            tag = " (default)" if p.resolve() == default.resolve() else ""
+            print(f"  {i}. {p.name}{tag}")
+        prompt = (
+            f"Select checkpoint [1-{len(ckpts)} or filename] "
+            f"(Enter for default: {default.name}; auto in {timeout}s) > "
+        )
+        sel = input_fn(prompt, timeout)
+    else:
+        print("  (none found)")
+        prompt = (
+            f"Press Enter to start fresh ({default.name}; auto in {timeout}s), "
+            f"or type a checkpoint filename to restore > "
+        )
+        sel = input_fn(prompt, timeout)
+
+    if not sel:
+        return default
+
+    sel = sel.strip()
+    if sel.isdigit() and ckpts:
+        idx = int(sel)
+        if 1 <= idx <= len(ckpts):
+            return ckpts[idx - 1]
+        print(f"[warn] Invalid selection {sel}; using default.")
+        return default
+
+    cand = Path(sel)
+    if not cand.is_absolute():
+        cand = Path(workspace) / sel
+    if cand.exists():
+        # Optional: accept legacy names beginning with executor_
+        return cand
+
+    print(f"[warn] '{sel}' not found; using default.")
+    return default
+
+
+def resolve_resume_checkpoint(
+    workspace: str,
+    resume_from: Optional[str],
+    timeout: int,
+    choose_fn: Optional[Callable[..., Optional[Path]]] = None,
+    input_fn: Optional[Callable[[str, int], Optional[str]]] = None,
+) -> Optional[Path]:
+    """
+    Resolve a resume target from CLI value (resume_from) or via interactive chooser.
+
+    - If resume_from is provided and exists (either absolute or relative to checkpoints/ or workspace/),
+      it is returned.
+    - Otherwise, choose_fn(workspace, timeout, input_fn) is called if provided; otherwise
+      choose_checkpoint is used with the provided input_fn.
+    """
+    if resume_from:
+        p = Path(resume_from)
+        if not p.is_absolute():
+            cand = ckpt_dir(workspace) / p
+            if cand.exists():
+                print(
+                    f"[resume] Using checkpoint from CLI (checkpoints): {cand.name}"
+                )
+                return cand
+            p = Path(workspace) / p
+        if p.exists():
+            print(f"[resume] Using checkpoint from CLI: {p.name}")
+            return p
+        print(
+            f"[warn] --resume-from '{resume_from}' not found; falling back to interactive/default."
+        )
+
+    chooser = choose_fn or choose_checkpoint
+    return chooser(workspace, timeout=timeout, input_fn=input_fn)
+
+
+def restore_executor_from_snapshot(workspace: str, snapshot: Path) -> None:
+    """
+    Copy the selected snapshot database into the live executor DB
+    (checkpoints/executor_checkpoint.db).
+
+    Safety rule:
+    - If the live DB has SQLite sidecars (-wal / -shm), do not restore over it,
+      because another process may still own or be using that database.
+    """
+    live = ckpt_dir(workspace) / "executor_checkpoint.db"
+
+    if not snapshot.exists():
+        print(
+            f"[resume] No snapshot to restore (missing: {snapshot}); starting fresh."
+        )
+        return
+
+    if snapshot.resolve() == live.resolve():
+        print(f"[resume] Live DB already at desired checkpoint: {live.name}")
+        return
+
+    live_sidecars = _sqlite_sidecars(live)
+    if live_sidecars:
+        names = ", ".join(p.name for p in live_sidecars)
+        print(
+            "[warn] Refusing to restore over live executor DB because SQLite "
+            f"sidecars exist: {names}. Another process may still be using it."
+        )
+        print(
+            "[warn] Please stop other processes using this workspace/checkpoint "
+            "and retry."
+        )
+        return
+
+    try:
+        snapshot_sqlite_db(snapshot, live)
+        print(f"[resume] Restored: {snapshot.name} → {live.name}")
+    except Exception as e:
+        print(
+            f"[warn] Failed to restore '{snapshot}': {e}. Continuing with current live DB."
+        )
+
+
+def sync_progress_for_snapshot_single(
+    workspace: str,
+    snapshot: Path,
+    plan_sig: str,
+    progress_file: Optional[Path] = None,
+) -> None:
+    """
+    For SINGLE mode numbered snapshots, align executor_progress.json so the engine resumes at the right step.
+
+    executor_<k>.db means 'k' steps completed ⇒ next_index = k (0-based start from k).
+    """
+    k, _ = parse_snapshot_indices(snapshot)
+    if not k:
+        # Not a numbered snapshot (e.g., executor_checkpoint.db) — leave JSON as-is
+        print(
+            "[resume] Using live/default checkpoint; not altering executor_progress.json."
+        )
+        return
+    prog_path = progress_file or progress_file(workspace)
+    payload = {
+        "next_index": int(
+            k
+        ),  # start loop at idx=k (i.e., step k+1 in 1-based terms)
+        "plan_hash": str(plan_sig),
+        "last_summary": f"Resumed from snapshot {snapshot.name}",
+    }
+    prog_path.write_text(json.dumps(payload, indent=2))
+    print(
+        f"[resume] Wrote {prog_path.name}: next_index={k}, plan_hash={plan_sig[:8]}. . ."
+    )
+
+
+def hash_plan(plan_steps) -> str:
+    """
+    Hash the structure so we can detect if the plan changed between runs.
+    Deterministic by sorting keys and using default=str for objects.
+    """
+    import hashlib
+    import json
+
+    return hashlib.sha256(
+        json.dumps(plan_steps, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()
+
+
+# Progress JSON helpers (executor progress tracking)
+def progress_file(workspace: str) -> Path:
+    """Default executor progress JSON location."""
+    return Path(workspace) / "executor_progress.json"
+
+
+def load_exec_progress(workspace: str) -> dict:
+    p = progress_file(workspace)
+    if p.exists():
+        try:
+            return json.loads(p.read_text())
+        except Exception:
+            return {}
+    return {}
+
+
+def save_exec_progress(
+    workspace: str,
+    next_index: int,
+    plan_hash: str,
+    last_summary: str | None = None,
+) -> None:
+    p = progress_file(workspace)
+    payload = {"next_index": int(next_index), "plan_hash": plan_hash}
+    if last_summary is not None:
+        payload["last_summary"] = last_summary
+    p.write_text(json.dumps(payload, indent=2))

--- a/src/ursa/util/interactive.py
+++ b/src/ursa/util/interactive.py
@@ -1,0 +1,60 @@
+# src/ursa/util/interactive.py
+from __future__ import annotations
+
+from typing import Optional
+
+
+def timed_input_with_countdown(prompt: str, timeout: int) -> Optional[str]:
+    """
+    Read a line with a per-second countdown. Returns:
+      - the user's input (str) if provided,
+      - None if timeout expires,
+      - None if non-interactive or timeout<=0.
+    No bracketed prefixes are printed (clean output for all prompts).
+    """
+    import sys
+    import time
+
+    # Non-interactive or disabled timeout → default immediately (no noisy prefix)
+    try:
+        is_tty = sys.stdin.isatty()
+    except Exception:
+        is_tty = False
+
+    if not is_tty:
+        print("(non-interactive) selecting default . . .")
+        return None
+    if timeout <= 0:
+        print("(timeout disabled) selecting default . . .")
+        return None
+
+    # Show prompt and run a 1s polling loop
+    deadline = time.time() + timeout
+    print(prompt, end="", flush=True)
+
+    try:
+        import select
+
+        while True:
+            remaining = int(max(0, deadline - time.time()))
+            if remaining in {30, 10, 5, 4, 3, 2, 1}:
+                print(
+                    f"\n{remaining} seconds left . . .  (Ctrl-C to abort)",
+                    flush=True,
+                )
+                print(prompt, end="", flush=True)
+            if remaining <= 0:
+                print()
+                return None
+
+            rlist, _, _ = select.select([sys.stdin], [], [], 1.0)
+            if rlist:
+                line = sys.stdin.readline()
+                return None if line is None else line.strip()
+
+    except Exception:
+        # Fallback if select is unavailable
+        try:
+            return input()
+        except KeyboardInterrupt:
+            raise

--- a/src/ursa/util/llm_factory.py
+++ b/src/ursa/util/llm_factory.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from langchain.chat_models import init_chat_model
+
+"""
+llm_factory.py
+
+Utilities for constructing LangChain chat models for URSA runners using a YAML config.
+
+This centralizes:
+- provider alias resolution (e.g., "openai:gpt-5" or "my_endpoint:openai/gpt-oss-120b")
+- auth and base_url wiring from cfg.models.providers
+- merging of per-run defaults + optional YAML profiles + per-agent overrides
+- best-effort logging banners that redact known secret-like fields
+
+Goal: any URSA program (plan/execute, hypothesizer, etc.) can share the same model
+configuration behavior and get consistent logging and overrides.
+"""
+
+
+# ---------------------------------------------------------------------
+# Secret masking / sanitization for logs
+# ---------------------------------------------------------------------
+def _looks_like_secret_key(name: str) -> bool:
+    n = name.lower().replace("-", "_").replace(" ", "_")
+
+    exact = {
+        "api_key",
+        "apikey",
+        "access_token",
+        "refresh_token",
+        "client_secret",
+        "password",
+        "passwd",
+        "authorization",
+        "private_key",
+    }
+    if n in exact:
+        return True
+
+    return (
+        n.endswith("_api_key")
+        or n.endswith("_token")
+        or n.endswith("_secret")
+        or n.endswith("_password")
+    )
+
+
+def _mask_secret(value: Any) -> str:
+    """
+    Fully redact secret-like values for logging.
+    """
+    return "[REDACTED]"
+
+
+def _sanitize_for_logging(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        out = {}
+        for k, v in obj.items():
+            if _looks_like_secret_key(str(k)):
+                out[k] = _mask_secret(v)
+            else:
+                out[k] = _sanitize_for_logging(v)
+        return out
+    if isinstance(obj, list):
+        return [_sanitize_for_logging(v) for v in obj]
+    return obj
+
+
+@dataclass
+class ModelConfig:
+    provider: str
+    model_name: str
+    model_extra: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def kwargs(self) -> dict[str, Any]:
+        return {
+            "model": self.model_name,
+            "model_provider": self.provider,
+            **self.model_extra,
+        }
+
+    def __str__(self) -> str:
+        safe_model_extra = _sanitize_for_logging(self.model_extra or {})
+
+        text = (
+            f"provider: {self.provider}\n"
+            f"model: {self.model_name}\n\n"
+            f"model kwargs: {json.dumps(safe_model_extra, indent=2)}"
+        )
+
+        effort = None
+        try:
+            effort = (self.model_extra or {}).get("reasoning", {}).get("effort")
+        except Exception:
+            effort = None
+
+        if effort:
+            text += (
+                f"\n\nReasoning effort requested: {effort}\n"
+                "Note: This confirms what we sent to init_chat_model; actual enforcement is provider-side."
+            )
+
+        return text
+
+
+# ---------------------------------------------------------------------
+# Logging banner
+# ---------------------------------------------------------------------
+def llm_init_banner(
+    llm: ModelConfig,
+    agent_name: str | None = None,
+    model_obj: Any = None,
+) -> str:
+    who = agent_name or "llm"
+    text = f"LLM init ({who})\n{llm}"
+
+    if model_obj is not None:
+        readback = {}
+        for attr in (
+            "model_name",
+            "model",
+            "reasoning",
+            "temperature",
+            "max_completion_tokens",
+            "max_tokens",
+        ):
+            if hasattr(model_obj, attr):
+                try:
+                    readback[attr] = getattr(model_obj, attr)
+                except Exception:
+                    pass
+
+        for attr in ("model_kwargs", "kwargs"):
+            if hasattr(model_obj, attr):
+                try:
+                    readback[attr] = getattr(model_obj, attr)
+                except Exception:
+                    pass
+
+        if readback:
+            text += (
+                "\n\nLLM readback (best-effort from LangChain object)\n"
+                + json.dumps(_sanitize_for_logging(readback), indent=2)
+            )
+
+    return text
+
+
+def _print_llm_init_banner(
+    llm: ModelConfig,
+    *,
+    agent_name: str | None = None,
+    model_obj: Any = None,
+    console: Any | None = None,
+) -> None:
+    """
+    Render the formatted LLM init banner to either rich console output or plain text.
+    """
+    banner_text = llm_init_banner(
+        llm=llm,
+        agent_name=agent_name,
+        model_obj=model_obj,
+    )
+
+    if console is not None:
+        try:
+            from rich.panel import Panel
+            from rich.text import Text
+
+            # Split the sections into separate panels for readability.
+            parts = banner_text.split("\n\n")
+
+            if parts:
+                console.print(
+                    Panel.fit(
+                        Text.from_markup(
+                            parts[0]
+                            + ("\n\n" + parts[1] if len(parts) > 1 else "")
+                        ),
+                        border_style="cyan",
+                    )
+                )
+
+            for part in parts[2:]:
+                border = "green"
+                if part.startswith("Reasoning effort requested:"):
+                    border = "yellow"
+                console.print(
+                    Panel.fit(
+                        Text.from_markup(part),
+                        border_style=border,
+                    )
+                )
+        except Exception:
+            print(banner_text)
+    else:
+        print(banner_text)
+
+
+# ---------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------
+def setup_llm(
+    *,
+    model_config,
+    agent_name: str | None = None,
+    console: Any | None = None,
+):
+    """
+    Build a LangChain chat model from a resolved ModelConfig.
+    """
+    model = init_chat_model(**model_config.kwargs)
+
+    _print_llm_init_banner(
+        model_config,
+        agent_name=agent_name,
+        model_obj=model,
+        console=console,
+    )
+
+    return model

--- a/src/ursa/util/llm_factory.py
+++ b/src/ursa/util/llm_factory.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
 import json
+<<<<<<< HEAD
 from dataclasses import dataclass, field
+=======
+import os
+
+# needed for SSL / PKI verifications, if the user needs that
+import ssl
+>>>>>>> 9b0fcdd (improvements to support some SSL things as well)
 from typing import Any
 
+import httpx
 from langchain.chat_models import init_chat_model
 
 """
@@ -57,6 +65,22 @@ def _mask_secret(value: Any) -> str:
     return "[REDACTED]"
 
 
+def _json_safe(obj: Any) -> Any:
+    """Best-effort conversion to something json.dumps can handle."""
+    # Primitives are fine
+    if obj is None or isinstance(obj, (str, int, float, bool)):
+        return obj
+    # Common containers
+    if isinstance(obj, dict):
+        return {str(k): _json_safe(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_json_safe(v) for v in obj]
+    if isinstance(obj, tuple):
+        return [_json_safe(v) for v in obj]
+    # Fallback: readable repr (keeps type info)
+    return f"<{obj.__class__.__name__}>"
+
+
 def _sanitize_for_logging(obj: Any) -> Any:
     if isinstance(obj, dict):
         out = {}
@@ -68,7 +92,7 @@ def _sanitize_for_logging(obj: Any) -> Any:
         return out
     if isinstance(obj, list):
         return [_sanitize_for_logging(v) for v in obj]
-    return obj
+    return _json_safe(obj)
 
 
 @dataclass
@@ -201,6 +225,36 @@ def _print_llm_init_banner(
             print(banner_text)
     else:
         print(banner_text)
+
+
+def _maybe_add_system_trust_httpx_clients(
+    provider: str, provider_extra: dict
+) -> dict:
+    """
+    If we're using OpenAI-compatible provider + running on macOS corporate PKI,
+    use system trust store via truststore to avoid certifi/conda OpenSSL issues.
+    """
+    if provider != "openai":
+        return provider_extra
+
+    # Don't override if caller already provided custom clients
+    if "http_client" in provider_extra or "http_async_client" in provider_extra:
+        return provider_extra
+
+    try:
+        import truststore  # pip install truststore
+    except Exception:
+        return provider_extra
+
+    ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+
+    # Provide both sync + async so invoke() and ainvoke() both work.
+    provider_extra = dict(provider_extra or {})
+    provider_extra["http_client"] = httpx.Client(verify=ctx, trust_env=False)
+    provider_extra["http_async_client"] = httpx.AsyncClient(
+        verify=ctx, trust_env=False
+    )
+    return provider_extra
 
 
 # ---------------------------------------------------------------------

--- a/src/ursa/util/llm_factory.py
+++ b/src/ursa/util/llm_factory.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
 import json
-<<<<<<< HEAD
-from dataclasses import dataclass, field
-=======
-import os
 
 # needed for SSL / PKI verifications, if the user needs that
 import ssl
->>>>>>> 9b0fcdd (improvements to support some SSL things as well)
+from dataclasses import dataclass, field
 from typing import Any
 
 import httpx

--- a/src/ursa/util/run_meta.py
+++ b/src/ursa/util/run_meta.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+"""
+run_meta.py
+
+This module manages per-workspace "run metadata" stored in `run_meta.json`.
+
+A workspace is a directory created for a single run (or a series of resumed runs)
+of an agentic workflow. We store small bits of bookkeeping state that should
+persist across restarts, e.g.:
+
+- which planning mode the workspace is locked to ("single" vs "hierarchical")
+- whether one-time setup steps were already performed (e.g., logo generation)
+- plan signature/hash and plan step count from the last planning phase
+- the thread_id and model name used for the run
+"""
+
+
+def _run_meta_file(workspace: str) -> Path:
+    return Path(workspace) / "run_meta.json"
+
+
+def load_run_meta(workspace: str) -> dict:
+    p = _run_meta_file(workspace)
+    if p.exists():
+        try:
+            return json.loads(p.read_text())
+        except Exception:
+            return {}
+    return {}
+
+
+def save_run_meta(workspace: str, **fields) -> dict:
+    """
+    Update run_meta.json with provided key/value fields.
+    Fields set to None are ignored (so callers can do save_run_meta(..., foo=maybe_none)).
+    """
+    p = _run_meta_file(workspace)
+    p.parent.mkdir(parents=True, exist_ok=True)
+
+    meta = load_run_meta(workspace)
+    meta.update({k: v for k, v in fields.items() if v is not None})
+    p.write_text(json.dumps(meta, indent=2))
+    return meta
+
+
+def lock_or_warn_planning_mode(
+    workspace: str,
+    chosen_mode: str,
+    console: Any | None = None,
+) -> tuple[str, bool]:
+    """
+    Ensure a workspace has a fixed planning_mode.
+    Returns (effective_mode, locked_already).
+
+    If planning_mode is already stored in run_meta.json and differs from chosen_mode,
+    we warn and keep the existing mode. If `console` (rich console) is provided, we
+    print a nice Panel; otherwise we fall back to plain print().
+    """
+    meta = load_run_meta(workspace)
+    existing = meta.get("planning_mode")
+
+    if existing:
+        if existing != chosen_mode:
+            msg = (
+                f"Workspace already locked to planning_mode={existing}\n"
+                f"Ignoring requested mode '{chosen_mode}'. Use a new --workspace if you want a different mode."
+            )
+            if console is not None:
+                try:
+                    from rich.panel import Panel
+
+                    console.print(Panel.fit(msg, border_style="yellow"))
+                except Exception:
+                    print(msg)
+            else:
+                print(msg)
+        return existing, True
+
+    # First run for this workspace: lock it
+    save_run_meta(workspace, planning_mode=chosen_mode)
+    return chosen_mode, False

--- a/src/ursa/util/workspace.py
+++ b/src/ursa/util/workspace.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import randomname
+from rich.panel import Panel
+
+
+def setup_workspace(
+    *,
+    user_specified_workspace: str | None,
+    project: str = "run",
+    model_name: str = "openai:gpt-5-mini",
+    console,
+) -> str:
+    """
+    Create (or reuse) a workspace directory for a run.
+
+    Behavior:
+      - If user_specified_workspace is None, make a new folder named:
+            "<project>_<randomname>"
+      - Otherwise use the provided workspace path.
+      - Always mkdir(parents=True, exist_ok=True)
+      - Prints a Rich panel with the chosen workspace + model.
+
+    Returns:
+      workspace (str)
+    """
+    if user_specified_workspace is None:
+        print("No workspace specified, creating one for this project!")
+        print(
+            "Make sure to pass this string to restart using --workspace <this workspace string>"
+        )
+        workspace = f"{project}_{randomname.get_name(adj=('colors', 'emotions', 'character', 'speed', 'size', 'weather', 'appearance', 'sound', 'age', 'taste'), noun=('cats', 'dogs', 'apex_predators', 'birds', 'fish', 'fruit'))}"
+    else:
+        workspace = user_specified_workspace
+        print(f"User specified workspace: {workspace}")
+
+    Path(workspace).mkdir(parents=True, exist_ok=True)
+
+    # Choose a fun emoji based on the model family
+    if model_name.startswith("openai"):
+        model_emoji = "🤖"
+    elif "llama" in model_name.lower():
+        model_emoji = "🦙"
+    else:
+        model_emoji = "🧠"
+
+    console.print(
+        Panel.fit(
+            f":rocket:  [bold bright_blue]{workspace}[/bold bright_blue]  :rocket:\n"
+            f"{model_emoji}  [bold cyan]{model_name}[/bold cyan]",
+            title="[bold green]ACTIVE WORKSPACE[/bold green]",
+            border_style="bright_magenta",
+            padding=(1, 4),
+        )
+    )
+
+    return workspace
+
+
+def ensure_symlink(
+    *, workspace: str | Path, symlink_cfg: dict | None
+) -> dict | None:
+    """
+    Ensure a symlink described by symlink_cfg exists inside workspace.
+
+    symlink_cfg shape:
+      {"source": "...", "dest": "..."}  # dest is relative to workspace
+    Adds/returns:
+      {"source": ..., "dest": ..., "is_linked": True}
+
+    If symlink_cfg is None/empty, returns None.
+    """
+    if not symlink_cfg or not isinstance(symlink_cfg, dict):
+        return None
+
+    # If caller already marked it linked, do nothing.
+    if symlink_cfg.get("is_linked"):
+        return symlink_cfg
+
+    src = Path(symlink_cfg["source"]).expanduser().resolve()
+    ws_root = Path(workspace).expanduser().resolve()
+    dst = ws_root / symlink_cfg["dest"]
+
+    # Ensure parent dir exists
+    dst.parent.mkdir(parents=True, exist_ok=True)
+
+    # If something exists there, replace it
+    if dst.exists() or dst.is_symlink():
+        dst.unlink()
+
+    dst.symlink_to(src, target_is_directory=src.is_dir())
+    print(f"Symlinked {src} (source) --> {dst} (dest)")
+
+    out = dict(symlink_cfg)
+    out["is_linked"] = True
+    return out


### PR DESCRIPTION
OK like most things complex, this touched a lot of code, sorry.  Basically the plan was:
1. create a simpler YAML file in the two_example/plan_execute called hello world - it runs faster, good for quick tests, and new users might find it informational.
2. i then refactored the plan-execute-from-yaml file - there's a lot of functionality in there i wanted to use in another code (below), so I moved most of it to src/ursa/util/ such as checkpointing, workspace management, configuration (YAML) text file reading, stuff like that.  this made it accessible to code below, but also tidied up the plan/execYAML.
3. I needed to build a better example using the hypothesizer agent that is able to read documents in a directory you give it (notice here I'm using the YAML, symlink dirs, like I've used before).... so that example is now in single_agent_examples/doc_critique_writer.py
4. This example uses some input docs which we instruct the user to download via a sci_fi_bill_of_rights/README.txt from the Gutenberg online repo - in this case, it's the US bill of rights and then HGWells The Time Machine (text, we don't include them in the repo, but the user can freely download them w/ that README / wget).
5. Then there's a YAML which instructs the hypothesizer (doc critique writer) to use the sci_fi doc (for which it has to find it in the directory, read it, etc.) as a future possibility and suggest edits to the Bill of Rights (btw, this is awesome :)).  To accomplish this right, we tap into tool calling capability to list files in the directory as well as our existing tools for read_file (including testing on PDFs).

This all works and is awesome.  It's a good example of this technique and then I privately swap it for other LLMs and private docs we don't want to share and the same workflow works.