### PR TITLE
fix: more robust planner/execution agents

### DIFF
--- a/src/ursa/agents/execution_agent.py
+++ b/src/ursa/agents/execution_agent.py
@@ -171,7 +171,8 @@ class ExecutionAgent(AgentWithTools, BaseAgent[ExecutionState]):
             edit_code, read_file, run_web_search, run_osti_search, run_arxiv_search),
             keyed by tool name for quick lookups.
         tool_node (ToolNode): Graph node that dispatches tool calls.
-        llm (BaseChatModel): LLM instance bound to the available tools.
+        llm (BaseChatModel): Base LLM instance used for summaries and recap.
+        tool_llm (BaseChatModel): Tool-bound LLM used for the execution loop.
 
     Methods:
         query_executor(state): Send messages to the executor LLM, ensure
@@ -222,6 +223,7 @@ class ExecutionAgent(AgentWithTools, BaseAgent[ExecutionState]):
         self.log_state = log_state
         self.tokens_before_summarize = tokens_before_summarize
         self.messages_to_keep = messages_to_keep
+        self.tool_llm = llm
 
     def _patch_dangling(
         self, state: ExecutionState, summarized: bool
@@ -426,7 +428,7 @@ class ExecutionAgent(AgentWithTools, BaseAgent[ExecutionState]):
 
         # 4) Invoke the LLM with the prepared message sequence.
         try:
-            response = self.llm.invoke(
+            response = self.tool_llm.invoke(
                 messages, self.build_config(tags=["agent"])
             )
             new_state["messages"].append(response)
@@ -534,9 +536,10 @@ class ExecutionAgent(AgentWithTools, BaseAgent[ExecutionState]):
     def _build_graph(self):
         """Construct and compile the agent's LangGraph state machine."""
 
-        # Bind tools to llm and context summarizer
-
-        self.llm = self.llm.bind_tools(self.tools.values())
+        # Keep self.llm unbound for summary/recap calls. The executor loop uses a
+        # separate tool-bound model so provider-specific tool transcripts cannot
+        # leak into summarization history.
+        self.tool_llm = self.llm.bind_tools(self.tools.values())
 
         # Register nodes:
         # - "agent": LLM planning/execution step

--- a/src/ursa/agents/planning_agent.py
+++ b/src/ursa/agents/planning_agent.py
@@ -136,6 +136,10 @@ class PlanningAgent(BaseAgent[PlanningState]):
                 self.build_config(tags=["planner", "reflect"]),
             )
         )
+        if not res.strip():
+            # Some providers can return an empty reflection message; treat that as
+            # "no objections" so we do not regenerate from an empty human turn.
+            res = "[APPROVED]"
         return {
             "plan": state["plan"],
             "messages": [HumanMessage(content=res)],

--- a/tests/agents/test_execution_agent/test_execution_agent.py
+++ b/tests/agents/test_execution_agent/test_execution_agent.py
@@ -1,11 +1,12 @@
+from collections.abc import Iterator
 from math import sqrt
 from pathlib import Path
-from typing import Iterator
+from types import SimpleNamespace
 
 import pytest
 from langchain.tools import ToolRuntime, tool
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
 from ursa.agents import ExecutionAgent
 
@@ -68,9 +69,35 @@ class ToolReadyFakeChatModel(GenericFakeChatModel):
         return self
 
 
+class SplitBehaviorFakeChatModel(GenericFakeChatModel):
+    """Emit plain responses; bind_tools() returns a separate tool-calling fake model."""
+
+    def bind_tools(self, tools, **kwargs):
+        return ToolCallingFakeChatModel(messages=_tool_call_message_stream())
+
+
+class ToolCallingFakeChatModel(GenericFakeChatModel):
+    pass
+
+
 def _message_stream(content: str) -> Iterator[AIMessage]:
     while True:
         yield AIMessage(content=content)
+
+
+def _tool_call_message_stream() -> Iterator[AIMessage]:
+    while True:
+        yield AIMessage(
+            content="tool-bound-response",
+            tool_calls=[
+                {
+                    "name": "fake_run_command",
+                    "args": {"query": "pwd"},
+                    "id": "call-1",
+                    "type": "tool_call",
+                }
+            ],
+        )
 
 
 @pytest.fixture
@@ -149,6 +176,48 @@ async def test_execution_agent_invokes_extra_tool(chat_model, tmpdir: Path):
         isinstance(execution_agent.workspace, Path)
         and execution_agent.workspace.exists()
     )
