### PR TITLE
Mcp fix and api key for dashboard

### DIFF
--- a/docs/best-practices/sandboxing.md
+++ b/docs/best-practices/sandboxing.md
@@ -76,9 +76,17 @@ MCP servers can expose powerful external tools. Only connect MCP servers that yo
 ## Protect secrets
 
 - Prefer `api_key_env` rather than literal API keys in YAML files.
+- In the desktop dashboard, prefer **Secure system storage** so keys are kept
+  in the operating system credential manager instead of configuration files.
 - Do not store API keys in persistent agent names or prompts.
 - Review shared agent archives before distributing them.
 - Avoid committing project-specific config files that contain endpoint secrets.
+
+Dashboard-stored model credentials are bound to their provider or endpoint
+origin. Changing the endpoint host requires saving the key again. The dashboard
+passes a key to its worker through a one-time private pipe and removes
+credential-like variables from the worker environment so agent-launched
+commands do not inherit model API keys.
 
 ## Containerization options
 

--- a/docs/getting-started/dashboard.md
+++ b/docs/getting-started/dashboard.md
@@ -41,6 +41,33 @@ ursa-dashboard \
 
 The config file initializes the dashboard LLM endpoint settings.
 
+## Configure API credentials
+
+Open **Settings -> LLM** and choose an API-key source:
+
+- **Secure system storage** stores the key in macOS Keychain, Windows
+  Credential Manager, or the available Linux keyring service. The key field is
+  always blank when Settings opens; the dashboard reports only whether a usable
+  key is configured.
+- **Environment variable** retains the existing headless and automation
+  workflow. Enter the variable name, not its value.
+- **No API key** is appropriate for endpoints that do not require one.
+
+Embedding credentials are configured independently under
+**Settings -> Embedding/RAG**, or can explicitly reuse the saved LLM key when
+both configurations resolve to the same provider or endpoint origin. Saved keys
+are bound to the configured provider or endpoint origin. After changing the
+endpoint host, save the key again to approve its use with that host.
+
+The raw key is never written to dashboard settings, sessions, run records, or
+worker configuration files. In remote dashboard mode, credential changes must
+be served over HTTPS.
+
+!!! note "Headless Linux"
+    Secure system storage requires an available desktop keyring service.
+    Headless deployments should continue to use environment variables or a
+    deployment-managed secret provider.
+
 ## Where next?
 
 - [Configuration](../configuration/index.md)

--- a/docs/persistence_updates/06_web_dashboard_workflow.md
+++ b/docs/persistence_updates/06_web_dashboard_workflow.md
@@ -74,6 +74,14 @@ The dashboard can pass the dashboard web-access default into agents that opt int
 
 Tool availability still depends on the selected behavior and configuration.
 
