### PR TITLE
optional-dependencies need to be specified in uv pip compile

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,10 @@ jobs:
         run: uv build .
 
       - name: Generate requirements.txt
-        run: uv pip compile pyproject.toml -q --no-annotate --universal --group dev -o requirements.txt
+        run: |
+          uv pip compile pyproject.toml -q --no-annotate --universal --group dev -o requirements.txt \
+            --extra image \
+            --extra dashboard
 
       - name: Login to ghcr
         uses: docker/login-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH=/root/.local/bin:$PATH
 COPY dist/*.whl /wheelhouse/
 COPY requirements.txt /app
 RUN uv pip install --system --break-system-packages -r /app/requirements.txt
-RUN uv pip install --system --break-system-packages "$(ls /wheelhouse/*.whl)[dashboard,image]"
+RUN uv pip install --system --break-system-packages "$(ls /wheelhouse/*.whl)"
 # RUN uv pip install --system --break-system-packages --no-deps `ls /wheelhouse/*.whl`
 RUN ursa --version
 


### PR DESCRIPTION

without this, I see the following on Docker build:

```shell
warning: The package `ursa-ai @ file:///wheelhouse/ursa_ai-0.15.7.[...].whl` does not have 
an extra named `image`
warning: The package `ursa-ai @ file:///wheelhouse/ursa_ai-0.15.7.[...].whl` does not have 
an extra named `dashboard`
```

see #229