### PR TITLE
Debugging Earls problem

### DIFF
--- a/src/ursa/agents/base.py
+++ b/src/ursa/agents/base.py
@@ -942,6 +942,7 @@ class AgentWithTools:
         self.tool_node = ToolNode([])
         self._apply_tools(tools, rebuild_graph=False)
         super().__init__(*args, **kwargs)
+        self.tool_llm = self.llm.model_copy()
 
     def __post_init__(self):
         super().__post_init__()

--- a/src/ursa/agents/execution_agent.py
+++ b/src/ursa/agents/execution_agent.py
@@ -214,7 +214,6 @@ class ExecutionAgent(AgentWithTools, BaseAgent[ExecutionState]):
         if extra_tools:
             default_tools.extend(extra_tools)
 
-        self.tool_llm = llm.copy()
         super().__init__(llm=llm, tools=default_tools, **kwargs)
         self.agent_memory = agent_memory
         self.safe_codes = set(safe_codes or ["python", "julia"])

--- a/src/ursa/agents/execution_agent.py
+++ b/src/ursa/agents/execution_agent.py
@@ -223,7 +223,7 @@ class ExecutionAgent(AgentWithTools, BaseAgent[ExecutionState]):
         self.log_state = log_state
         self.tokens_before_summarize = tokens_before_summarize
         self.messages_to_keep = messages_to_keep
-        self.tool_llm = llm
+        self.tool_llm = llm.copy()
 
     def _patch_dangling(
         self, state: ExecutionState, summarized: bool

--- a/src/ursa/agents/execution_agent.py
+++ b/src/ursa/agents/execution_agent.py
@@ -214,6 +214,7 @@ class ExecutionAgent(AgentWithTools, BaseAgent[ExecutionState]):
         if extra_tools:
             default_tools.extend(extra_tools)
 
+        self.tool_llm = llm.copy()
         super().__init__(llm=llm, tools=default_tools, **kwargs)
         self.agent_memory = agent_memory
         self.safe_codes = set(safe_codes or ["python", "julia"])
@@ -223,7 +224,6 @@ class ExecutionAgent(AgentWithTools, BaseAgent[ExecutionState]):
         self.log_state = log_state
         self.tokens_before_summarize = tokens_before_summarize
         self.messages_to_keep = messages_to_keep
-        self.tool_llm = llm.copy()
 
     def _patch_dangling(
         self, state: ExecutionState, summarized: bool

--- a/src/ursa/agents/execution_agent.py
+++ b/src/ursa/agents/execution_agent.py
@@ -594,7 +594,7 @@ class ExecutionAgent(AgentWithTools, BaseAgent[ExecutionState]):
         # Keep self.llm unbound for summary/recap calls. The executor loop uses a
         # separate tool-bound model so provider-specific tool transcripts cannot
         # leak into summarization history.
-        self.tool_llm = self.llm.bind_tools(self.tools.values())
+        self.tool_llm = self.tool_llm.bind_tools(self.tools.values())
 
         # Register nodes:
         # - "agent": LLM planning/execution step

--- a/tests/agents/test_execution_agent/test_execution_agent.py
+++ b/tests/agents/test_execution_agent/test_execution_agent.py
@@ -77,7 +77,8 @@ class SplitBehaviorFakeChatModel(GenericFakeChatModel):
 
 
 class ToolCallingFakeChatModel(GenericFakeChatModel):
-    pass
+    def bind_tools(self, tools, **kwargs):
+        return self
 
 
 def _message_stream(content: str) -> Iterator[AIMessage]:
@@ -189,6 +190,7 @@ def test_execution_agent_keeps_tool_calls_out_of_summary_and_recap(
         tokens_before_summarize=1,
         messages_to_keep=1,
     )
+
     _ = execution_agent.compiled_graph
 
     summarized_state, summarized = execution_agent._summarize_context({


### PR DESCRIPTION
tool_llm was not a copy of llm, but a reference to the same object, which caused some problems on one particular model/endpoint combination. 

Making a copy instead so self.llm does not get bound with tools, per the intent of tool_llm

I have run 4 cases on that endpoint with this fix and it no longer shows the issue.