### PR TITLE
feat: environmental variable interpolation for configs

### DIFF
--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -39,7 +39,10 @@ mcp_servers:
       - --config
       - config.yaml
     env:
-      OPENAI_API_KEY: SUPER_SECRET_API_KEY
+      # Ursa will interpolate env variables into ${VAR}
+      # fallbacks can be specified as ${VAR:Default}
+      OPENAI_API_KEY: ${SUPER_SECRET_API_KEY}
+      ANOTHER_VAR: ${ANOTHER_VAR:4}
       # More environmental variables to set for the mcp server
   ursa-http:
     # streamable-http servers are configured when started, not here

--- a/src/ursa/cli/config.py
+++ b/src/ursa/cli/config.py
@@ -1,4 +1,5 @@
 import json
+import re
 from copy import deepcopy
 from dataclasses import dataclass
 from os import environ
@@ -103,6 +104,8 @@ class UrsaConfig(BaseModel):
         with open(path, "r") as fid:
             data = loader(fid)
 
+        data = deep_interp_env(data)
+
         return cls.model_validate(data)
 
     @field_serializer("workspace")
@@ -165,3 +168,44 @@ def deep_merge_dicts(
         else:
             merged[key] = value
     return merged
+
+
+ENV_SUB_REGEX = re.compile(r"\${(?P<env>\w+)(?::(?P<default>.+))?}")
+
+
+def deep_interp_env(x: dict[str, Any] | str | Any):
+    """Interpolate all environment variables in stored keys"""
+    if isinstance(x, dict):
+        return {k: deep_interp_env(v) for k, v in x.items()}
+    elif isinstance(x, str):
+        return interpolate_env(x)
+    else:
+        return x
+
+
+def interpolate_env(value: str) -> str:
+    """
+    Interpolate environment variables in a string
+
+    Supported patterns:
+        ${VAR}
+            Replaced with the value of VAR if set, otherwise an empty string.
+
+        ${VAR:DEFAULT}
+            Replaced with the value of VAR if set; otherwise replaced with
+            DEFAULT.
+
+    Args:
+        value: The input string containing zero or more environment
+            variable expressions.
+
+    Returns:
+        The input string with all supported environment variable
+        expressions expanded.
+    """
+
+    def interpolate_env(m: re.Match[str]) -> str:
+        groups = m.groupdict("")
+        return environ.get(groups["env"], default=groups["default"])
+
+    return ENV_SUB_REGEX.sub(interpolate_env, value)

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -95,6 +95,33 @@ def test_config_env_cli_precedence(tmp_path, monkeypatch):
     assert config_cli.emb_model.max_completion_tokens == 1024
 
 
+def test_config_file_env_interpolation(tmp_path, monkeypatch):
+    env_workspace = tmp_path / "env-workspace"
+    env_workspace.mkdir()
+    monkeypatch.setenv("URSA_CFG_WORKSPACE", str(env_workspace))
+    monkeypatch.setenv("URSA_CFG_LLM_MODEL", "openai:gpt-env")
+    monkeypatch.delenv("URSA_CFG_EMB_MODEL", raising=False)
+
+    cfg_path = tmp_path / "ursa-env.yml"
+    cfg_path.write_text(
+        "\n".join([
+            "workspace: ${URSA_CFG_WORKSPACE}",
+            "llm_model:",
+            "  model: ${URSA_CFG_LLM_MODEL}",
+            "emb_model:",
+            "  model: ${URSA_CFG_EMB_MODEL:openai:gpt-5}",
+        ])
+    )
+
+    parser = build_parser()
+    args = parser.parse_args(["--config", str(cfg_path)])
+    config = resolve_config(args)
+
+    assert config.workspace == env_workspace
+    assert config.llm_model.model == "openai:gpt-env"
+    assert config.emb_model.model == "openai:gpt-5"
+
+
 def test_config_file_with_extra_keys(tmp_path):
     cfg_path = tmp_path / "ursa.yml"
     cfg_path.write_text(

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,0 +1,67 @@
+import ursa.cli.config as config_mod
+
+
+def test_interpolate_env_replaces_existing_variable(monkeypatch):
+    monkeypatch.setenv("URSA_TEST_VAR", "world")
+
+    assert config_mod.interpolate_env("hello ${URSA_TEST_VAR}") == "hello world"
+
+
+def test_interpolate_env_uses_default_when_missing(
+    monkeypatch,
+):
+    monkeypatch.delenv("URSA_MISSING_VAR", raising=False)
+
+    assert (
+        config_mod.interpolate_env("value ${URSA_MISSING_VAR:fallback}")
+        == "value fallback"
+    )
+
+
+def test_interpolate_env_allows_colon_in_default(monkeypatch):
+    monkeypatch.delenv("URSA_URL_VAR", raising=False)
+
+    assert (
+        config_mod.interpolate_env(
+            "url=${URSA_URL_VAR:mysql://localhost:5432/db}"
+        )
+        == "url=mysql://localhost:5432/db"
+    )
+
+
+def test_interpolate_env_missing_variable_without_default_is_empty(
+    monkeypatch,
+):
+    monkeypatch.delenv("URSA_EMPTY_VAR", raising=False)
+
+    assert (
+        config_mod.interpolate_env("start ${URSA_EMPTY_VAR} end")
+        == "start  end"
+    )
+
+
+def test_deep_interp_env_recurses_nested_dictionaries(
+    monkeypatch,
+):
+    monkeypatch.setenv("URSA_DEEP_VALUE", "galaxy")
+    monkeypatch.delenv("URSA_DEEP_FALLBACK", raising=False)
+
+    data = {
+        "layer1": {
+            "with_env": "prefix ${URSA_DEEP_VALUE} suffix",
+            "with_default": "${URSA_DEEP_FALLBACK:nebula}",
+        },
+        "unchanged": 42,
+    }
+
+    result = config_mod.deep_interp_env(data)
+
+    assert result == {
+        "layer1": {
+            "with_env": "prefix galaxy suffix",
+            "with_default": "nebula",
+        },
+        "unchanged": 42,
+    }
+    # Confirm original structure is untouched
+    assert data["layer1"]["with_env"] == "prefix ${URSA_DEEP_VALUE} suffix"


### PR DESCRIPTION
Adds support for interpolating environmental variables
into the config at load time

This does not eliminate the need for api_key_env as we
still don't want to expose `api_key` as a cli flag
(leaks secrets) but don't want to force the use of a
config file to set the llm/embedding model api keys

This is primarily to support api keys with the mcp_servers
config