+## API credentials
+
+Dashboard model and embedding keys can be saved through Settings using the
+operating system credential store. Dashboard persistence contains only an
+opaque credential reference and endpoint binding; raw keys are not included in
+session or run history. Environment-variable credentials remain available for
+headless deployments and automation.
+
 ## Practical workflow
 
 1. Create a group if needed:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ Issues = "https://github.com/lanl/ursa/issues"
 [project.optional-dependencies]
 dashboard = [
     "fastapi>=0.120.0",
+    "keyring>=25.0.0,<26.0.0",
     "uvicorn>=0.37.0",
 ]
 fm = [

--- a/src/ursa/cli/__init__.py
+++ b/src/ursa/cli/__init__.py
@@ -92,6 +92,16 @@ def build_parser() -> ArgumentParser:
 
     # Run Ursa as an MCP Server
     mcp_parser = ArgumentParser()
+    mcp_parser.add_argument(
+        "--config",
+        default=None,
+        type=Path,
+        help=(
+            "Path to a YAML/JSON file with additional configuration "
+            "(LLM model, endpoint, embedding model, MCP servers, etc.) "
+            "for the URSA instance hosted by the MCP server. CLI opts have priority."
+        ),
+    )
     mcp_parser.add_class_arguments(MCPServerConfig, help="MCP server options")
     subparsers.add_subcommand(
         "mcp-server",

--- a/src/ursa/tools/run_command_tool.py
+++ b/src/ursa/tools/run_command_tool.py
@@ -111,7 +111,7 @@ def run_command(query: str, runtime: ToolRuntime[AgentContext]) -> str:
                 query,
                 text=True,
                 shell=True,
-                timeout=60000,
+                timeout=600000,
                 capture_output=True,
                 cwd=workspace_dir,
                 check=False,

--- a/src/ursa_dashboard/api_models.py
+++ b/src/ursa_dashboard/api_models.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, SecretStr
 
 
 class RunCreateRequest(BaseModel):
@@ -22,9 +22,9 @@ class RunRecord(BaseModel):
     run_id: str
     agent_id: str
     status: str
-    created_at: Optional[str] = None
-    started_at: Optional[str] = None
-    finished_at: Optional[str] = None
+    created_at: str | None = None
+    started_at: str | None = None
+    finished_at: str | None = None
     params: dict[str, Any] = Field(default_factory=dict)
     agent_init: dict[str, Any] = Field(default_factory=dict)
     llm: dict[str, Any] = Field(default_factory=dict)
@@ -84,6 +84,19 @@ class SettingsResponse(BaseModel):
 
 class SettingsPatchRequest(BaseModel):
     patch: dict[str, Any] = Field(default_factory=dict)
+
+
+class CredentialSetRequest(BaseModel):
+    api_key: SecretStr
+
+
+class CredentialStatusResponse(BaseModel):
+    kind: Literal["llm", "embedding"]
+    source: Literal["environment", "stored", "llm", "none"]
+    configured: bool
+    usable: bool
+    needs_reentry: bool = False
+    target: str
 
 
 class ErrorResponse(BaseModel):

--- a/src/ursa_dashboard/app.py
+++ b/src/ursa_dashboard/app.py
@@ -14,7 +14,7 @@ import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, AsyncIterator
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit
 
 from fastapi import (
     Depends,
@@ -63,6 +63,8 @@ from ursa.rag.persistence import (
 from ursa.security import GroupBaseURLPolicyError, enforce_group_base_url_policy
 
 from .api_models import (
+    CredentialSetRequest,
+    CredentialStatusResponse,
     ErrorResponse,
     FileMetaResponse,
     RunCancelRequest,
@@ -85,6 +87,19 @@ from .api_models import (
     WorkspaceListResponse,
 )
 from .artifacts import scan_artifacts
+from .credentials import (
+    CredentialConfigurationError,
+    CredentialKind,
+    CredentialStore,
+    CredentialStoreError,
+    KeyringCredentialStore,
+    assert_no_credential_metadata,
+    assert_no_raw_api_key,
+    credential_id,
+    credential_status,
+    credential_target,
+    store_api_key,
+)
 from .environment_run_ui import (
     render_environment_run_detail_page,
     render_environment_runs_page,
@@ -118,10 +133,15 @@ from .sessions import (
 from .sessions import (
     update_session as session_update_session,
 )
-from .settings import AuthConfig, SettingsStore, apply_dashboard_config
+from .settings import (
+    AuthConfig,
+    SettingsStore,
+    apply_dashboard_config,
+    merge_global_settings_patch,
+)
 
 
-def create_app() -> FastAPI:
+def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
     auth = AuthConfig.from_env()
 
     security = HTTPBearer(auto_error=False)
@@ -170,7 +190,11 @@ def create_app() -> FastAPI:
         ).strip()
         or "default"
     )
-    rm = RunManager()
+    credential_store = credential_store or KeyringCredentialStore()
+    rm = RunManager(
+        credential_store=credential_store,
+        dashboard_group=dashboard_group,
+    )
     settings_store = SettingsStore(rm.dashboard_root)
     dashboard_config = str(
         os.environ.get("URSA_DASHBOARD_CONFIG", "") or ""
@@ -342,8 +366,154 @@ def create_app() -> FastAPI:
         dependencies=[Depends(require_auth)],
     )
     def patch_settings(req: SettingsPatchRequest) -> SettingsResponse:
-        s = settings_store.patch(req.patch)
+        for section in ("llm", "embedding"):
+            section_patch = req.patch.get(section)
+            if isinstance(section_patch, dict):
+                try:
+                    assert_no_raw_api_key(
+                        section_patch, context=f"settings.{section}"
+                    )
+                    assert_no_credential_metadata(
+                        section_patch, context=f"settings.{section}"
+                    )
+                except CredentialConfigurationError as e:
+                    raise HTTPException(status_code=400, detail=str(e)) from e
+
+        try:
+            s = merge_global_settings_patch(settings_store.load(), req.patch)
+            enforce_group_base_url_policy(s.llm.base_url, dashboard_group)
+            if s.embedding.model:
+                enforce_group_base_url_policy(
+                    s.embedding.base_url, dashboard_group
+                )
+        except (GroupBaseURLPolicyError, ValueError) as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+        settings_store.save(s)
         return SettingsResponse(settings=s.model_dump(mode="json"))
+
+    def _credential_config(
+        kind: CredentialKind,
+    ) -> tuple[Any, dict[str, Any]]:
+        settings = settings_store.load()
+        config = getattr(settings, kind)
+        return settings, config.model_dump(mode="json")
+
+    def _require_safe_credential_request(request: Request) -> None:
+        if auth.mode == "remote" and request.url.scheme != "https":
+            raise HTTPException(
+                status_code=400,
+                detail="Credential changes require HTTPS in remote mode.",
+            )
+        origin = str(request.headers.get("origin") or "").strip()
+        if not origin:
+            return
+        parsed = urlsplit(origin)
+        request_origin = f"{request.url.scheme}://{request.url.netloc}"
+        supplied_origin = f"{parsed.scheme}://{parsed.netloc}"
+        if supplied_origin != request_origin:
+            raise HTTPException(status_code=403, detail="Origin not allowed")
+
+    def _credential_status_response(
+        kind: CredentialKind,
+    ) -> CredentialStatusResponse:
+        _settings, config = _credential_config(kind)
+        try:
+            status = credential_status(
+                config,
+                group=dashboard_group,
+                kind=kind,
+                store=credential_store,
+            )
+        except (CredentialStoreError, CredentialConfigurationError) as e:
+            raise HTTPException(status_code=503, detail=str(e)) from e
+        return CredentialStatusResponse.model_validate(status)
+
+    @app.get(
+        "/credentials/status",
+        dependencies=[Depends(require_auth)],
+    )
+    def get_credential_statuses(response: Response) -> dict[str, Any]:
+        response.headers["Cache-Control"] = "no-store"
+        return {
+            kind: _credential_status_response(kind).model_dump(mode="json")
+            for kind in ("llm", "embedding")
+        }
+
+    @app.put(
+        "/credentials/{kind}",
+        response_model=CredentialStatusResponse,
+        dependencies=[Depends(require_auth)],
+    )
+    def set_credential(
+        kind: CredentialKind,
+        req: CredentialSetRequest,
+        request: Request,
+        response: Response,
+    ) -> CredentialStatusResponse:
+        response.headers["Cache-Control"] = "no-store"
+        _require_safe_credential_request(request)
+        value = req.api_key.get_secret_value()
+        if not value.strip():
+            raise HTTPException(status_code=400, detail="API key is empty")
+        if len(value) > 65_536:
+            raise HTTPException(status_code=400, detail="API key is too large")
+
+        settings, config = _credential_config(kind)
+        try:
+            if kind == "llm" or config.get("model"):
+                enforce_group_base_url_policy(
+                    config.get("base_url"), dashboard_group
+                )
+            secret_id = credential_id(dashboard_group, kind)
+            target = credential_target(config)
+            store_api_key(
+                credential_store,
+                credential_id=secret_id,
+                target=target,
+                value=value,
+            )
+            updated = config | {
+                "credential_source": "stored",
+                "credential_id": secret_id,
+                "credential_target": target,
+            }
+            setattr(settings, kind, type(getattr(settings, kind))(**updated))
+            settings_store.save(settings)
+        except (
+            CredentialStoreError,
+            CredentialConfigurationError,
+            GroupBaseURLPolicyError,
+            ValueError,
+        ) as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+        finally:
+            value = ""
+
+        return _credential_status_response(kind)
+
+    @app.delete(
+        "/credentials/{kind}",
+        response_model=CredentialStatusResponse,
+        dependencies=[Depends(require_auth)],
+    )
+    def delete_credential(
+        kind: CredentialKind, request: Request, response: Response
+    ) -> CredentialStatusResponse:
+        response.headers["Cache-Control"] = "no-store"
+        _require_safe_credential_request(request)
+        settings, config = _credential_config(kind)
+        try:
+            credential_store.delete_secret(credential_id(dashboard_group, kind))
+            updated = config | {
+                "credential_source": "none",
+                "credential_id": None,
+                "credential_target": None,
+            }
+            setattr(settings, kind, type(getattr(settings, kind))(**updated))
+            settings_store.save(settings)
+        except (CredentialStoreError, ValueError) as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+        return _credential_status_response(kind)
 
     @app.get(
         "/rag-tools",
@@ -470,6 +640,13 @@ def create_app() -> FastAPI:
                 status_code=400, detail="No session changes provided"
             )
         if "llm" in patch:
+            try:
+                assert_no_raw_api_key(patch["llm"] or {}, context="session.llm")
+                assert_no_credential_metadata(
+                    patch["llm"] or {}, context="session.llm"
+                )
+            except CredentialConfigurationError as e:
+                raise HTTPException(status_code=400, detail=str(e)) from e
             llm_patch = patch["llm"] or {}
             merged_llm = _deep_merge_dicts(
                 existing_session.get("llm") or {}, llm_patch
@@ -479,6 +656,12 @@ def create_app() -> FastAPI:
                 # remove keys from the JSON editor instead of keeping stale keys.
                 merged_llm["model_kwargs"] = llm_patch.get("model_kwargs") or {}
             patch["llm"] = merged_llm
+            try:
+                enforce_group_base_url_policy(
+                    merged_llm.get("base_url"), dashboard_group
+                )
+            except GroupBaseURLPolicyError as e:
+                raise HTTPException(status_code=400, detail=str(e)) from e
         if "runner" in patch:
             patch["runner"] = _deep_merge_dicts(
                 existing_session.get("runner") or {}, patch["runner"] or {}
@@ -538,6 +721,12 @@ def create_app() -> FastAPI:
         except Exception:
             raise HTTPException(status_code=404, detail="Unknown session_id")
 
+        try:
+            assert_no_raw_api_key(req.llm or {}, context="message.llm")
+            assert_no_credential_metadata(req.llm or {}, context="message.llm")
+        except CredentialConfigurationError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+
         agent_id = str(req.agent_id or sess.get("agent_id") or "")
         if agent_id not in REGISTRY:
             raise HTTPException(
@@ -573,6 +762,13 @@ def create_app() -> FastAPI:
         # Demo agents should work without external credentials.
         if agent_id.startswith("demo_") and "disabled" not in llm:
             llm["disabled"] = True
+
+        try:
+            await asyncio.to_thread(
+                rm.validate_credentials, llm=llm, embedding=embedding
+            )
+        except (CredentialConfigurationError, CredentialStoreError) as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
 
         params = dict(req.params or {})
         params.setdefault("prompt", prompt)
@@ -691,6 +887,12 @@ def create_app() -> FastAPI:
         ):
             raise HTTPException(status_code=404, detail="Unknown agent_id")
 
+        try:
+            assert_no_raw_api_key(req.llm or {}, context="run.llm")
+            assert_no_credential_metadata(req.llm or {}, context="run.llm")
+        except CredentialConfigurationError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+
         # Merge with global defaults (apply only if caller didn't provide)
         s = settings_store.load().model_dump(mode="json")
         llm = _deep_merge_dicts(s.get("llm") or {}, req.llm or {})
@@ -701,6 +903,13 @@ def create_app() -> FastAPI:
         # Demo agents should work without external credentials.
         if req.agent_id.startswith("demo_") and "disabled" not in llm:
             llm["disabled"] = True
+
+        try:
+            await asyncio.to_thread(
+                rm.validate_credentials, llm=llm, embedding=embedding
+            )
+        except (CredentialConfigurationError, CredentialStoreError) as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
 
         agent_init = _agent_init_with_dashboard_defaults(
             req.agent_id, req.agent_init
@@ -2141,6 +2350,7 @@ def create_app() -> FastAPI:
     showArtifacts: true,
 
     settings: null,
+    credentialStatuses: {},
     _settingsMode: 'global',
     _settingsSessionId: null,
     _settingsSessionTitle: '',
@@ -3648,6 +3858,9 @@ def create_app() -> FastAPI:
     const sub = $('#settingsModalSubtitle');
     const uiBtn = document.querySelector('.settingsNavBtn[data-settings-section="ui"]');
     const mcpBtn = document.querySelector('.settingsNavBtn[data-settings-section="mcp"]');
+    $$('.globalCredentialOnly').forEach(el => {
+      el.style.display = mode === 'session' ? 'none' : '';
+    });
     if (mode === 'session') {
       if (title) title.textContent = 'Session settings';
       if (sub) sub.textContent = `Applies to this session only: ${session?.title || session?.session_id || ''}`;
@@ -3863,6 +4076,72 @@ def create_app() -> FastAPI:
     document.documentElement.setAttribute('data-theme', resolved);
   }
 
+  function renderCredentialStatus(kind) {
+    const status = state.credentialStatuses?.[kind] || {};
+    const el = $(`#set_${kind}_credential_status`);
+    if (!el) return;
+    if (status.needs_reentry) {
+      el.textContent = 'Saved key is not approved for this endpoint. Enter it again to rebind.';
+      return;
+    }
+    if (status.source === 'stored') {
+      el.textContent = status.usable ? 'Key saved securely.' : 'No usable saved key.';
+      return;
+    }
+    if (status.source === 'environment') {
+      el.textContent = status.configured ? 'Environment variable is available.' : 'Environment variable is not currently available.';
+      return;
+    }
+    if (status.source === 'llm') {
+      el.textContent = status.usable ? 'Using the saved LLM key.' : 'Saved LLM key is unavailable or bound to a different endpoint.';
+      return;
+    }
+    el.textContent = 'No API key will be used.';
+  }
+
+  function updateCredentialControls(kind) {
+    const source = $(`#set_${kind}_credential_source`)?.value || 'none';
+    const stored = $(`#set_${kind}_stored_fields`);
+    const env = $(`#set_${kind}_env_fields`);
+    if (stored) stored.style.display = source === 'stored' ? '' : 'none';
+    if (env) env.style.display = source === 'environment' ? '' : 'none';
+    renderCredentialStatus(kind);
+  }
+
+  async function refreshCredentialStatuses() {
+    try {
+      state.credentialStatuses = await api('GET', '/credentials/status');
+    } catch (e) {
+      state.credentialStatuses = {};
+      for (const kind of ['llm', 'embedding']) {
+        const el = $(`#set_${kind}_credential_status`);
+        if (el) el.textContent = 'Credential store unavailable: ' + e.message;
+      }
+      return;
+    }
+    renderCredentialStatus('llm');
+    renderCredentialStatus('embedding');
+  }
+
+  async function removeStoredCredential(kind) {
+    if (!confirm(`Remove the saved ${kind === 'llm' ? 'LLM' : 'embedding'} API key?`)) return;
+    try {
+      state.credentialStatuses[kind] = await api('DELETE', `/credentials/${kind}`);
+      const source = $(`#set_${kind}_credential_source`);
+      if (source) source.value = 'none';
+      const keyInput = $(`#set_${kind}_api_key`);
+      if (keyInput) keyInput.value = '';
+      updateCredentialControls(kind);
+      const res = await api('GET', '/settings');
+      state.settings = res.settings || state.settings;
+      await refreshCredentialStatuses();
+      updateCredentialControls('llm');
+      updateCredentialControls('embedding');
+    } catch (e) {
+      alert('Could not remove key: ' + e.message);
+    }
+  }
+
   async function loadSettings(opts={}) {
     const mode = opts.mode || state._settingsMode || 'global';
     const session = opts.session || null;
@@ -3888,16 +4167,23 @@ def create_app() -> FastAPI:
     $('#set_base_url').value = llm.base_url || '';
     $('#set_model').value = llm.model || '';
     $('#set_api_key_env').value = llm.api_key_env || '';
+    $('#set_llm_credential_source').value = llm.credential_source || (llm.api_key_env ? 'environment' : 'none');
+    $('#set_llm_api_key').value = '';
     const modelKwargs = llm.model_kwargs || {};
     $('#set_model_kwargs').value = Object.keys(modelKwargs).length ? JSON.stringify(modelKwargs, null, 2) : '';
 
     $('#set_embedding_base_url').value = embedding.base_url || '';
     $('#set_embedding_model').value = embedding.model || '';
     $('#set_embedding_api_key_env').value = embedding.api_key_env || '';
+    $('#set_embedding_credential_source').value = embedding.credential_source || (embedding.api_key_env ? 'environment' : 'none');
+    $('#set_embedding_api_key').value = '';
     const embeddingModelKwargs = embedding.model_kwargs || {};
     $('#set_embedding_model_kwargs').value = Object.keys(embeddingModelKwargs).length ? JSON.stringify(embeddingModelKwargs, null, 2) : '';
 
     $('#set_timeout').value = runner.timeout_seconds ?? '';
+    updateCredentialControls('llm');
+    updateCredentialControls('embedding');
+    if (mode === 'global') await refreshCredentialStatuses();
 
     // MCP is global-only.
     state._mcpServers = _cloneJson(mcp.servers || {});
@@ -3999,12 +4285,41 @@ def create_app() -> FastAPI:
       return;
     }
 
+    let llmKey = '';
+    let embeddingKey = '';
+    if (state._settingsMode === 'global') {
+      llmKey = $('#set_llm_api_key').value || '';
+      embeddingKey = $('#set_embedding_api_key').value || '';
+      const llmSource = $('#set_llm_credential_source').value || 'none';
+      const embeddingSource = $('#set_embedding_credential_source').value || 'none';
+      const embeddingConfigured = Boolean(($('#set_embedding_model').value || '').trim());
+      if (llmSource === 'stored' && !llmKey && !state.credentialStatuses?.llm?.configured) {
+        alert('Enter an LLM API key before selecting secure storage.');
+        return;
+      }
+      if (embeddingConfigured && embeddingSource === 'stored' && !embeddingKey && !state.credentialStatuses?.embedding?.configured) {
+        alert('Enter an embedding API key before selecting secure storage.');
+        return;
+      }
+      if (embeddingConfigured && embeddingSource === 'llm' && !state.credentialStatuses?.llm?.configured) {
+        alert('Save an LLM API key before reusing it for embeddings.');
+        return;
+      }
+    }
+
+    const llmPatch = {
+      base_url: ($('#set_base_url').value || '').trim() || null,
+      model: ($('#set_model').value || '').trim() || null,
+      api_key_env: ($('#set_api_key_env').value || '').trim() || null,
+      model_kwargs: modelKwargs,
+    };
+    if (state._settingsMode === 'global') {
+      llmPatch.credential_source = llmKey ? 'none' : ($('#set_llm_credential_source').value || 'none');
+    }
+
     const common = {
       llm: {
-        base_url: ($('#set_base_url').value || '').trim() || null,
-        model: ($('#set_model').value || '').trim() || null,
-        api_key_env: ($('#set_api_key_env').value || '').trim() || null,
-        model_kwargs: modelKwargs,
+        ...llmPatch,
       },
       runner: {
         timeout_seconds: ($('#set_timeout').value === '' ? null : Number($('#set_timeout').value)),
@@ -4021,6 +4336,7 @@ def create_app() -> FastAPI:
         base_url: ($('#set_embedding_base_url').value || '').trim() || null,
         model: ($('#set_embedding_model').value || '').trim() || null,
         api_key_env: ($('#set_embedding_api_key_env').value || '').trim() || null,
+        credential_source: embeddingKey ? 'none' : ($('#set_embedding_credential_source').value || 'none'),
         model_kwargs: embeddingModelKwargs,
       },
       mcp: {
@@ -4062,8 +4378,29 @@ def create_app() -> FastAPI:
     } else {
       const res = await api('PATCH', '/settings', { patch: cleaned });
       state.settings = res.settings || {};
+      let credentialSaveError = null;
+      try {
+        if (llmKey) {
+          state.credentialStatuses.llm = await api('PUT', '/credentials/llm', { api_key: llmKey });
+        }
+        if (embeddingKey) {
+          state.credentialStatuses.embedding = await api('PUT', '/credentials/embedding', { api_key: embeddingKey });
+        }
+      } catch (e) {
+        credentialSaveError = e;
+        alert('Settings were saved, but the API key could not be stored: ' + e.message);
+      } finally {
+        llmKey = '';
+        embeddingKey = '';
+        $('#set_llm_api_key').value = '';
+        $('#set_embedding_api_key').value = '';
+      }
+      await refreshCredentialStatuses();
+      const refreshed = await api('GET', '/settings');
+      state.settings = refreshed.settings || state.settings;
       applyTheme(state.settings?.ui?.theme || 'system');
       await refreshSessions();
+      if (credentialSaveError) return;
     }
 
     const saved = $('#settingsSaved');
@@ -4220,6 +4557,10 @@ def create_app() -> FastAPI:
     if (mClr) mClr.onclick = clearMcpEditor;
     const ragRefresh = $('#ragRefreshBtn');
     if (ragRefresh) ragRefresh.onclick = refreshRagTools;
+    $('#set_llm_credential_source').onchange = () => updateCredentialControls('llm');
+    $('#set_embedding_credential_source').onchange = () => updateCredentialControls('embedding');
+    $('#set_llm_remove_key').onclick = () => removeStoredCredential('llm');
+    $('#set_embedding_remove_key').onclick = () => removeStoredCredential('embedding');
 
     $('#saveSettingsBtn').onclick = saveSettings;
 
@@ -5127,8 +5468,15 @@ textarea.input { width: 100%; box-sizing: border-box; resize: vertical; }
             <div class="sectionHead">LLM</div>
             <div class="fieldRow"><div class="label">Base URL</div><input class="input" id="set_base_url" placeholder="Model Provider Default" /></div>
             <div class="fieldRow"><div class="label">Model</div><input class="input" id="set_model" placeholder="openai:gpt-5.4-mini" /></div>
-            <div class="fieldRow"><div class="label">API key env</div><input class="input" id="set_api_key_env" placeholder="OPENAI_API_KEY" /></div>
-            <div class="muted small" style="margin: 2px 0 10px">The dashboard does not store API keys. Set the key in the dashboard server environment and reference its variable name here.</div>
+            <div class="globalCredentialOnly">
+              <div class="fieldRow"><div class="label">API key source</div><select class="input" id="set_llm_credential_source"><option value="stored">Secure system storage</option><option value="environment">Environment variable</option><option value="none">No API key</option></select></div>
+              <div id="set_llm_stored_fields">
+                <div class="fieldRow"><div class="label">API key</div><input class="input" id="set_llm_api_key" type="password" autocomplete="new-password" spellcheck="false" placeholder="Enter to save or replace" /></div>
+                <div class="fieldRow"><div></div><div class="row" style="justify-content:flex-start"><button class="btn danger" id="set_llm_remove_key" type="button">Remove saved key</button></div></div>
+              </div>
+              <div id="set_llm_env_fields"><div class="fieldRow"><div class="label">API key env</div><input class="input" id="set_api_key_env" placeholder="OPENAI_API_KEY" /></div></div>
+              <div class="fieldHelp"><div></div><div class="fieldHelpText" id="set_llm_credential_status">Checking credential status…</div></div>
+            </div>
             <div class="fieldRow"><div class="label">Model kwargs</div><textarea class="input" id="set_model_kwargs" rows="7" placeholder='{{"max_completion_tokens":25000,"temperature":0.5,"reasoning": {{"effort": "medium"}}}}' style="font-family: var(--mono);"></textarea></div>
             <div class="muted small" style="margin: 2px 0 10px">Additional JSON object passed to LangChain init_chat_model. Explicit fields above still take precedence for model and base_url.</div>
           </div>
@@ -5140,8 +5488,15 @@ textarea.input { width: 100%; box-sizing: border-box; resize: vertical; }
             <div class="muted small" style="margin: 2px 0 10px">Configure the embedding model used by RAG agents and persisted RAG tools. The dashboard stores only non-secret settings.</div>
             <div class="fieldRow"><div class="label">Base URL</div><input class="input" id="set_embedding_base_url" placeholder="Model Provider Default" /></div>
             <div class="fieldRow"><div class="label">Model</div><input class="input" id="set_embedding_model" placeholder="openai:text-embedding-3-large" /></div>
-            <div class="fieldRow"><div class="label">API key env</div><input class="input" id="set_embedding_api_key_env" placeholder="OPENAI_API_KEY" /></div>
-            <div class="muted small" style="margin: 2px 0 10px">Set the embedding API key in the dashboard server environment and reference its variable name here.</div>
+            <div class="globalCredentialOnly">
+              <div class="fieldRow"><div class="label">API key source</div><select class="input" id="set_embedding_credential_source"><option value="stored">Secure system storage</option><option value="llm">Reuse saved LLM key</option><option value="environment">Environment variable</option><option value="none">No API key</option></select></div>
+              <div id="set_embedding_stored_fields">
+                <div class="fieldRow"><div class="label">API key</div><input class="input" id="set_embedding_api_key" type="password" autocomplete="new-password" spellcheck="false" placeholder="Enter to save or replace" /></div>
+                <div class="fieldRow"><div></div><div class="row" style="justify-content:flex-start"><button class="btn danger" id="set_embedding_remove_key" type="button">Remove saved key</button></div></div>
+              </div>
+              <div id="set_embedding_env_fields"><div class="fieldRow"><div class="label">API key env</div><input class="input" id="set_embedding_api_key_env" placeholder="OPENAI_API_KEY" /></div></div>
+              <div class="fieldHelp"><div></div><div class="fieldHelpText" id="set_embedding_credential_status">Checking credential status…</div></div>
+            </div>
             <div class="fieldRow"><div class="label">Model kwargs</div><textarea class="input" id="set_embedding_model_kwargs" rows="7" placeholder='{{"dimensions":1024}}' style="font-family: var(--mono);"></textarea></div>
             <div class="muted small" style="margin: 2px 0 10px">Additional JSON object passed to LangChain init_embeddings. Explicit fields above still take precedence for model and base_url.</div>
           </div>

--- a/src/ursa_dashboard/credentials.py
+++ b/src/ursa_dashboard/credentials.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections.abc import Mapping
+from typing import Literal, Protocol
+from urllib.parse import urlsplit
+
+from ursa.security import normalize_base_url, validate_group_name
+
+CredentialKind = Literal["llm", "embedding"]
+CredentialSource = Literal["environment", "stored", "llm", "none"]
+
+_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_STORED_CREDENTIAL_VERSION = 1
+
+
+class CredentialStoreError(RuntimeError):
+    """Raised when the configured credential backend cannot be used."""
+
+
+class CredentialConfigurationError(ValueError):
+    """Raised when credential metadata is missing or unsafe."""
+
+
+class CredentialStore(Protocol):
+    def set_secret(self, credential_id: str, value: str) -> None: ...
+
+    def get_secret(self, credential_id: str) -> str | None: ...
+
+    def delete_secret(self, credential_id: str) -> None: ...
+
+
+class KeyringCredentialStore:
+    """Store dashboard credentials in the operating system credential store."""
+
+    def __init__(self, *, service_name: str = "ursa-ai") -> None:
+        self.service_name = service_name
+
+    @staticmethod
+    def _keyring():
+        try:
+            import keyring
+        except ImportError as e:  # pragma: no cover - installation failure
+            raise CredentialStoreError(
+                "Secure credential storage is unavailable. Install the "
+                "dashboard credential-store dependency or use an environment "
+                "variable."
+            ) from e
+        return keyring
+
+    def set_secret(self, credential_id: str, value: str) -> None:
+        try:
+            self._keyring().set_password(
+                self.service_name, credential_id, value
+            )
+        except Exception as e:
+            raise CredentialStoreError(
+                "The operating system credential store could not save the key."
+            ) from e
+
+    def get_secret(self, credential_id: str) -> str | None:
+        try:
+            return self._keyring().get_password(
+                self.service_name, credential_id
+            )
+        except Exception as e:
+            raise CredentialStoreError(
+                "The operating system credential store could not read the key."
+            ) from e
+
+    def delete_secret(self, credential_id: str) -> None:
+        keyring = self._keyring()
+        try:
+            if keyring.get_password(self.service_name, credential_id) is None:
+                return
+            keyring.delete_password(self.service_name, credential_id)
+        except Exception as e:
+            raise CredentialStoreError(
+                "The operating system credential store could not remove the key."
+            ) from e
+
+
+class MemoryCredentialStore:
+    """In-memory credential store for tests and embedded integrations."""
+
+    def __init__(self) -> None:
+        self._values: dict[str, str] = {}
+
+    def set_secret(self, credential_id: str, value: str) -> None:
+        self._values[credential_id] = value
+
+    def get_secret(self, credential_id: str) -> str | None:
+        return self._values.get(credential_id)
+
+    def delete_secret(self, credential_id: str) -> None:
+        self._values.pop(credential_id, None)
+
+
+def credential_id(group: str, kind: CredentialKind) -> str:
+    """Return the only keyring identifier allowed for a dashboard slot."""
+    return f"dashboard:{validate_group_name(group)}:{kind}"
+
+
+def credential_target(config: Mapping[str, object]) -> str:
+    """Bind a credential to an endpoint origin or model provider."""
+    base_url = normalize_base_url(
+        str(config.get("base_url")) if config.get("base_url") else None
+    )
+    if base_url:
+        parsed = urlsplit(base_url)
+        if parsed.scheme and parsed.netloc:
+            host = (parsed.hostname or "").lower()
+            port = f":{parsed.port}" if parsed.port else ""
+            return f"origin:{parsed.scheme.lower()}://{host}{port}"
+        return f"endpoint:{base_url}"
+
+    model = str(config.get("model") or "openai").strip()
+    provider = model.split(":", 1)[0] if ":" in model else "openai"
+    return f"provider:{provider.lower()}"
+
+
+def store_api_key(
+    store: CredentialStore,
+    *,
+    credential_id: str,
+    target: str,
+    value: str,
+) -> None:
+    """Store the key and its trusted endpoint binding as one secure record."""
+    record = {
+        "version": _STORED_CREDENTIAL_VERSION,
+        "target": target,
+        "value": value,
+    }
+    store.set_secret(credential_id, json.dumps(record, separators=(",", ":")))
+
+
+def read_api_key(
+    store: CredentialStore, *, credential_id: str
+) -> tuple[str, str] | None:
+    """Read and validate a bound key from the secure credential store."""
+    raw = store.get_secret(credential_id)
+    if raw is None:
+        return None
+    try:
+        record = json.loads(raw)
+    except (TypeError, json.JSONDecodeError) as e:
+        raise CredentialConfigurationError(
+            "The saved credential record is invalid. Save the API key again."
+        ) from e
+    if (
+        not isinstance(record, dict)
+        or record.get("version") != _STORED_CREDENTIAL_VERSION
+        or not isinstance(record.get("target"), str)
+        or not isinstance(record.get("value"), str)
+        or not record["value"]
+    ):
+        raise CredentialConfigurationError(
+            "The saved credential record is invalid. Save the API key again."
+        )
+    return record["value"], record["target"]
+
+
+def effective_credential_source(
+    config: Mapping[str, object],
+) -> CredentialSource:
+    value = str(config.get("credential_source") or "").strip().lower()
+    if not value:
+        # Backward compatibility for settings created before credential_source.
+        return "environment" if config.get("api_key_env") else "none"
+    if value not in {"environment", "stored", "llm", "none"}:
+        raise CredentialConfigurationError(
+            f"Unknown credential source: {value}"
+        )
+    return value  # type: ignore[return-value]
+
+
+def assert_no_raw_api_key(
+    config: Mapping[str, object], *, context: str
+) -> None:
+    """Reject literal API keys in objects that will be persisted or returned."""
+    for key, value in config.items():
+        normalized = str(key).strip().lower()
+        if normalized in {"api_key", "apikey", "api-key"}:
+            raise CredentialConfigurationError(
+                f"{context} must not contain a literal API key; use the "
+                "credential endpoint or api_key_env instead."
+            )
+        if isinstance(value, Mapping):
+            assert_no_raw_api_key(value, context=context)
+        elif isinstance(value, (list, tuple)):
+            for item in value:
+                if isinstance(item, Mapping):
+                    assert_no_raw_api_key(item, context=context)
+
+
+def assert_no_credential_metadata(
+    config: Mapping[str, object], *, context: str
+) -> None:
+    """Keep secure-store references under server control."""
+    if {"credential_id", "credential_target"}.intersection(config):
+        raise CredentialConfigurationError(
+            f"{context} contains server-managed credential metadata."
+        )
+
+
+def resolve_api_key(
+    config: Mapping[str, object],
+    *,
+    group: str,
+    kind: CredentialKind,
+    store: CredentialStore,
+    environ: Mapping[str, str] | None = None,
+) -> str | None:
+    """Resolve a key without adding it to persistent configuration."""
+    assert_no_raw_api_key(config, context=kind)
+    source = effective_credential_source(config)
+    if source == "none":
+        return None
+
+    if source == "environment":
+        env_name = str(config.get("api_key_env") or "").strip()
+        if not env_name:
+            return None
+        if not _ENV_NAME_RE.fullmatch(env_name):
+            raise CredentialConfigurationError(
+                f"Invalid {kind} API-key environment variable name."
+            )
+        value = (environ or os.environ).get(env_name)
+        if not value:
+            raise CredentialConfigurationError(
+                f"{kind.capitalize()} API-key environment variable "
+                f"'{env_name}' is not set."
+            )
+        return value
+
+    if source == "llm":
+        if kind != "embedding":
+            raise CredentialConfigurationError(
+                "Only embedding settings may reuse the LLM credential."
+            )
+        stored = read_api_key(store, credential_id=credential_id(group, "llm"))
+        if not stored:
+            raise CredentialConfigurationError(
+                "No stored LLM API key is available to reuse."
+            )
+        value, trusted_target = stored
+        expected_target = credential_target(config)
+        if trusted_target != expected_target:
+            raise CredentialConfigurationError(
+                "The stored LLM credential is not approved for the embedding "
+                "endpoint. Save a separate embedding key or use the same endpoint."
+            )
+        return value
+
+    expected_id = credential_id(group, kind)
+    configured_id = str(config.get("credential_id") or "")
+    if configured_id != expected_id:
+        raise CredentialConfigurationError(
+            f"The stored {kind} credential reference is invalid."
+        )
+
+    expected_target = credential_target(config)
+    bound_target = str(config.get("credential_target") or "")
+    if not bound_target or bound_target != expected_target:
+        raise CredentialConfigurationError(
+            f"The stored {kind} credential is not approved for the current "
+            "model endpoint. Save the key again after reviewing the endpoint."
+        )
+
+    stored = read_api_key(store, credential_id=expected_id)
+    if not stored:
+        raise CredentialConfigurationError(
+            f"No stored {kind} API key is available. Save one in Settings."
+        )
+    value, trusted_target = stored
+    if trusted_target != expected_target:
+        raise CredentialConfigurationError(
+            f"The stored {kind} credential is not approved for the current "
+            "model endpoint. Save the key again after reviewing the endpoint."
+        )
+    return value
+
+
+def credential_status(
+    config: Mapping[str, object],
+    *,
+    group: str,
+    kind: CredentialKind,
+    store: CredentialStore,
+) -> dict[str, object]:
+    """Return non-secret status suitable for a dashboard API response."""
+    source = effective_credential_source(config)
+    target = credential_target(config)
+    configured = False
+    usable = source == "none"
+    needs_reentry = False
+
+    if source == "environment":
+        env_name = str(config.get("api_key_env") or "").strip()
+        configured = bool(env_name and os.environ.get(env_name))
+        usable = configured or not env_name
+    elif source == "llm":
+        stored = (
+            read_api_key(store, credential_id=credential_id(group, "llm"))
+            if kind == "embedding"
+            else None
+        )
+        configured = stored is not None
+        trusted_target = stored[1] if stored else None
+        usable = configured and trusted_target == target
+        needs_reentry = configured and not usable
+    elif source == "stored":
+        expected_id = credential_id(group, kind)
+        metadata_matches = (
+            config.get("credential_id") == expected_id
+            and config.get("credential_target") == target
+        )
+        stored = read_api_key(store, credential_id=expected_id)
+        configured = stored is not None
+        trusted_target = stored[1] if stored else None
+        binding_matches = trusted_target == target
+        usable = configured and metadata_matches and binding_matches
+        needs_reentry = configured and not usable
+
+    return {
+        "kind": kind,
+        "source": source,
+        "configured": configured,
+        "usable": usable,
+        "needs_reentry": needs_reentry,
+        "target": target,
+    }

--- a/src/ursa_dashboard/registry.py
+++ b/src/ursa_dashboard/registry.py
@@ -45,18 +45,6 @@ def _common_llm_params() -> list[AgentParam]:
             target="base_url",
         ),
         AgentParam(
-            name="llm_api_key",
-            title="LLM API Key",
-            description="API key (if required).",
-            type="string",
-            required=False,
-            default="",
-            advanced=True,
-            hidden=True,
-            source=ParamSource.llm,
-            target="api_key",
-        ),
-        AgentParam(
             name="llm_model",
             title="LLM Model",
             description="Model name.",

--- a/src/ursa_dashboard/run_manager.py
+++ b/src/ursa_dashboard/run_manager.py
@@ -7,9 +7,16 @@ import signal
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from .artifacts import scan_artifacts
+from .credentials import (
+    CredentialConfigurationError,
+    CredentialStore,
+    KeyringCredentialStore,
+    assert_no_raw_api_key,
+    resolve_api_key,
+)
 from .events import make_event
 from .retention import RetentionPolicy, enforce_retention
 from .security import dashboard_root_from_env, safe_join
@@ -51,10 +58,14 @@ class RunManager:
         dashboard_root: Path | None = None,
         config: RunConfig | None = None,
         retention: RetentionPolicy | None = None,
+        credential_store: CredentialStore | None = None,
+        dashboard_group: str = "default",
     ):
         self.dashboard_root = dashboard_root or dashboard_root_from_env()
         self.config = config or RunConfig()
         self.retention = retention or RetentionPolicy()
+        self.credential_store = credential_store or KeyringCredentialStore()
+        self.dashboard_group = dashboard_group
 
         self.dashboard_root.mkdir(parents=True, exist_ok=True)
         (self.dashboard_root / "_meta" / "runs").mkdir(
@@ -218,6 +229,9 @@ class RunManager:
         runner: dict[str, Any],
         extra: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
+        assert_no_raw_api_key(llm, context="run.llm")
+        if extra and isinstance(extra.get("embedding"), dict):
+            assert_no_raw_api_key(extra["embedding"], context="run.embedding")
         run_id = new_ulid()
         paths = self._run_paths(agent_id=agent_id, run_id=run_id)
         ensure_dirs(paths)
@@ -287,6 +301,12 @@ class RunManager:
 
         await self._queue.put(run_id)
         return rec
+
+    def validate_credentials(
+        self, *, llm: dict[str, Any], embedding: dict[str, Any]
+    ) -> None:
+        """Fail before run creation when required credentials are unavailable."""
+        self._resolve_credentials(llm=llm, embedding=embedding)
 
     async def get_run(self, run_id: str) -> dict[str, Any]:
         return self._read_run(run_id)
@@ -366,6 +386,140 @@ class RunManager:
     # Internals
     # ----------------------------
 
+    def _resolve_credentials(
+        self, *, llm: dict[str, Any], embedding: dict[str, Any]
+    ) -> dict[str, str | None]:
+        llm_disabled = bool(llm.get("disabled")) or str(
+            llm.get("model") or ""
+        ).strip().lower() in {"none", "disabled"}
+        llm_key = None
+        if not llm_disabled:
+            llm_key = resolve_api_key(
+                llm,
+                group=self.dashboard_group,
+                kind="llm",
+                store=self.credential_store,
+            )
+
+        embedding_key = None
+        embedding_model = str(embedding.get("model") or "").strip()
+        if embedding_model and embedding_model.lower() not in {
+            "none",
+            "disabled",
+        }:
+            embedding_key = resolve_api_key(
+                embedding,
+                group=self.dashboard_group,
+                kind="embedding",
+                store=self.credential_store,
+            )
+        return {
+            "llm_api_key": llm_key,
+            "embedding_api_key": embedding_key,
+        }
+
+    @staticmethod
+    def _worker_environment(
+        rec: dict[str, Any], *, project_root: str
+    ) -> dict[str, str]:
+        """Build the worker environment without model-provider credentials."""
+        env = dict(os.environ)
+        sensitive_names = {
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "GOOGLE_API_KEY",
+            "GEMINI_API_KEY",
+            "AZURE_OPENAI_API_KEY",
+            "MISTRAL_API_KEY",
+            "COHERE_API_KEY",
+            "GROQ_API_KEY",
+            "TOGETHER_API_KEY",
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+        }
+        for section in ("llm", "embedding"):
+            config = rec.get(section) or {}
+            env_name = str(config.get("api_key_env") or "").strip()
+            if env_name:
+                sensitive_names.add(env_name)
+        secret_markers = (
+            "api_key",
+            "apikey",
+            "access_token",
+            "refresh_token",
+            "secret",
+            "password",
+            "credential",
+            "bearer",
+        )
+        for name in list(env):
+            lowered = name.lower()
+            if (
+                name in sensitive_names
+                or any(marker in lowered for marker in secret_markers)
+                or lowered.endswith("_token")
+            ):
+                env.pop(name, None)
+
+        env["PYTHONUNBUFFERED"] = "1"
+        existing_pp = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            project_root
+            if not existing_pp
+            else (project_root + os.pathsep + existing_pp)
+        )
+        env.setdefault("TERM", "xterm-256color")
+        env.setdefault("PYTHONIOENCODING", "utf-8")
+        return env
+
+    async def _fail_before_spawn(
+        self, run_id: str, *, error: Exception
+    ) -> None:
+        rec = self._read_run(run_id)
+        agent_id = rec["agent_id"]
+        previous = rec.get("status") or "starting"
+        rec["status"] = "failed"
+        rec["finished_at"] = utc_now()
+        rec["error"] = {
+            "error_type": error.__class__.__name__,
+            "message": str(error),
+        }
+        self._write_run(run_id, rec)
+        await self._emit(
+            run_id=run_id,
+            agent_id=agent_id,
+            type="state_change",
+            payload={
+                "from": previous,
+                "to": "failed",
+                "reason": "credential_preflight",
+            },
+            level="error",
+        )
+
+        session_id = rec.get("session_id")
+        if not session_id:
+            return
+        try:
+            from .sessions import append_message as _append_session_message
+            from .sessions import update_session as _update_session
+
+            _append_session_message(
+                self.dashboard_root,
+                session_id=str(session_id),
+                role="assistant",
+                text=f"(failed) {error}",
+                run_id=run_id,
+            )
+            _update_session(
+                self.dashboard_root,
+                str(session_id),
+                {"active_run_id": None, "last_run_id": run_id},
+            )
+        except Exception:
+            pass
+
     def _load_last_seq(self, events_path: Path) -> int:
         """Infer last seq from events.jsonl (best-effort)."""
         if not events_path.exists() or events_path.stat().st_size == 0:
@@ -440,6 +594,16 @@ class RunManager:
                 payload={"from": prev, "to": "starting", "reason": "dequeued"},
             )
 
+        try:
+            resolved_secrets = await asyncio.to_thread(
+                self._resolve_credentials,
+                llm=rec.get("llm") or {},
+                embedding=rec.get("embedding") or {},
+            )
+        except (CredentialConfigurationError, RuntimeError) as e:
+            await self._fail_before_spawn(run_id, error=e)
+            return
+
         # Write config JSON blobs for the worker.
         params_json = paths.run_dir / "params.json"
         agent_init_json = paths.run_dir / "agent_init.json"
@@ -508,26 +672,17 @@ class RunManager:
             str(mcp_json),
             "--output-json",
             str(output_json),
+            "--secrets-stdin",
         ]
 
-        env = dict(os.environ)
-        env["PYTHONUNBUFFERED"] = "1"
         # Ensure the worker can import `ursa_dashboard` even when the dashboard
         # is run from a source checkout (not installed as a package).
         project_root = str(Path(__file__).resolve().parent.parent)
-        existing_pp = env.get("PYTHONPATH")
-        env["PYTHONPATH"] = (
-            project_root
-            if not existing_pp
-            else (project_root + os.pathsep + existing_pp)
-        )
+        env = self._worker_environment(rec, project_root=project_root)
 
-        # Strongly discourage interactive behavior (no stdin). For log readability,
-        # prefer *plain* output when stdout/stderr are pipes (the default behavior of
-        # rich/tqdm). Users can opt-in to forced ANSI output if they want.
-        env.setdefault("TERM", "xterm-256color")
-        env.setdefault("PYTHONIOENCODING", "utf-8")
-
+        # The worker reads one credential message from stdin and then the pipe is
+        # closed, preventing interactive behavior. Prefer plain output when logs
+        # are pipes; users can opt in to forced ANSI output.
         force_no_ansi = str(
             os.environ.get("URSA_DASHBOARD_NO_ANSI", "")
         ).strip().lower() in {
@@ -545,11 +700,45 @@ class RunManager:
         proc = await asyncio.create_subprocess_exec(
             *cmd,
             cwd=str(paths.run_dir),
-            stdin=asyncio.subprocess.DEVNULL,
+            stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=env,
         )
+
+        if proc.stdin is None:  # pragma: no cover - asyncio contract
+            proc.kill()
+            await proc.wait()
+            await self._fail_before_spawn(
+                run_id,
+                error=RuntimeError("Worker secret channel is unavailable"),
+            )
+            return
+        pipe_error: Exception | None = None
+        try:
+            secret_message = (
+                json.dumps(resolved_secrets, ensure_ascii=False) + "\n"
+            ).encode("utf-8")
+            proc.stdin.write(secret_message)
+            await proc.stdin.drain()
+        except Exception as e:
+            pipe_error = e
+        finally:
+            proc.stdin.close()
+            with contextlib.suppress(Exception):
+                await proc.stdin.wait_closed()
+            secret_message = b""
+            resolved_secrets = {}
+        if pipe_error is not None:
+            with contextlib.suppress(ProcessLookupError, OSError):
+                proc.kill()
+            with contextlib.suppress(Exception):
+                await proc.wait()
+            await self._fail_before_spawn(
+                run_id,
+                error=RuntimeError("Could not deliver credentials to worker"),
+            )
+            return
 
         async with self._lock:
             rec = self._read_run(run_id)
@@ -753,7 +942,7 @@ class RunManager:
         run_id: str,
         agent_id: str,
         stream_name: str,
-        stream: Optional[asyncio.StreamReader],
+        stream: asyncio.StreamReader | None,
         log_path: Path,
         cap_bytes: int,
     ) -> None:

--- a/src/ursa_dashboard/settings.py
+++ b/src/ursa_dashboard/settings.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import os
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
 from ursa.cli.config import UrsaConfig
 from ursa.security import enforce_group_base_url_policy
 
+from .credentials import assert_no_raw_api_key
 from .storage import read_json, utc_now, write_json
 
 
@@ -17,13 +18,16 @@ class LLMSettings(BaseModel):
     model: str = "openai:gpt-5.2"
     base_url: str | None = None
 
-    # Security: we intentionally do *not* store an API key in settings.json.
-    # Instead, we store the *name* of an environment variable that contains
-    # the key. The worker copies that value into OPENAI_API_KEY at runtime.
+    # Security: settings contain only a credential source/reference. Stored
+    # keys live in the OS credential store; environment variables remain an
+    # explicit compatibility option.
     api_key_env: str | None = Field(
         default="OPENAI_API_KEY",
         description="Name of the environment variable that contains the LLM API key (the secret is not stored).",
     )
+    credential_source: Literal["environment", "stored", "none"] = "stored"
+    credential_id: str | None = None
+    credential_target: str | None = None
 
     model_kwargs: dict[str, Any] = Field(
         default_factory=dict,
@@ -37,6 +41,7 @@ class LLMSettings(BaseModel):
             return {}
         if not isinstance(v, dict):
             raise ValueError("llm.model_kwargs must be a JSON object")
+        assert_no_raw_api_key(v, context="llm.model_kwargs")
         return v
 
     @field_validator("api_key_env")
@@ -97,6 +102,11 @@ class EmbeddingSettings(BaseModel):
         default="OPENAI_API_KEY",
         description="Name of the environment variable that contains the embedding API key (the secret is not stored).",
     )
+    credential_source: Literal["environment", "stored", "llm", "none"] = (
+        "stored"
+    )
+    credential_id: str | None = None
+    credential_target: str | None = None
     model_kwargs: dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("model_kwargs")
@@ -106,6 +116,7 @@ class EmbeddingSettings(BaseModel):
             return {}
         if not isinstance(v, dict):
             raise ValueError("embedding.model_kwargs must be a JSON object")
+        assert_no_raw_api_key(v, context="embedding.model_kwargs")
         return v
 
     @field_validator("api_key_env")
@@ -173,6 +184,7 @@ def dashboard_llm_patch_from_ursa_config(path: str | Path) -> dict[str, Any]:
         patch["base_url"] = llm_cfg.base_url
     if llm_cfg.api_key_env is not None:
         patch["api_key_env"] = llm_cfg.api_key_env
+        patch["credential_source"] = "environment"
     if llm_cfg.max_completion_tokens is not None:
         patch["max_tokens"] = llm_cfg.max_completion_tokens
 
@@ -214,6 +226,7 @@ def dashboard_llm_patch_from_ursa_config(path: str | Path) -> dict[str, Any]:
             emb_patch["base_url"] = emb_cfg.base_url
         if emb_cfg.api_key_env is not None:
             emb_patch["api_key_env"] = emb_cfg.api_key_env
+            emb_patch["credential_source"] = "environment"
 
         emb_model_kwargs: dict[str, Any] = {}
         for key, value in (emb_cfg.model_extra or {}).items():
@@ -307,6 +320,18 @@ class SettingsStore:
             self.save(s)
             return s
         data = read_json(self.path)
+        # Settings created before secure storage existed used api_key_env.
+        # Preserve that behavior while letting fresh installs default to the
+        # operating system credential store.
+        for section in ("llm", "embedding"):
+            section_data = data.get(section)
+            if (
+                isinstance(section_data, dict)
+                and "credential_source" not in section_data
+            ):
+                section_data["credential_source"] = (
+                    "environment" if section_data.get("api_key_env") else "none"
+                )
         return GlobalSettings.model_validate(data)
 
     def save(self, settings: GlobalSettings) -> None:

--- a/src/ursa_dashboard/worker_main.py
+++ b/src/ursa_dashboard/worker_main.py
@@ -11,6 +11,8 @@ from typing import Any
 
 from ursa.util.http import inject_truststore_into_ssl
 
+_UNSET = object()
+
 
 def _normalize_model(model: str) -> str:
     # Examples use "openai:gpt-5.4-mini".
@@ -19,36 +21,44 @@ def _normalize_model(model: str) -> str:
     return f"openai:{model}"
 
 
-def _init_llm(llm_cfg: dict[str, Any]):
+def _api_key_from_config(
+    config: dict[str, Any],
+    *,
+    label: str,
+    override: str | None | object = _UNSET,
+) -> str | None:
+    if "api_key" in config:
+        raise ValueError(
+            f"Literal {label} API keys are not accepted in worker config"
+        )
+    if override is not _UNSET:
+        return str(override) if override else None
+
+    env_name = str(config.get("api_key_env") or "").strip()
+    if not env_name:
+        return None
+    env_val = os.environ.get(env_name)
+    if not env_val:
+        raise ValueError(
+            f"{label} api_key_env '{env_name}' is not set in the worker environment"
+        )
+    return env_val
+
+
+def _init_llm(
+    llm_cfg: dict[str, Any],
+    *,
+    api_key_override: str | None | object = _UNSET,
+):
     # Avoid importing langchain unless actually executing.
     from langchain.chat_models import init_chat_model  # type: ignore
 
     raw_base_url = llm_cfg.get("base_url")
     base_url = str(raw_base_url).strip() if raw_base_url is not None else None
 
-    # Security: prefer reading the API key from an environment variable.
-    # - If llm_cfg.api_key is provided (advanced / legacy), it is used directly.
-    # - Otherwise, if llm_cfg.api_key_env is set, copy that env var's value
-    #   into OPENAI_API_KEY for the OpenAI-compatible client stack.
-    api_key = llm_cfg.get("api_key")
-    if api_key is not None and str(api_key).strip() != "":
-        os.environ["OPENAI_API_KEY"] = str(api_key)
-    else:
-        env_name = llm_cfg.get("api_key_env")
-        if env_name is not None:
-            env_name = str(env_name).strip()
-        if env_name:
-            env_val = os.environ.get(env_name)
-            if not env_val:
-                raise ValueError(
-                    f"LLM api_key_env '{env_name}' is not set in the dashboard environment"
-                )
-            os.environ["OPENAI_API_KEY"] = str(env_val)
-            api_key = str(env_val)
-    if base_url:
-        # Support multiple common env names.
-        os.environ["OPENAI_BASE_URL"] = str(base_url)
-        os.environ["OPENAI_API_BASE"] = str(base_url)
+    api_key = _api_key_from_config(
+        llm_cfg, label="LLM", override=api_key_override
+    )
 
     model = _normalize_model(str(llm_cfg.get("model") or "openai:gpt-5.4-mini"))
 
@@ -58,19 +68,24 @@ def _init_llm(llm_cfg: dict[str, Any]):
 
     kwargs: dict[str, Any] = {**model_kwargs, "model": model}
 
-    kwargs["api_key"] = api_key
+    if api_key is not None:
+        kwargs["api_key"] = api_key
     if base_url:
         kwargs["base_url"] = base_url
 
     return init_chat_model(**kwargs)
 
 
-def _init_embedding(embedding_cfg: dict[str, Any]):
+def _init_embedding(
+    embedding_cfg: dict[str, Any],
+    *,
+    api_key_override: str | None | object = _UNSET,
+):
     """Initialize an embedding model from dashboard settings.
 
-    Returns None when no embedding model is configured. Mirrors the LLM worker
-    behavior: non-secret config is snapshotted into the run record, while the
-    actual secret is read from api_key_env at worker runtime.
+    Returns None when no embedding model is configured. Non-secret config is
+    snapshotted into the run record; the run manager delivers stored or
+    environment-backed secrets through the worker's one-time stdin channel.
     """
 
     model = str(embedding_cfg.get("model") or "").strip()
@@ -82,25 +97,9 @@ def _init_embedding(embedding_cfg: dict[str, Any]):
     raw_base_url = embedding_cfg.get("base_url")
     base_url = str(raw_base_url).strip() if raw_base_url is not None else None
 
-    api_key = embedding_cfg.get("api_key")
-    if api_key is not None and str(api_key).strip() != "":
-        os.environ["OPENAI_API_KEY"] = str(api_key)
-    else:
-        env_name = embedding_cfg.get("api_key_env")
-        if env_name is not None:
-            env_name = str(env_name).strip()
-        if env_name:
-            env_val = os.environ.get(env_name)
-            if not env_val:
-                raise ValueError(
-                    f"Embedding api_key_env '{env_name}' is not set in the dashboard environment"
-                )
-            os.environ["OPENAI_API_KEY"] = str(env_val)
-            api_key = str(env_val)
-
-    if base_url:
-        os.environ["OPENAI_BASE_URL"] = str(base_url)
-        os.environ["OPENAI_API_BASE"] = str(base_url)
+    api_key = _api_key_from_config(
+        embedding_cfg, label="Embedding", override=api_key_override
+    )
 
     model_kwargs = embedding_cfg.get("model_kwargs") or {}
     if not isinstance(model_kwargs, dict):
@@ -121,6 +120,32 @@ def _maybe_run_async(result):
     return result
 
 
+def _read_secrets_stdin(*, max_bytes: int = 65_536) -> dict[str, str | None]:
+    payload = sys.stdin.buffer.read(max_bytes + 1)
+    if len(payload) > max_bytes:
+        raise ValueError("Worker secret payload is too large")
+    if not payload.strip():
+        return {}
+    value = json.loads(payload.decode("utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("Worker secret payload must be an object")
+    allowed = {"llm_api_key", "embedding_api_key"}
+    if set(value) - allowed:
+        raise ValueError("Worker secret payload contains unknown fields")
+    return {
+        key: (str(item) if item is not None else None)
+        for key, item in value.items()
+    }
+
+
+def _redact_secrets(text: str, values: list[str]) -> str:
+    redacted = text
+    for value in values:
+        if value:
+            redacted = redacted.replace(value, "[REDACTED]")
+    return redacted
+
+
 def main() -> int:
     inject_truststore_into_ssl()
     ap = argparse.ArgumentParser()
@@ -135,10 +160,18 @@ def main() -> int:
     ap.add_argument("--embedding-json", required=False)
     ap.add_argument("--mcp-json", required=False)
     ap.add_argument("--output-json", required=True)
+    ap.add_argument("--secrets-stdin", action="store_true")
     args = ap.parse_args()
 
     out_path = Path(args.output_json)
+    secret_values: list[str] = []
     try:
+        secrets_payload = _read_secrets_stdin() if args.secrets_stdin else {}
+        secret_values = [
+            value
+            for value in secrets_payload.values()
+            if isinstance(value, str) and value
+        ]
         params = json.loads(Path(args.params_json).read_text(encoding="utf-8"))
         agent_init = json.loads(
             Path(args.agent_init_json).read_text(encoding="utf-8")
@@ -173,8 +206,19 @@ def main() -> int:
         llm_disabled = bool(llm_cfg.get("disabled")) or str(
             llm_cfg.get("model") or ""
         ).strip().lower() in {"none", "disabled"}
-        llm = None if llm_disabled else _init_llm(llm_cfg)
-        embedding = _init_embedding(embedding_cfg)
+        llm = (
+            None
+            if llm_disabled
+            else _init_llm(
+                llm_cfg,
+                api_key_override=secrets_payload.get("llm_api_key"),
+            )
+        )
+        embedding = _init_embedding(
+            embedding_cfg,
+            api_key_override=secrets_payload.get("embedding_api_key"),
+        )
+        secrets_payload = {}
         # Ensure consistent cross-session threading.
         agent_init = dict(agent_init)
         agent_init["thread_id"] = "ursa"
@@ -272,13 +316,15 @@ def main() -> int:
         )
         return 0
     except Exception as e:
+        message = _redact_secrets(str(e), secret_values)
+        stack = _redact_secrets(traceback.format_exc(), secret_values)
         err = {
             "status": "failed",
             "content_type": "text/plain",
-            "text": f"Run failed: {e}",
+            "text": f"Run failed: {message}",
             "error_type": e.__class__.__name__,
-            "message": str(e),
-            "stack": traceback.format_exc(),
+            "message": message,
+            "stack": stack,
         }
         out_path.parent.mkdir(parents=True, exist_ok=True)
         out_path.write_text(

--- a/src/ursa_dashboard/worker_main.py
+++ b/src/ursa_dashboard/worker_main.py
@@ -14,9 +14,29 @@ from ursa.util.http import inject_truststore_into_ssl
 _UNSET = object()
 
 
-def _normalize_model(model: str) -> str:
+def _normalize_model(model: str, model_provider: Any = None) -> str:
     # Examples use "openai:gpt-5.4-mini".
+    #
+    # The dashboard targets an OpenAI-compatible client stack by default, so a
+    # bare model name (e.g. "llama3.1" or a custom endpoint model) is prefixed
+    # with "openai:" so LangChain can resolve a provider. However, we must NOT
+    # manufacture a provider prefix when the caller has already specified the
+    # provider explicitly via a `model_provider` kwarg: doing so would send a
+    # doubly-qualified name like "openai:llama3.1" to the endpoint (LangChain's
+    # init_chat_model only strips a provider prefix when model_provider is
+    # unset), which the provider then rejects as an unknown model.
+    #
+    # Behavior:
+    #   - already-prefixed model (contains ":")            -> unchanged
+    #   - bare model + explicit model_provider given       -> unchanged (bare)
+    #   - bare model + no model_provider                   -> prepend "openai:"
+    #
+    # Note: a user who supplies BOTH a provider-prefixed model (e.g.
+    # "openai:gpt-4o") AND a model_provider is genuinely double-specifying; we
+    # intentionally leave that as-is and let LangChain surface the error.
     if ":" in model:
+        return model
+    if model_provider is not None and str(model_provider).strip() != "":
         return model
     return f"openai:{model}"
 
@@ -60,11 +80,14 @@ def _init_llm(
         llm_cfg, label="LLM", override=api_key_override
     )
 
-    model = _normalize_model(str(llm_cfg.get("model") or "openai:gpt-5.4-mini"))
-
     model_kwargs = llm_cfg.get("model_kwargs") or {}
     if not isinstance(model_kwargs, dict):
         raise ValueError("llm.model_kwargs must be a JSON object")
+
+    model = _normalize_model(
+        str(llm_cfg.get("model") or "openai:gpt-5.4-mini"),
+        model_kwargs.get("model_provider"),
+    )
 
     kwargs: dict[str, Any] = {**model_kwargs, "model": model}
 
@@ -105,7 +128,10 @@ def _init_embedding(
     if not isinstance(model_kwargs, dict):
         raise ValueError("embedding.model_kwargs must be a JSON object")
 
-    kwargs: dict[str, Any] = {**model_kwargs, "model": _normalize_model(model)}
+    kwargs: dict[str, Any] = {
+        **model_kwargs,
+        "model": _normalize_model(model, model_kwargs.get("model_provider")),
+    }
     if api_key is not None:
         kwargs["api_key"] = api_key
     if base_url:

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -30,6 +30,74 @@ def test_mcp_server_passes_only_stdio_run_options(monkeypatch):
     mcp.run.assert_called_once_with(transport="stdio", log_level="INFO")
 
 
+def test_mcp_server_config_flag_sets_hosted_llm(monkeypatch, tmp_path):
+    """`ursa mcp-server --config FILE` must configure the hosted URSA instance.
+
+    Regression: previously the mcp-server subparser had no --config option, so
+    `ursa mcp-server --config foo.yaml` failed with "Unrecognized arguments".
+    The subcommand-local --config should feed the LLM model/endpoint (and other
+    UrsaConfig fields) into the HITL instance backing the MCP server.
+    """
+    hitl_class = MagicMock()
+    hitl_class.return_value = MagicMock()
+    hitl_class.return_value.as_mcp_server.return_value = MagicMock()
+    monkeypatch.setattr("ursa.cli.hitl.HITL", hitl_class)
+    monkeypatch.setattr("ursa.cli.inject_truststore_into_ssl", lambda: None)
+
+    config_file = tmp_path / "mcp.yaml"
+    config_file.write_text(
+        yaml.safe_dump({
+            "llm_model": {
+                "model": "ollama:llama3.1",
+                "base_url": "http://localhost:11434",
+            }
+        })
+    )
+
+    main(["mcp-server", "--config", str(config_file)])
+
+    # HITL should be constructed with the config loaded from --config.
+    (ursa_config,), _ = hitl_class.call_args
+    assert ursa_config.llm_model.model == "ollama:llama3.1"
+    assert ursa_config.llm_model.base_url == "http://localhost:11434"
+
+
+def test_mcp_server_config_flag_parses_alongside_transport(
+    monkeypatch, tmp_path
+):
+    """--config coexists with MCP transport options on the subcommand."""
+    hitl_class = MagicMock()
+    hitl_class.return_value = MagicMock()
+    mcp = MagicMock()
+    hitl_class.return_value.as_mcp_server.return_value = mcp
+    monkeypatch.setattr("ursa.cli.hitl.HITL", hitl_class)
+    monkeypatch.setattr("ursa.cli.inject_truststore_into_ssl", lambda: None)
+
+    config_file = tmp_path / "mcp.yaml"
+    config_file.write_text(
+        yaml.safe_dump({"llm_model": {"model": "ollama:llama3.1"}})
+    )
+
+    main([
+        "mcp-server",
+        "--config",
+        str(config_file),
+        "--transport",
+        "streamable-http",
+        "--port",
+        "9001",
+    ])
+
+    (ursa_config,), _ = hitl_class.call_args
+    assert ursa_config.llm_model.model == "ollama:llama3.1"
+    mcp.run.assert_called_once_with(
+        transport="streamable-http",
+        log_level="INFO",
+        host="localhost",
+        port=9001,
+    )
+
+
 def test_mcp_server_passes_http_options_when_running(monkeypatch):
     hitl, mcp = _stub_mcp_server(monkeypatch)
 

--- a/tests/dashboard/test_credentials.py
+++ b/tests/dashboard/test_credentials.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ursa import security
+from ursa_dashboard.app import create_app
+from ursa_dashboard.credentials import (
+    CredentialConfigurationError,
+    MemoryCredentialStore,
+    assert_no_raw_api_key,
+    credential_id,
+    credential_target,
+    resolve_api_key,
+    store_api_key,
+)
+from ursa_dashboard.run_manager import RunManager
+from ursa_dashboard.settings import SettingsStore
+
+
+def test_stored_credential_is_bound_to_endpoint() -> None:
+    store = MemoryCredentialStore()
+    config = {
+        "model": "openai:gpt-test",
+        "base_url": "https://models.example.org/v1",
+        "credential_source": "stored",
+        "credential_id": credential_id("default", "llm"),
+        "credential_target": "origin:https://models.example.org",
+    }
+    store_api_key(
+        store,
+        credential_id=credential_id("default", "llm"),
+        target="origin:https://models.example.org",
+        value="secret-value",
+    )
+
+    assert credential_target(config) == "origin:https://models.example.org"
+    assert (
+        resolve_api_key(
+            config,
+            group="default",
+            kind="llm",
+            store=store,
+        )
+        == "secret-value"
+    )
+
+    changed = config | {
+        "base_url": "https://other.example.org/v1",
+        "credential_target": "origin:https://other.example.org",
+    }
+    with pytest.raises(CredentialConfigurationError, match="not approved"):
+        resolve_api_key(
+            changed,
+            group="default",
+            kind="llm",
+            store=store,
+        )
+
+
+def test_literal_api_keys_are_rejected_recursively() -> None:
+    with pytest.raises(CredentialConfigurationError, match="literal API key"):
+        assert_no_raw_api_key(
+            {"model_kwargs": {"api_key": "secret-value"}},
+            context="test",
+        )
+
+
+def test_embedding_can_reuse_llm_key_only_for_same_target() -> None:
+    store = MemoryCredentialStore()
+    store_api_key(
+        store,
+        credential_id=credential_id("default", "llm"),
+        target="origin:https://models.example.org",
+        value="shared-secret",
+    )
+    config = {
+        "model": "openai:text-embedding-test",
+        "base_url": "https://models.example.org/embeddings",
+        "credential_source": "llm",
+    }
+
+    assert (
+        resolve_api_key(
+            config,
+            group="default",
+            kind="embedding",
+            store=store,
+        )
+        == "shared-secret"
+    )
+
+    with pytest.raises(CredentialConfigurationError, match="not approved"):
+        resolve_api_key(
+            config | {"base_url": "https://other.example.org/v1"},
+            group="default",
+            kind="embedding",
+            store=store,
+        )
+
+
+def test_new_settings_default_to_secure_storage_and_legacy_uses_env(
+    tmp_path,
+) -> None:
+    store = SettingsStore(tmp_path / "dashboard")
+    assert store.load().llm.credential_source == "stored"
+
+    data = json.loads(store.path.read_text(encoding="utf-8"))
+    data["llm"].pop("credential_source")
+    store.path.write_text(json.dumps(data), encoding="utf-8")
+
+    assert store.load().llm.credential_source == "environment"
+
+
+def test_worker_environment_excludes_model_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MY_MODEL_KEY", "secret-value")
+    monkeypatch.setenv("OPENAI_API_KEY", "another-secret")
+    monkeypatch.setenv("GH_TOKEN", "token-secret")
+    monkeypatch.setenv("SAFE_SETTING", "kept")
+    rec = {
+        "llm": {"api_key_env": "MY_MODEL_KEY"},
+        "embedding": {},
+    }
+
+    env = RunManager._worker_environment(rec, project_root="/project")
+
+    assert "MY_MODEL_KEY" not in env
+    assert "OPENAI_API_KEY" not in env
+    assert "GH_TOKEN" not in env
+    assert env["SAFE_SETTING"] == "kept"
+    assert env["PYTHONPATH"].split(":", 1)[0] == "/project"
+
+
+def test_credential_api_never_persists_or_returns_raw_key(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setattr(security, "URSA_CACHE_DIR", tmp_path / "ursa")
+    monkeypatch.setenv("URSA_DASHBOARD_GROUP", "default")
+    store = MemoryCredentialStore()
+    secret = "ursa-test-secret-never-persist"
+
+    with TestClient(create_app(credential_store=store)) as client:
+        settings_response = client.patch(
+            "/settings",
+            json={
+                "patch": {
+                    "llm": {
+                        "model": "openai:gpt-test",
+                        "base_url": "https://models.example.org/v1",
+                        "credential_source": "none",
+                    }
+                }
+            },
+        )
+        assert settings_response.status_code == 200
+
+        response = client.put("/credentials/llm", json={"api_key": secret})
+        assert response.status_code == 200
+        assert response.headers["cache-control"] == "no-store"
+        assert response.json() == {
+            "kind": "llm",
+            "source": "stored",
+            "configured": True,
+            "usable": True,
+            "needs_reentry": False,
+            "target": "origin:https://models.example.org",
+        }
+        assert secret not in response.text
+
+        settings = client.get("/settings")
+        assert settings.status_code == 200
+        assert secret not in settings.text
+        assert settings.json()["settings"]["llm"]["credential_source"] == (
+            "stored"
+        )
+
+        mismatch = client.patch(
+            "/settings",
+            json={
+                "patch": {"llm": {"base_url": "https://other.example.org/v1"}}
+            },
+        )
+        assert mismatch.status_code == 200
+        status = client.get("/credentials/status").json()["llm"]
+        assert status["configured"] is True
+        assert status["usable"] is False
+        assert status["needs_reentry"] is True
+
+        deleted = client.delete("/credentials/llm")
+        assert deleted.status_code == 200
+        assert deleted.json()["source"] == "none"
+        assert deleted.json()["configured"] is False
+
+    dashboard_root = tmp_path / "ursa" / "default" / "dashboard"
+    for path in dashboard_root.rglob("*"):
+        if path.is_file():
+            assert secret not in path.read_text(
+                encoding="utf-8", errors="ignore"
+            )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"patch": {"llm": {"api_key": "secret-value"}}},
+        {"patch": {"llm": {"model_kwargs": {"api_key": "secret-value"}}}},
+    ],
+)
+def test_settings_api_rejects_literal_keys(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, payload: dict
+) -> None:
+    monkeypatch.setattr(security, "URSA_CACHE_DIR", tmp_path / "ursa")
+    monkeypatch.setenv("URSA_DASHBOARD_GROUP", "default")
+
+    with TestClient(
+        create_app(credential_store=MemoryCredentialStore())
+    ) as client:
+        response = client.patch("/settings", json=payload)
+
+    assert response.status_code == 400
+    assert "literal API key" in response.json()["detail"]
+    assert "secret-value" not in response.text
+
+
+def test_settings_api_rejects_forged_credential_metadata(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setattr(security, "URSA_CACHE_DIR", tmp_path / "ursa")
+    monkeypatch.setenv("URSA_DASHBOARD_GROUP", "default")
+
+    with TestClient(
+        create_app(credential_store=MemoryCredentialStore())
+    ) as client:
+        response = client.patch(
+            "/settings",
+            json={
+                "patch": {
+                    "llm": {
+                        "credential_id": "dashboard:default:llm",
+                        "credential_target": "origin:https://evil.example",
+                    }
+                }
+            },
+        )
+
+    assert response.status_code == 400
+    assert "server-managed credential metadata" in response.json()["detail"]
+
+
+def test_run_api_rejects_literal_key_before_persistence(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setattr(security, "URSA_CACHE_DIR", tmp_path / "ursa")
+    monkeypatch.setenv("URSA_DASHBOARD_GROUP", "default")
+
+    with TestClient(
+        create_app(credential_store=MemoryCredentialStore())
+    ) as client:
+        response = client.post(
+            "/runs",
+            json={
+                "agent_id": "chat_agent",
+                "params": {"prompt": "hello"},
+                "llm": {"api_key": "secret-value"},
+            },
+        )
+
+    assert response.status_code == 400
+    meta_dir = tmp_path / "ursa" / "default" / "dashboard" / "_meta"
+    persisted = ""
+    for path in meta_dir.rglob("*"):
+        if path.is_file():
+            persisted += path.read_text(encoding="utf-8", errors="ignore")
+    assert "secret-value" not in persisted
+
+
+def test_settings_file_contains_only_credential_metadata(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setattr(security, "URSA_CACHE_DIR", tmp_path / "ursa")
+    monkeypatch.setenv("URSA_DASHBOARD_GROUP", "default")
+    store = MemoryCredentialStore()
+
+    with TestClient(create_app(credential_store=store)) as client:
+        client.patch(
+            "/settings",
+            json={"patch": {"llm": {"credential_source": "none"}}},
+        )
+        client.put("/credentials/llm", json={"api_key": "secret-value"})
+
+    settings_path = (
+        tmp_path / "ursa" / "default" / "dashboard" / "_meta" / "settings.json"
+    )
+    persisted = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert persisted["llm"]["credential_source"] == "stored"
+    assert "api_key" not in persisted["llm"]
+    assert "secret-value" not in settings_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_run_manager_delivers_key_only_through_stdin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    store = MemoryCredentialStore()
+    secret = "pipe-only-secret"
+    secret_id = credential_id("default", "llm")
+    store_api_key(
+        store,
+        credential_id=secret_id,
+        target="origin:https://models.example.org",
+        value=secret,
+    )
+    manager = RunManager(
+        dashboard_root=tmp_path / "dashboard",
+        credential_store=store,
+        dashboard_group="default",
+    )
+    captured: dict = {}
+
+    class FakeStdin:
+        def __init__(self) -> None:
+            self.data = bytearray()
+
+        def write(self, value: bytes) -> None:
+            self.data.extend(value)
+
+        async def drain(self) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+        async def wait_closed(self) -> None:
+            return None
+
+    class FakeProcess:
+        def __init__(self) -> None:
+            self.pid = 4321
+            self.returncode = 0
+            self.stdin = FakeStdin()
+            self.stdout = asyncio.StreamReader()
+            self.stderr = asyncio.StreamReader()
+            self.stdout.feed_eof()
+            self.stderr.feed_eof()
+
+        async def wait(self) -> int:
+            return self.returncode
+
+    async def fake_subprocess(*cmd, **kwargs):
+        process = FakeProcess()
+        captured.update({"cmd": cmd, "kwargs": kwargs, "process": process})
+        return process
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subprocess)
+
+    llm = {
+        "model": "openai:gpt-test",
+        "base_url": "https://models.example.org/v1",
+        "credential_source": "stored",
+        "credential_id": secret_id,
+        "credential_target": "origin:https://models.example.org",
+    }
+    run = await manager.create_run(
+        agent_id="chat_agent",
+        params={"prompt": "hello"},
+        agent_init={},
+        llm=llm,
+        runner={},
+        extra={
+            "embedding": {
+                "model": None,
+                "credential_source": "none",
+            }
+        },
+    )
+    await manager._execute_run(run["run_id"])
+
+    process = captured["process"]
+    payload = json.loads(bytes(process.stdin.data).decode("utf-8"))
+    assert payload == {"llm_api_key": secret, "embedding_api_key": None}
+    assert secret not in " ".join(captured["cmd"])
+    assert secret not in json.dumps(captured["kwargs"]["env"])
+
+    for path in (tmp_path / "dashboard").rglob("*"):
+        if path.is_file():
+            assert secret not in path.read_text(
+                encoding="utf-8", errors="ignore"
+            )

--- a/tests/dashboard/test_settings_config.py
+++ b/tests/dashboard/test_settings_config.py
@@ -36,6 +36,7 @@ def test_dashboard_config_maps_cli_llm_model_to_dashboard_settings(tmp_path):
             "model": "openai:gpt-test",
             "base_url": "https://models.example.org/v1",
             "api_key_env": "SAFE_API_KEY",
+            "credential_source": "environment",
             "max_tokens": 4096,
             "temperature": 0.3,
             "model_kwargs": {
@@ -69,6 +70,7 @@ def test_dashboard_config_maps_cli_emb_model_to_dashboard_settings(tmp_path):
         "model": "openai:text-embedding-3-large",
         "base_url": "https://models.example.org/v1",
         "api_key_env": "SAFE_EMBEDDING_KEY",
+        "credential_source": "environment",
         "model_kwargs": {"dimensions": 1024, "timeout": 60},
     }
 

--- a/tests/dashboard/test_worker_main.py
+++ b/tests/dashboard/test_worker_main.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import io
 import os
 
+import pytest
+
+import ursa_dashboard.worker_main as worker_main
 from ursa_dashboard.worker_main import _init_embedding, _init_llm
 
 
@@ -74,8 +78,8 @@ def test_dashboard_worker_passes_configured_base_url(monkeypatch):
     })
 
     assert captured["base_url"] == "https://models.example.org/v1"
-    assert os.environ["OPENAI_BASE_URL"] == ("https://models.example.org/v1")
-    assert os.environ["OPENAI_API_BASE"] == ("https://models.example.org/v1")
+    assert "OPENAI_BASE_URL" not in os.environ
+    assert "OPENAI_API_BASE" not in os.environ
 
 
 def test_dashboard_worker_returns_none_without_embedding_model():
@@ -110,5 +114,58 @@ def test_dashboard_worker_initializes_embedding_model(monkeypatch):
         "base_url": "https://models.example.org/v1",
         "dimensions": 1024,
     }
-    assert os.environ["OPENAI_BASE_URL"] == "https://models.example.org/v1"
-    assert os.environ["OPENAI_API_BASE"] == "https://models.example.org/v1"
+    assert "OPENAI_BASE_URL" not in os.environ
+    assert "OPENAI_API_BASE" not in os.environ
+
+
+def test_dashboard_worker_uses_override_without_exporting_secret(monkeypatch):
+    captured: dict = {}
+
+    def fake_init_chat_model(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        "langchain.chat_models.init_chat_model", fake_init_chat_model
+    )
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    _init_llm(
+        {"model": "openai:gpt-test", "api_key_env": "MISSING_KEY"},
+        api_key_override="pipe-secret",
+    )
+
+    assert captured["api_key"] == "pipe-secret"
+    assert "OPENAI_API_KEY" not in os.environ
+
+
+def test_dashboard_worker_reads_secret_payload_from_stdin(monkeypatch):
+    class FakeStdin:
+        buffer = io.BytesIO(
+            b'{"llm_api_key":"pipe-secret","embedding_api_key":null}\n'
+        )
+
+    monkeypatch.setattr(worker_main.sys, "stdin", FakeStdin())
+
+    assert worker_main._read_secrets_stdin() == {
+        "llm_api_key": "pipe-secret",
+        "embedding_api_key": None,
+    }
+
+
+def test_dashboard_worker_rejects_literal_key_config(monkeypatch):
+    monkeypatch.setattr(
+        "langchain.chat_models.init_chat_model", lambda **_kwargs: object()
+    )
+
+    with pytest.raises(ValueError, match="Literal LLM API keys"):
+        _init_llm({"model": "openai:gpt-test", "api_key": "secret"})
+
+
+def test_worker_error_redaction_removes_full_secret() -> None:
+    assert (
+        worker_main._redact_secrets(
+            "provider rejected pipe-secret", ["pipe-secret"]
+        )
+        == "provider rejected [REDACTED]"
+    )

--- a/tests/dashboard/test_worker_main.py
+++ b/tests/dashboard/test_worker_main.py
@@ -82,9 +82,103 @@ def test_dashboard_worker_passes_configured_base_url(monkeypatch):
     assert "OPENAI_API_BASE" not in os.environ
 
 
+def test_dashboard_worker_prepends_openai_for_bare_model_without_provider(
+    monkeypatch,
+):
+    captured: dict = {}
+
+    def fake_init_chat_model(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        "langchain.chat_models.init_chat_model", fake_init_chat_model
+    )
+
+    _init_llm({"model": "gpt-test", "api_key_env": None})
+
+    # No provider prefix and no model_provider kwarg -> default to openai:.
+    assert captured["model"] == "openai:gpt-test"
+    assert "model_provider" not in captured
+
+
+def test_dashboard_worker_keeps_bare_model_when_model_provider_given(
+    monkeypatch,
+):
+    captured: dict = {}
+
+    def fake_init_chat_model(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        "langchain.chat_models.init_chat_model", fake_init_chat_model
+    )
+
+    _init_llm({
+        "model": "gpt-test",
+        "api_key_env": None,
+        "model_kwargs": {"model_provider": "openai"},
+    })
+
+    # An explicit model_provider must NOT trigger the "openai:" prepend,
+    # otherwise the endpoint receives a doubly-qualified "openai:gpt-test".
+    assert captured["model"] == "gpt-test"
+    assert captured["model_provider"] == "openai"
+
+
+def test_dashboard_worker_leaves_prefixed_model_with_provider_untouched(
+    monkeypatch,
+):
+    captured: dict = {}
+
+    def fake_init_chat_model(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        "langchain.chat_models.init_chat_model", fake_init_chat_model
+    )
+
+    _init_llm({
+        "model": "openai:gpt-test",
+        "api_key_env": None,
+        "model_kwargs": {"model_provider": "openai"},
+    })
+
+    # A genuinely double-specified config is left as-is (allowed to error
+    # downstream); we do not silently rewrite the user's input.
+    assert captured["model"] == "openai:gpt-test"
+    assert captured["model_provider"] == "openai"
+
+
 def test_dashboard_worker_returns_none_without_embedding_model():
     assert _init_embedding({}) is None
     assert _init_embedding({"model": "disabled"}) is None
+
+
+def test_dashboard_worker_embedding_keeps_bare_model_with_provider(monkeypatch):
+    captured: dict = {}
+
+    def fake_init_embeddings(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        "langchain.embeddings.init_embeddings", fake_init_embeddings
+    )
+    monkeypatch.setenv("SAFE_EMBEDDING_KEY", "test-secret")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+
+    _init_embedding({
+        "model": "text-embedding-custom",
+        "api_key_env": "SAFE_EMBEDDING_KEY",
+        "model_kwargs": {"model_provider": "openai"},
+    })
+
+    assert captured["model"] == "text-embedding-custom"
+    assert captured["model_provider"] == "openai"
 
 
 def test_dashboard_worker_initializes_embedding_model(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -7368,6 +7368,7 @@ dependencies = [
 [package.optional-dependencies]
 dashboard = [
     { name = "fastapi" },
+    { name = "keyring" },
     { name = "uvicorn" },
 ]
 dsi = [
@@ -7432,6 +7433,7 @@ requires-dist = [
     { name = "fastmcp", specifier = "~=3.0" },
     { name = "jsonargparse", specifier = ">=4.45.0" },
     { name = "justext", specifier = ">=3.0.2" },
+    { name = "keyring", marker = "extra == 'dashboard'", specifier = ">=25.0.0,<26.0.0" },
     { name = "langchain", specifier = ">=1.3.2" },
     { name = "langchain-anthropic", specifier = ">=1.4" },
     { name = "langchain-chroma", specifier = ">=1.0.0" },


### PR DESCRIPTION
Three important usability fixes:

- Making ursa mcp-server accept the --config argument
  - It could already be used with ursa --config config.yaml mcp-server, but that was inconsistent with the rest of the config usage. Now ursa mcp-server --config config.yaml will work. 
- Allowing the API key to be set to the keychain for Windows and Mac from the dashboard.
  - Allows users to set their API key in the dashboard in a secure way to avoid having to set the key as an environmental variable.
- Fixed a bug in the dashboard only where setting model provider in the kwargs would not work properly.