### PR TITLE
fix: enable tool error handling

### DIFF
--- a/src/ursa/agents/base.py
+++ b/src/ursa/agents/base.py
@@ -33,7 +33,7 @@ from typing import (
 from uuid import uuid4
 
 from langchain.chat_models import BaseChatModel
-from langchain.tools import BaseTool
+from langchain.tools import BaseTool, ToolException
 from langchain_core.load import dumps
 from langchain_core.messages import BaseMessage, HumanMessage
 from langchain_core.runnables import RunnableLambda
@@ -41,6 +41,7 @@ from langchain_mcp_adapters.client import MultiServerMCPClient
 from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.graph.state import CompiledStateGraph, StateGraph
 from langgraph.prebuilt import ToolNode
+from langgraph.prebuilt.tool_node import ToolInvocationError
 
 from ursa.observability.timing import (
     Telemetry,  # for timing / telemetry / metrics
@@ -818,6 +819,14 @@ class BaseAgent(Generic[TState], ABC):
         )
 
 
+def _default_tool_error_handler(e: Exception):
+    if isinstance(e, ToolInvocationError):
+        return e.message
+    elif isinstance(e, ToolException):
+        return str(e)
+    raise e
+
+
 class AgentWithTools:
     """Mixin that equips an agent with LangGraph tools management."""
 
@@ -825,9 +834,11 @@ class AgentWithTools:
         self,
         *args,
         tools: list[BaseTool] | dict[str, BaseTool] | None = None,
+        handle_tool_errors=_default_tool_error_handler,
         **kwargs,
     ):
         self._tools: dict[str, BaseTool] = {}
+        self.handle_tool_errors = handle_tool_errors
         self.tool_node = ToolNode([])
         self._apply_tools(tools, rebuild_graph=False)
         super().__init__(*args, **kwargs)
@@ -891,7 +902,10 @@ class AgentWithTools:
             mapping = {tool.name: tool for tool in tools}
 
         self._tools = mapping
-        self.tool_node = ToolNode(list(self._tools.values()))
+        self.tool_node = ToolNode(
+            list(self._tools.values()),
+            handle_tool_errors=self.handle_tool_errors,
+        )
 
         if rebuild_graph and hasattr(self, "build_graph"):
             self.__dict__.pop("compiled_graph", None)

--- a/tests/test_base_interface.py
+++ b/tests/test_base_interface.py
@@ -91,9 +91,14 @@ def _make_tool(name: str):
 
 
 class DummyAgentWithTools(AgentWithTools, BaseAgent):
-    def __init__(self, llm, tools=None, **kwargs):
+    def __init__(self, llm, tools=None, handle_tool_errors=True, **kwargs):
         self.build_graph_calls = 0
-        super().__init__(llm=llm, tools=tools, **kwargs)
+        super().__init__(
+            llm=llm,
+            tools=tools,
+            handle_tool_errors=handle_tool_errors,
+            **kwargs,
+        )
 
     def _noop(self, state):
         return state
@@ -176,6 +181,23 @@ def test_agent_with_tools_setter_updates_mapping_and_rebuilds_graph(
     assert agent.tools == {"beta": beta}
     assert agent.build_graph_calls == initial_calls + 1
     assert isinstance(agent.tool_node, ToolNode)
+
+
+@pytest.mark.parametrize("handle_tool_errors", [True, "Custom error message"])
+def test_handle_tool_errors_propagation(
+    chat_model, tmp_path, handle_tool_errors
+):
+    """Verify that handle_tool_errors is propagated to ToolNode."""
+    # Dummy tool used only for adding to the agent; no need to run it
+    alpha = _make_tool("alpha")
+    agent = DummyAgentWithTools(
+        llm=chat_model,
+        tools=[alpha],
+        workspace=tmp_path,
+        handle_tool_errors=handle_tool_errors,
+    )
+    # The ToolNode internally stores the error handling strategy
+    assert agent.tool_node._handle_tool_errors == handle_tool_errors
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Currently LangGraph raises a ToolException for MCP errors, which doesn't get handled by the default error ToolNode error handle.

This exposes the ability to config how the tool node handles tool errors and changes the default handler to catch ToolException (i.e. return the error to the agent)