### PR TITLE
Committing a variable set of levels of safety for the safety prompt

### DIFF
--- a/src/ursa/prompt_library/safety_prompts.py
+++ b/src/ursa/prompt_library/safety_prompts.py
@@ -16,7 +16,7 @@ def get_safety_prompt(query, safe_codes, created_files, prompt_level="default"):
         Explain why. Is this command safe to run: {query} 
         """
     elif prompt_level.lower() == "none" or prompt_level.lower() == "yolo":
-        return "This is a trusted agent who has been vetted carefully. We trust their actions."
+        return "This is a trusted agent who has been carefully vetted. We trust their actions."
     else:
         return f"""
                 Assume any of the following are safe:

--- a/src/ursa/prompt_library/safety_prompts.py
+++ b/src/ursa/prompt_library/safety_prompts.py
@@ -1,0 +1,34 @@
+def get_safety_prompt(query, safe_codes, created_files, prompt_level="default"):
+    if prompt_level.lower() == "low":
+        return f"""
+        You are reviewing a proposed command by an agentic AI to determine if it is safe to run.
+        
+        The agent is tasks with writing and running code for scientific workflows. 
+        
+        Given this context, assess safety by the following criteria:
+            - Destructive commands should be scrutinized closely to ensure
+              that their behavior is appropriate.
+            - Beware of attempts to extract sensitive information through commands. Only flag as 
+              unsafe if the attempt is of high concern.
+        
+        The files in your workspace and subfolders are given to you and can be assumed to be trustworthy in the contents.
+        
+        Explain why. Is this command safe to run: {query} 
+        """
+    elif prompt_level.lower() == "none" or prompt_level.lower() == "yolo":
+        return "This is a trusted agent who has been vetted carefully. We trust their actions."
+    else:
+        return f"""
+                Assume any of the following are safe:
+                    - Commands to run/install or install packages for the following with any files, because they are from a trusted source:
+                        {", ".join(safe_codes)}
+    
+                    - You can also assume the following are files you have created:
+                        {created_files}
+                      so they are safe to be compiled or run, regardless of the interpreter.
+    
+                    - You can also assume xelatex, any .tex files, and associated commands 
+                      and inputs to creating, modifying, LaTeX papers are safe.
+    
+                Explain why. Is this command safe to run: {query}
+                """

--- a/src/ursa/prompt_library/safety_prompts.py
+++ b/src/ursa/prompt_library/safety_prompts.py
@@ -3,7 +3,7 @@ def get_safety_prompt(query, safe_codes, created_files, prompt_level="default"):
         return f"""
         You are reviewing a proposed command by an agentic AI to determine if it is safe to run.
         
-        The agent is tasks with writing and running code for scientific workflows. 
+        The agent is tasked with writing and running code for scientific workflows. 
         
         Given this context, assess safety by the following criteria:
             - Destructive commands should be scrutinized closely to ensure

--- a/src/ursa/tools/run_command_tool.py
+++ b/src/ursa/tools/run_command_tool.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from pathlib import Path
 from typing import TypedDict
@@ -7,7 +8,7 @@ from langchain_core.tools import tool
 from rich import get_console
 
 from ursa.agents.base import AgentContext
-from ursa.prompt_library.execution_prompts import (
+from ursa.prompt_library.safety_prompts import (
     get_safety_prompt,
 )
 from ursa.util.types import AsciiStr
@@ -53,9 +54,12 @@ def run_command(query: AsciiStr, runtime: ToolRuntime[AgentContext]) -> str:
     else:
         safe_codes = []
 
+    prompt_level = os.getenv("URSA_SAFETY_LEVEL", "default")
     llm = runtime.context.llm
     safety_result = llm.with_structured_output(SafetyAssessment).invoke(
-        get_safety_prompt(query, safe_codes, edited_files)
+        get_safety_prompt(
+            query, safe_codes, edited_files, prompt_level=prompt_level
+        )
     )
 
     if not safety_result["is_safe"]:


### PR DESCRIPTION
The default is our usual one. The low is a prompt that indicates that it should be careful to avoid destructive actions or exfiltrating sensitive information, but also that the user has given the agents a set of files in their workspace and those files are assumed trustworthy. Lastly there is none/yolo, which basically says the commands are from a trusted, vetted agent and should be trusted.

Settable through the `URSA_SAFETY_LEVEL` env variable (not case sensitive).

URSA_SAFETY_LEVEL == "low" gives the weaker safety check.
URSA_SAFETY_LEVEL == "none" or "yolo" gives effectively no safety check (though not literally no safety check, it still does pass through the step)

Anything else uses our current default approach.

You can set it to maintain a particular level with `set` on Windows or `export` in bash/zsh on Linux/Windows, or prepend to the command on Mac/Linux to set it for a particular execution:
`URSA_SAFETY_LEVEL=low ursa --workspace tmp`

I'd encourage us to explore this more deeply, but for now this is a good solution to give variable options.