### PR TITLE
Hotfix: Small fix to a batch size issue when ingesting docs into a RAG database.

### DIFF
--- a/src/ursa/agents/rag_agent.py
+++ b/src/ursa/agents/rag_agent.py
@@ -27,7 +27,7 @@ from ursa.util.parse import (
 #     that would be unlikely to give meaningful
 #     information to perform RAG on.
 MIN_CHARS = 30
-MAX_BATCH_SIZE = 3000
+MAX_BATCH_SIZE = 200
 
 
 class RAGMetadata(TypedDict):

--- a/src/ursa/agents/rag_agent.py
+++ b/src/ursa/agents/rag_agent.py
@@ -27,6 +27,7 @@ from ursa.util.parse import (
 #     that would be unlikely to give meaningful
 #     information to perform RAG on.
 MIN_CHARS = 30
+MAX_BATCH_SIZE = 3000
 
 
 class RAGMetadata(TypedDict):
@@ -223,9 +224,16 @@ class RAGAgent(BaseAgent[RAGState]):
         if state["doc_texts"]:
             print("[RAG Agent] Ingesting Documents Into RAG Database....")
             with self._vs_lock:
-                self.vectorstore.add_documents(batch_docs, ids=batch_ids)
-                for id in batch_ids:
-                    self._mark_paper_ingested(id)
+                for i in range(0, len(batch_docs), MAX_BATCH_SIZE):
+                    chunk_docs = batch_docs[i : i + MAX_BATCH_SIZE]
+                    chunk_ids = batch_ids[i : i + MAX_BATCH_SIZE]
+
+                    # Ingest the specific chunk
+                    self.vectorstore.add_documents(chunk_docs, ids=chunk_ids)
+
+                    # Mark these specific papers as ingested
+                    for id in chunk_ids:
+                        self._mark_paper_ingested(id)
 
         return state
 


### PR DESCRIPTION
Will merge when it is confirmed to work fully. but this should fix an issue with large document ingests by the RAG agent where it throws an error trying to ingest too much at one. Just like me :) 

It breaks the list of docs into smaller batches to avoid tripping a batch size issue. Currently if the batch size is over 3000, it splits it up into smaller batches of size at most 3000. 