### PR TITLE
Fix FastMCP 3 server startup options

### DIFF
--- a/src/ursa/cli/__init__.py
+++ b/src/ursa/cli/__init__.py
@@ -250,9 +250,11 @@ def main(args=None):
             from ursa.cli.hitl import HITL
 
             hitl = HITL(ursa_config)
-            mcp = hitl.as_mcp_server(
-                host=cmd_config.host,
-                port=cmd_config.port,
-                log_level=cmd_config.log_level.upper(),
-            )
-            mcp.run(transport=cmd_config.transport)
+            mcp = hitl.as_mcp_server()
+            run_kwargs = {
+                "transport": cmd_config.transport,
+                "log_level": cmd_config.log_level.upper(),
+            }
+            if cmd_config.transport == "streamable-http":
+                run_kwargs.update(host=cmd_config.host, port=cmd_config.port)
+            mcp.run(**run_kwargs)

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -1,12 +1,57 @@
+from unittest.mock import MagicMock
+
 import yaml
 
-from ursa.cli import build_parser, resolve_config
+from ursa.cli import build_parser, main, resolve_config
 from ursa.cli.config import (
     ChatModelConfig,
     EmbModelConfig,
     ModelConfig,
     UrsaConfig,
 )
+
+
+def _stub_mcp_server(monkeypatch):
+    mcp = MagicMock()
+    hitl = MagicMock()
+    hitl.as_mcp_server.return_value = mcp
+    hitl_class = MagicMock(return_value=hitl)
+    monkeypatch.setattr("ursa.cli.hitl.HITL", hitl_class)
+    monkeypatch.setattr("ursa.cli.inject_truststore_into_ssl", lambda: None)
+    return hitl, mcp
+
+
+def test_mcp_server_passes_only_stdio_run_options(monkeypatch):
+    hitl, mcp = _stub_mcp_server(monkeypatch)
+
+    main(["mcp-server"])
+
+    hitl.as_mcp_server.assert_called_once_with()
+    mcp.run.assert_called_once_with(transport="stdio", log_level="INFO")
+
+
+def test_mcp_server_passes_http_options_when_running(monkeypatch):
+    hitl, mcp = _stub_mcp_server(monkeypatch)
+
+    main([
+        "mcp-server",
+        "--transport",
+        "streamable-http",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "9001",
+        "--log_level",
+        "warning",
+    ])
+
+    hitl.as_mcp_server.assert_called_once_with()
+    mcp.run.assert_called_once_with(
+        transport="streamable-http",
+        log_level="WARNING",
+        host="127.0.0.1",
+        port=9001,
+    )
 
 
 def test_cli_parses_typed_flags(tmp_path):


### PR DESCRIPTION
## Summary

- construct the FastMCP server without transport runtime options that FastMCP 3 removed from its constructor
- pass log level to the runner and pass host/port only for streamable HTTP
- add regression coverage for both stdio and streamable HTTP startup

## Problem

With FastMCP 3.1.1, `ursa mcp-server` fails during startup because `host` is no longer accepted by the FastMCP constructor.

## Testing

- focused MCP test suite: 4 passed
- Ruff 0.12.10 lint check: passed
- Ruff 0.12.10 format check: passed
- manual stdio server launch: passed