### PR TITLE
fix: exit command for hitl

### DIFF
--- a/src/ursa/cli/hitl.py
+++ b/src/ursa/cli/hitl.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import os
-import platform
 import threading
 from cmd import Cmd
 from dataclasses import dataclass, field
@@ -267,7 +266,6 @@ class AsyncLoopThread:
 
 class UrsaRepl(Cmd):
     exit_message: str = "[dim]Exiting ursa..."
-    _help_message: str = "[dim]For help, type: ? or help. Exit with Ctrl+d."
     prompt: str = "ursa> "
 
     def __init__(self, hitl: HITL, **kwargs):
@@ -331,6 +329,22 @@ class UrsaRepl(Cmd):
 
         return super().__getattribute__(name)
 
+    @staticmethod
+    def help_message():
+        if os.name == "nt":
+            exit_shortcut = "Crtl+Z"
+        elif os.name == "posix":
+            exit_shortcut = "Crtl+D"
+        else:
+            exit_shortcut = None
+
+        msg = "[dim]For help, type: ? or help."
+        if exit_shortcut is None:
+            msg += " Exit by typing 'exit'."
+        else:
+            msg += f" Exit with {exit_shortcut} or by typing exit."
+        return msg
+
     def get_names(self) -> list[str]:
         names = super().get_names()
         for name in self.hitl.agents.keys():
@@ -369,7 +383,7 @@ class UrsaRepl(Cmd):
 
     def do_clear(self, _: str):
         """Clear the screen. Same as pressing Ctrl+L."""
-        os.system("cls" if platform.system() == "Windows" else "clear")
+        os.system("cls" if os.name == "nt" else "clear")
 
     def emptyline(self):
         """Do nothing when an empty line is entered"""
@@ -382,7 +396,7 @@ class UrsaRepl(Cmd):
         self.show(self.llm_model_panel, markdown=False, highlight=False)
         if self.emb_model_panel:
             self.show(self.emb_model_panel, markdown=False, highlight=False)
-        self.show(self._help_message, markdown=False)
+        self.show(self.help_message(), markdown=False)
 
         while True:
             try:


### PR DESCRIPTION
Customize the URSA cli help message per OS, as windows uses a different key-combo for exiting a CLI