+
+
+def test_execution_agent_keeps_tool_calls_out_of_summary_and_recap(
+    tmpdir: Path,
+):
+    execution_agent = ExecutionAgent(
+        llm=SplitBehaviorFakeChatModel(
+            messages=_message_stream("base-response")
+        ),
+        workspace=tmpdir,
+        tokens_before_summarize=1,
+        messages_to_keep=1,
+    )
+    _ = execution_agent.compiled_graph
+
+    summarized_state, summarized = execution_agent._summarize_context({
+        "messages": [
+            SystemMessage(content="system"),
+            HumanMessage(content="x" * 200),
+            HumanMessage(content="keep me"),
+        ],
+        "symlinkdir": {},
+    })
+    assert summarized is True
+    assert not summarized_state["messages"][1].tool_calls
+
+    execution_agent.tokens_before_summarize = 99999
+    recap_result = execution_agent.recap({
+        "messages": [
+            SystemMessage(content="system"),
+            HumanMessage(content="hi"),
+        ],
+        "symlinkdir": {},
+    })
+    assert not recap_result["messages"][1].tool_calls
+
+    query_result = execution_agent.query_executor(
+        {"messages": [HumanMessage(content="hi")], "symlinkdir": {}},
+        runtime=SimpleNamespace(context=execution_agent.context),
+    )
+    assert query_result["messages"].tool_calls
+    assert query_result["messages"].tool_calls[0]["name"] == "fake_run_command"
 
 
 def test_safe_codes_in_store(chat_model, tmpdir):

--- a/tests/agents/test_planning_agent/test_planning_agent.py
+++ b/tests/agents/test_planning_agent/test_planning_agent.py
@@ -1,4 +1,8 @@
-from langchain_core.messages import HumanMessage
+from collections.abc import Iterator
+
+import pytest
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, HumanMessage
 
 from ursa.agents.planning_agent import Plan, PlanningAgent
 
@@ -47,3 +51,60 @@ async def test_planning_agent_creates_structured_plan(tmpdir):
     assert "messages" in result
     assert result["messages"], "agent should return at least one message"
     assert getattr(result["messages"][-1], "content", None)
+
+
+def _message_stream(content: str) -> Iterator[AIMessage]:
+    while True:
+        yield AIMessage(content=content)
+
+
+class EmptyReflectionFakeChatModel(GenericFakeChatModel):
+    def __init__(self, plan: Plan):
+        super().__init__(messages=_message_stream(""))
+        object.__setattr__(self, "plan", plan)
+        object.__setattr__(self, "structured_invocations", 0)
+
+    def with_structured_output(self, schema):
+        model = self
+
+        class StructuredOutput:
+            def invoke(self, messages):
+                object.__setattr__(
+                    model,
+                    "structured_invocations",
+                    model.structured_invocations + 1,
+                )
+                if model.structured_invocations > 1:
+                    raise AssertionError(
+                        "empty reflection should terminate planning without regenerating"
+                    )
+                return model.plan
+
+        return StructuredOutput()
+
+
+@pytest.mark.asyncio
+async def test_planning_agent_treats_empty_reflection_as_approval(tmpdir):
+    plan = Plan.model_validate({
+        "steps": [
+            {
+                "name": "Single step",
+                "description": "Do one thing",
+                "requires_code": False,
+                "expected_outputs": ["done"],
+                "success_criteria": ["it is done"],
+            }
+        ]
+    })
+    planning_agent = PlanningAgent(
+        llm=EmptyReflectionFakeChatModel(plan),
+        workspace=tmpdir,
+        max_reflection_steps=1,
+    )
+
+    result = await planning_agent.ainvoke({
+        "messages": [HumanMessage(content="make a plan")]
+    })
+
+    assert result["plan"] == plan
+    assert result["messages"][-1].content == "[APPROVED]"


### PR DESCRIPTION
Execution Agent:
- Summarization step can trigger tool calls which don't get resolved
  resulting in agent failure
- keep a tool free llm around to avoid this edge case

Planner:
LLMs can occasionally return an empty recap message, this would trigger
an error for the claude LLM during the next generation_node call as the
first message would be empty (invalid for claude).

This fixes that by treating an empty review as an approval
