### PR TITLE
Quick fix because a previous PR broke the execution agent summary on …

### DIFF
--- a/src/ursa/agents/execution_agent.py
+++ b/src/ursa/agents/execution_agent.py
@@ -483,10 +483,17 @@ class ExecutionAgent(AgentWithTools, BaseAgent[ExecutionState]):
                 config=self.build_config(tags=["recap"]),
             )
             response_content = response.text
-        except Exception as e:
-            response_content = f"Response error {e}"
-            response = AIMessage(content=response_content)
-            print("Error: ", e, " ", new_state["messages"][-1].text)
+        except Exception:
+            try:
+                response = self.tool_llm.invoke(
+                    input=new_state["messages"],
+                    config=self.build_config(tags=["recap"]),
+                )
+                response_content = response.text
+            except Exception as e:
+                response_content = f"Response error {e}"
+                response = AIMessage(content=response_content)
+                print("Error: ", e, " ", new_state["messages"][-1].text)
 
         console.print(
             Panel(


### PR DESCRIPTION
…the bedrock endpoint for unclear reasons. This fixes it by handling it the old way if the new way fails.