### PR TITLE
Hotfix hide hidden

### DIFF
--- a/src/ursa_dashboard/artifacts.py
+++ b/src/ursa_dashboard/artifacts.py
@@ -62,6 +62,10 @@ def scan_artifacts(
     (not necessarily an `artifacts/` subdir), so this scan can include the whole
     run directory.
 
+    Hidden files and directories are omitted from the artifact list so workspace
+    internals such as `.git`, `.venv`, and dotfiles do not appear in the
+    dashboard Files tab.
+
     `exclude_dirs` should contain directory names (not paths) to skip.
     """
     if not base_dir.exists():
@@ -71,10 +75,15 @@ def scan_artifacts(
 
     entries: list[ArtifactEntry] = []
     for root, dirs, files in os.walk(base_dir):
-        # prune excluded dirs
-        dirs[:] = [d for d in dirs if d not in exclude_dirs]
+        # Prune excluded and hidden dirs in-place so os.walk never descends
+        # into entries such as .git or .venv.
+        dirs[:] = [
+            d for d in dirs if d not in exclude_dirs and not d.startswith(".")
+        ]
 
         for fn in files:
+            if fn.startswith("."):
+                continue
             p = Path(root) / fn
             if not p.is_file():
                 continue

--- a/tests/util/test_dashboard_artifacts.py
+++ b/tests/util/test_dashboard_artifacts.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from ursa_dashboard.artifacts import scan_artifacts
+
+
+def _touch(path: Path, text: str = "x") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def test_scan_artifacts_hides_dotfiles_and_hidden_directories(
+    tmp_path: Path,
+) -> None:
+    _touch(tmp_path / "visible.txt")
+    _touch(tmp_path / ".hidden.txt")
+    _touch(tmp_path / ".git" / "config")
+    _touch(tmp_path / ".venv" / "pyvenv.cfg")
+    _touch(tmp_path / "outputs" / "result.txt")
+    _touch(tmp_path / "outputs" / ".secret")
+    _touch(tmp_path / "outputs" / ".cache" / "data.json")
+
+    rel_paths = {entry["rel_path"] for entry in scan_artifacts(tmp_path)}
+
+    assert rel_paths == {"outputs/result.txt", "visible.txt"}


### PR DESCRIPTION
Hide files or folders starting with "." from the artifacts menu of the dashboard.

Avoids the problem where pointing at a workspace with a git repo or .venv dumps a ton of stuff into the artifacts pane that we really do not want or need to see.