### PR TITLE
Fix image generation wiring

### DIFF
--- a/examples/two_agent_examples/plan_execute/pi_multiple_ways.yaml
+++ b/examples/two_agent_examples/plan_execute/pi_multiple_ways.yaml
@@ -90,7 +90,7 @@ logo:
   scene: random     # e.g., noir, sci-fi, horror, fantasy, etc. ("random" by default)
   stickers: true    # also make sticker variants
   n: 2              # how many variants for each batch
-  model: openai:gpt-image-1 # warning: most 'vision' models do not support image *GENERATION*, this one does
+  model: openai:gpt-image-1-mini # warning: most 'vision' models do not support image *GENERATION*, this one does
 
 
 problem: |

--- a/examples/two_agent_examples/plan_execute/plan_execute_from_yaml.py
+++ b/examples/two_agent_examples/plan_execute/plan_execute_from_yaml.py
@@ -826,6 +826,7 @@ def main(
         problem = getattr(config, "problem", "")
         project = getattr(config, "project", "run")
         symlinkdict = getattr(config, "symlink", {}) or None
+        models_cfg = getattr(config, "models", {}) or {}
 
         # sets up the workspace, run config json, etc.
         resolved_workspace = (
@@ -865,79 +866,80 @@ def main(
 
         # ---- One-time project logo kickoff (per workspace) -----------------
         meta = load_run_meta(workspace)
-        logo_cfg = getattr(cfg, "logo", {}) or {}
-        logo_enabled = bool(logo_cfg.get("enabled", True))
+        logo_cfg = getattr(config, "logo", {}) or {}
+        logo_enabled = bool(logo_cfg.get("enabled", False))
 
         if logo_enabled and not meta.get("logo_created"):
-            # knobs (you can keep reading from cfg, or hard-code)
-            scene_n = int(logo_cfg.get("scene_n", 2))
-            sticker_n = int(logo_cfg.get("sticker_n", 4))
+
+            def _logo_error(label: str, e: Exception):
+                console.print(
+                    Panel.fit(
+                        f"[bold red]{label}[/] {type(e).__name__}: {e!s}",
+                        border_style="red",
+                    )
+                )
+
+            scene_style = logo_cfg.get("scene", "random")
             stickers_enabled = bool(logo_cfg.get("stickers", True))
 
-            # IMPORTANT: to get 4 DIFFERENT scene styles, use random
-            scene_style = "random"
+            default_n = int(logo_cfg.get("n", 2))
+            scene_n = int(logo_cfg.get("scene_n", default_n))
+            sticker_n = int(logo_cfg.get("sticker_n", default_n))
 
-            # Optional: aperture to open/close prompt constraints (0..1)
+            raw_logo_model = logo_cfg.get("model", "gpt-image-1-mini")
             aperture = float(logo_cfg.get("aperture", 0.75))
 
             scene_dir = Path(workspace) / "logo_art" / "scenes"
             sticker_dir = Path(workspace) / "logo_art" / "stickers"
 
-            try:
-                _ = kickoff_logo(
+            kickoff_logo(
+                problem_text=problem,
+                workspace=workspace,
+                out_dir=scene_dir,
+                model=raw_logo_model,
+                quality="high",
+                n=scene_n,
+                style=scene_style,
+                mode="scene",
+                aspect="wide",
+                style_intensity="overt",
+                aperture=aperture,
+                console=console,
+                models_cfg=models_cfg,
+                on_done=lambda p: console.print(
+                    Panel.fit(
+                        f"[bold yellow]Project art saved:[/] {p}",
+                        border_style="yellow",
+                    )
+                ),
+                on_error=lambda e: _logo_error("Art generation failed:", e),
+            )
+
+            if stickers_enabled:
+                kickoff_logo(
                     problem_text=problem,
                     workspace=workspace,
-                    out_dir=scene_dir,
+                    out_dir=sticker_dir,
+                    model=raw_logo_model,
+                    size="1024x1024",
                     quality="high",
-                    n=scene_n,  # e.g. 4
-                    style=scene_style,  # MUST be "random" for multi-style scenes
-                    mode="scene",
-                    aspect="wide",
-                    style_intensity="overt",
+                    n=sticker_n,
+                    style="sticker",
                     aperture=aperture,
                     console=console,
+                    models_cfg=models_cfg,
                     on_done=lambda p: console.print(
                         Panel.fit(
-                            f"[bold yellow]Project art saved:[/] {p}",
+                            f"[bold yellow]Project sticker art saved:[/] {p}",
                             border_style="yellow",
                         )
                     ),
-                    on_error=lambda e: console.print(
-                        Panel.fit(
-                            f"[bold red]Art generation failed:[/] {e}",
-                            border_style="red",
-                        )
+                    on_error=lambda e: _logo_error(
+                        "Art sticker generation failed:", e
                     ),
                 )
 
-                if stickers_enabled:
-                    _ = kickoff_logo(
-                        problem_text=problem,
-                        workspace=workspace,
-                        out_dir=sticker_dir,
-                        size="1024x1024",
-                        quality="high",
-                        n=sticker_n,
-                        style="sticker",
-                        aperture=aperture,
-                        console=console,
-                        on_done=lambda p: console.print(
-                            Panel.fit(
-                                f"[bold yellow]Project sticker art saved:[/] {p}",
-                                border_style="yellow",
-                            )
-                        ),
-                        on_error=lambda e: console.print(
-                            Panel.fit(
-                                f"[bold red]Art sticker generation failed:[/] {e}",
-                                border_style="red",
-                            )
-                        ),
-                    )
-            finally:
-                save_run_meta(workspace, logo_created=True)
-
-        models_cfg = getattr(config, "models", {}) or {}
+            save_run_meta(workspace, logo_created=True)
 
         # gets the agents we'll use for this example including their checkpointer handles and database
         thread_id, planner_tuple, executor_tuple = setup_agents(

--- a/examples/two_agent_examples/plan_execute/ubc_STAT545A_hw02.yaml
+++ b/examples/two_agent_examples/plan_execute/ubc_STAT545A_hw02.yaml
@@ -79,7 +79,7 @@ logo:
   scene: random     # e.g., noir, sci-fi, horror, fantasy, etc. ("random" by default)
   stickers: true    # also make sticker variants
   n: 2              # how many variants for each batch
-  model: openai:gpt-image-1 # warning: most 'vision' models do not support image *GENERATION*, this one does
+  model: openai:gpt-image-1-mini # warning: most 'vision' models do not support image *GENERATION*, this one does
 
 
 # planning_mode must either be 'single' or 'heirarchical'

--- a/src/ursa/util/logo_generator.py
+++ b/src/ursa/util/logo_generator.py
@@ -13,7 +13,10 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
 
-from ursa.util.http import build_httpx_client
+from ursa.util.plan_execute_utils import (
+    resolve_model_choice,
+    sanitize_for_logging,
+)
 
 # Reuse a small thread pool so callers can "fire-and-continue" with one line.
 _EXEC = ThreadPoolExecutor(max_workers=2, thread_name_prefix="logo-gen")
@@ -480,6 +483,42 @@ def _pick_logo_constraints(aperture: float) -> str:
     return " ".join(chosen).strip()
 
 
+def _print_image_init_banner(
+    *,
+    provider: str,
+    model_name: str,
+    provider_extra: dict,
+    console: Optional[Console] = None,
+) -> None:
+    c = console or _DEFAULT_CONSOLE
+    safe_provider_extra = sanitize_for_logging(provider_extra or {})
+    c.print(
+        Panel.fit(
+            Text.from_markup(
+                f"[bold cyan]Image init[/]\n"
+                f"[bold]provider[/]: {provider}\n"
+                f"[bold]model[/]: {model_name}\n\n"
+                f"[bold]provider kwargs[/]: {safe_provider_extra}"
+            ),
+            border_style="cyan",
+        )
+    )
+
+
+def _resolve_image_model_choice(
+    model_choice: str, models_cfg: dict | None = None
+):
+    """
+    For image generation, bare model names like 'gpt-image-1-mini'
+    should default to the OpenAI provider.
+    """
+    if ":" not in model_choice:
+        model_choice = f"openai:{model_choice}"
+    return resolve_model_choice(
+        model_choice=model_choice, models_cfg=models_cfg or {}
+    )
+
+
 # ---------------------------
 # Prompt builders
 # ---------------------------
@@ -751,7 +790,7 @@ def generate_logo_sync(
     style_intensity: str = "overt",
     aperture: float = DEFAULT_APERTURE,
     console: Optional[Console] = None,
-    image_model_provider: str = "openai",
+    models_cfg: Optional[dict] = None,
     image_provider_kwargs: Optional[dict] = None,
 ) -> Path:
     """
@@ -769,16 +808,31 @@ def generate_logo_sync(
     out_dir.mkdir(parents=True, exist_ok=True)
 
     # this is how we'll pass through a vision model and provider/url/endpoint
-    client_kwargs = {}
-    if image_provider_kwargs:
-        # Only pass through safe/known kwargs
-        for k in ("api_key", "base_url", "organization"):
-            if k in image_provider_kwargs and image_provider_kwargs[k]:
-                client_kwargs[k] = image_provider_kwargs[k]
-    client = OpenAI(
-        http_client=build_httpx_client(),
-        **client_kwargs,
+    provider, pure_model, provider_extra = _resolve_image_model_choice(
+        model_choice=model,
+        models_cfg=models_cfg or {},
     )
+
+    client_kwargs = dict(provider_extra or {})
+    if image_provider_kwargs:
+        for k in ("api_key", "base_url", "organization"):
+            if image_provider_kwargs.get(k):
+                client_kwargs[k] = image_provider_kwargs[k]
+
+    _print_image_init_banner(
+        provider=provider,
+        model_name=pure_model,
+        provider_extra=client_kwargs,
+        console=console,
+    )
+
+    if provider != "openai":
+        raise ValueError(
+            f"Logo/image generation currently only supports OpenAI image models, got provider={provider!r}"
+        )
+
+    client = OpenAI(**client_kwargs)
+    model = pure_model
 
     final_size = _normalize_size(size, aspect, mode)
     # Scenes tend to look odd with transparent backgrounds; force opaque.
@@ -938,7 +992,7 @@ def kickoff_logo(
     out_dir: str | Path,
     filename: str | None = None,
     model: str = DEFAULT_IMAGE_MODEL,
-    size: str | None = None,  # allow None → computed from aspect/mode
+    size: str | None = None,
     background: str = "opaque",
     quality: str = "high",
     n: int = 4,
@@ -954,7 +1008,7 @@ def kickoff_logo(
     aperture: float = DEFAULT_APERTURE,
     console: Optional[Console] = None,
     image_model: Optional[str] = None,
-    image_model_provider: str = "openai",
+    models_cfg: Optional[dict] = None,
     image_provider_kwargs: Optional[dict] = None,
 ):
     _final_model = image_model or model
@@ -979,7 +1033,7 @@ def kickoff_logo(
             style_intensity=style_intensity,
             aperture=aperture,
             console=console,
-            image_model_provider=image_model_provider,
+            models_cfg=models_cfg,
             image_provider_kwargs=image_provider_kwargs,
         )
 


### PR DESCRIPTION
I had left some bugs in the image gen stuff, that's fixed now.  This also swaps to default logo generation off (always what i intended, oops) and also sets the default image model in the examples to 1-mini, so lower cost to someone trying them out if they're a user playing around.