### PR TITLE
Two hotfixes

### DIFF
--- a/examples/two_agent_examples/plan_execute/plan_execute_from_yaml.py
+++ b/examples/two_agent_examples/plan_execute/plan_execute_from_yaml.py
@@ -774,11 +774,20 @@ def run_substeps(
             )
 
             # Check if the graph has a the symlinkdir information already.
-            #     if not, set from the yaml. If so, it will inherit from the 
+            #     if not, set from the yaml. If so, it will inherit from the
             #     checkpoint.
-            config = {"configurable": {"thread_id": executor.thread_id, "recursion_limit": 999_999}}
-            if executor.compiled_graph.get_state(config).values.get("symlinkdir", None):
-                agent_input = {"messages": [HumanMessage(content=sub_exec_prompt)]}
+            config = {
+                "configurable": {
+                    "thread_id": executor.thread_id,
+                    "recursion_limit": 999_999,
+                }
+            }
+            if executor.compiled_graph.get_state(config).values.get(
+                "symlinkdir", None
+            ):
+                agent_input = {
+                    "messages": [HumanMessage(content=sub_exec_prompt)]
+                }
             else:
                 agent_input = {
                     "messages": [HumanMessage(content=sub_exec_prompt)],

--- a/examples/two_agent_examples/plan_execute/plan_execute_from_yaml.py
+++ b/examples/two_agent_examples/plan_execute/plan_execute_from_yaml.py
@@ -773,17 +773,20 @@ def run_substeps(
                 "Execute this sub-step and report the results fully—no placeholders."
             )
 
-            sub_result = executor.invoke(
-                {
+            # Check if the graph has a the symlinkdir information already.
+            #     if not, set from the yaml. If so, it will inherit from the 
+            #     checkpoint.
+            config = {"configurable": {"thread_id": executor.thread_id, "recursion_limit": 999_999}}
+            if executor.compiled_graph.get_state(config).values.get("symlinkdir", None):
+                agent_input = {"messages": [HumanMessage(content=sub_exec_prompt)]}
+            else:
+                agent_input = {
                     "messages": [HumanMessage(content=sub_exec_prompt)],
                     "workspace": executor.workspace,
                     "symlinkdir": symlinkdict,
-                },
-                config={
-                    "recursion_limit": 999_999,
-                    "configurable": {"thread_id": executor.thread_id},
-                },
-            )
+                }
+
+            sub_result = executor.invoke(agent_input, config=config)
 
             last_sub_summary = sub_result["messages"][-1].text
             last_ran_summary = last_sub_summary  # <—

--- a/src/ursa/cli/hitl.py
+++ b/src/ursa/cli/hitl.py
@@ -69,15 +69,18 @@ class AgentHITL:
         return self._agent.__doc__
 
     async def __call__(
-        self, prompt: str, last_agent_result: str | None = None
+        self, 
+        prompt: str, 
+        last_agent_result: str | None = None,
+        last_agent: Any | None = None
     ) -> str:
         assert self._agent is not None, "Agent not yet instantiated"
         agent = self._agent
 
         # Inject the previous agent's response into the query
-        if last_agent_result is not None:
+        if (last_agent_result is not None) and (last_agent != agent):
             prompt = "\n".join([
-                f"The last agent output was: {last_agent_result}",
+                f"The last agent output was: {last_agent_result}\n\n",
                 f"The user stated: {prompt}",
             ])
 
@@ -180,6 +183,7 @@ class HITL:
             )
 
         self.last_agent_result = None
+        self.last_agent        = None
 
     async def _get_checkpointer(
         self, name: str = "checkpoint"
@@ -209,9 +213,14 @@ class HITL:
     async def run_agent(self, name: str, prompt: str) -> str:
         assert name in self.agents, f"Unknown agent {name}"
         agent = await self.get_agent(name)
-        msg = await agent(prompt, last_agent_result=self.last_agent_result)
+        msg = await agent(
+            prompt, 
+            last_agent_result=self.last_agent_result, 
+            last_agent=self.last_agent
+        )
         assert isinstance(msg, str)
         self.last_agent_result = msg
+        self.last_agent = agent._agent
         return msg
 
     def as_mcp_server(self, **kwargs):

--- a/src/ursa/cli/hitl.py
+++ b/src/ursa/cli/hitl.py
@@ -69,10 +69,10 @@ class AgentHITL:
         return self._agent.__doc__
 
     async def __call__(
-        self, 
-        prompt: str, 
+        self,
+        prompt: str,
         last_agent_result: str | None = None,
-        last_agent: Any | None = None
+        last_agent: Any | None = None,
     ) -> str:
         assert self._agent is not None, "Agent not yet instantiated"
         agent = self._agent
@@ -183,7 +183,7 @@ class HITL:
             )
 
         self.last_agent_result = None
-        self.last_agent        = None
+        self.last_agent = None
 
     async def _get_checkpointer(
         self, name: str = "checkpoint"
@@ -214,9 +214,9 @@ class HITL:
         assert name in self.agents, f"Unknown agent {name}"
         agent = await self.get_agent(name)
         msg = await agent(
-            prompt, 
-            last_agent_result=self.last_agent_result, 
-            last_agent=self.last_agent
+            prompt,
+            last_agent_result=self.last_agent_result,
+            last_agent=self.last_agent,
         )
         assert isinstance(msg, str)
         self.last_agent_result = msg


### PR DESCRIPTION
- Check for symlinkdir in an executor state for the pla…n_execute_from_yaml workflow. This avoids a minor bug where the executor tries to symlink at every step of the workflow. 

- Fix the piping of the last agent output to the next query through the CLI if the agent is the same as the last step. Basically, there is no reason the agents output should be fed back to itself because it still has it in its history. Its just a big waste of tokens and might muddy the context by repeating.