### PR TITLE
Version Specific Docs 

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -13,6 +13,8 @@ jobs:
     permissions:
       # IMPORTANT: this permission is mandatory for Trusted Publishing
       id-token: write
+      contents: write
+      actions: write
     steps:
       - uses: actions/checkout@v4
 
@@ -25,3 +27,17 @@ jobs:
       # retrieve your distributions here
       - name: Publish package distributions to PyPI
         run: uv build && uv publish
+
+      - name: Tag latest release
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
+        run: |
+          git tag --force latest
+          git push --force origin refs/tags/latest
+
+      # Tags pushed with GITHUB_TOKEN do not start other workflows, so dispatch
+      # the site workflow explicitly while retaining its normal tag trigger.
+      - name: Deploy latest documentation
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run site.yml --ref latest

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,39 +1,63 @@
 name: Generate Site
-
 on:
   push:
+    branches:
+      - main
     tags:
-      - "v*"
+      - v*
+      - latest
     paths:
-      - 'docs/**'
-      - 'mkdocs.yml'
-      - 'pyproject.toml'
-      - 'src/**'
-  workflow_dispatch:  # allow manual trigger
-
+      - docs/**
+      - mkdocs.yml
+      - pyproject.toml
+      - src/**
+  workflow_dispatch: # allow manual trigger
+permissions:
+  contents: write
+concurrency:
+  group: docs-deployment
+  cancel-in-progress: false
 jobs:
   build-site:
     runs-on: ubuntu-latest
-    # Skip pre-releases
-    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
+    # Publish main continuously and stable version tags as releases.
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/tags/latest' || (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-'))
     steps:
       - uses: actions/checkout@v4
-
+        with:
+          fetch-depth: 0
       - name: Install uv
         uses: astral-sh/setup-uv@v6
-
       - name: Sync docs deps only
         run: uv sync --group docs --no-dev
+      - name: Configure Git author
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - name: Deploy main documentation
+        if: github.ref == 'refs/heads/main'
+        shell: bash
+        run: |
+          push_args=(--push)
+          if [[ "${ACT:-}" == "true" ]]; then
+            push_args=()
+          fi
+          uv run --no-sync mike deploy "${push_args[@]}" main
+      - name: Deploy release documentation
+        if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/tags/latest'
+        shell: bash
+        run: |
+          push_args=(--push)
+          if [[ "${ACT:-}" == "true" ]]; then
+            push_args=()
+          fi
 
-      - name: Build and deploy MkDocs site
-        run: uv run mkdocs gh-deploy --force
-
-      # - name: Build docs (strict)
-      #   run: uv run mkdocs build --strict
-
-      # - name: Upload site artifact
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: site
-      #     path: site/
-
+          if [[ "$GITHUB_REF_NAME" == v* ]]; then
+            version="${GITHUB_REF_NAME#v}"
+          else
+            release_tag=$(git tag --points-at HEAD --list 'v*' --sort=-version:refname | head -n 1)
+            test -n "$release_tag"
+            version="${release_tag#v}"
+          fi
+          uv run --no-sync mike deploy "${push_args[@]}" --update-aliases "$version" latest
+          uv run --no-sync mike set-default "${push_args[@]}" latest

--- a/docs/best-practices/contributing.md
+++ b/docs/best-practices/contributing.md
@@ -31,7 +31,7 @@ Adjust commands to match the current project configuration.
 ## Build documentation locally
 
 ```bash
-uv run mkdocs serve
+just docs
 ```
 
 Then open the local URL printed by MkDocs.
@@ -41,6 +41,18 @@ To build once:
 ```bash
 uv run mkdocs build
 ```
+
+Published documentation is versioned with Mike. To preview the versions already
+present on the local `gh-pages` branch, run:
+
+```bash
+uv run mike serve
+```
+
+The documentation workflow publishes `main` after documentation changes land on
+the main branch. Stable `v*` tags publish a version without the leading `v`, move
+the `latest` alias to that release, and make `latest` the default site version.
+Pre-release tags are not published.
 
 ## Documentation style
 

--- a/docs/configuration/mcp.md
+++ b/docs/configuration/mcp.md
@@ -1,9 +1,12 @@
 # MCP server configuration
 
-URSA can connect to external MCP servers and can also run as an MCP server itself.
+URSA can connect to external [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers and can also [run as an MCP server itself][getting-started-mcp-server].
 
 This page covers configuring external MCP servers for URSA to use. To serve
 URSA over MCP, see [Getting Started - MCP Server][getting-started-mcp-server].
+
+!!! note
+    This page assumes basic familiarity with the [Model Context Protocol](https://modelcontextprotocol.io/docs/learn/architecture)
 
 ## External stdio MCP server
 
@@ -39,3 +42,9 @@ ursa --config config.yaml
 MCP servers can expose powerful tools. Only connect MCP servers that you trust, and prefer dedicated workspaces and endpoint allowlists for sensitive workflows.
 
 See [Sandboxing and information control][sandboxing-and-information-control].
+
+## Creating an MCP server
+
+Creating an MCP server that hosts tools is beyond the scope of the URSA documentation.
+For Python servers, we recommend [FastMCP](https://gofastmcp.com).
+As an MCP client, URSA can connect to any MCP server regardless of which SDK was used to implement it.

--- a/docs/getting-started/mcp-server.md
+++ b/docs/getting-started/mcp-server.md
@@ -2,6 +2,9 @@
 
 URSA can run as a [Model Context Protocol](https://modelcontextprotocol.io/) server so other MCP-compatible clients or agent frameworks can use URSA capabilities.
 
+!!! note
+    This guide assumes basic familiarity with the [Model Context Protocol](https://modelcontextprotocol.io/docs/learn/architecture).
+
 ## Prerequisites
 
 - URSA is installed.
@@ -19,7 +22,6 @@ Create `config.yaml`:
 llm_model:
   model: openai:gpt-5.4
   api_key_env: OPENAI_API_KEY
-
 workspace: ./ursa-mcp-workspace
 ```
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block outdated %}
+  You are not viewing the latest published version of the documentation.
+  <a href="{{ '../' ~ base_url }}">
+    <strong>Go to the latest version.</strong>
+  </a>
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,18 @@
 site_name: URSA
+site_url: https://lanl.github.io/ursa/
 repo_url: https://github.com/lanl/ursa
 
 theme:
   name: material
+  custom_dir: docs/overrides
   logo: assets/favicon.png
   favicon: assets/favicon.png
+
+extra:
+  version:
+    provider: mike
+    default: latest
+    alias: true
 
 markdown_extensions:
   - admonition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ ursa-dashboard = "ursa_dashboard.main:app"
 
 [project.urls]
 Homepage = "https://github.com/lanl/ursa"
-Documentation = "https://github.com/lanl/ursa/tree/main/docs"
+Documentation = "https://lanl.github.io/ursa/"
 Repository = "https://github.com/lanl/ursa"
 Issues = "https://github.com/lanl/ursa/issues"
 
@@ -155,6 +155,7 @@ dev = [
     "ruff==0.12.10",
 ]
 docs = [
+    "mike>=2.1.3,<3",
     "mkdocs>=1.6.1",
     "mkdocs-autorefs>=1.4.3",
     "mkdocs-material>=9.6.21",

--- a/uv.lock
+++ b/uv.lock
@@ -3488,6 +3488,23 @@ wheels = [
 ]
 
 [[package]]
+name = "mike"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "mkdocs" },
+    { name = "pyparsing" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "verspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/47/fa87e9d56bef16cdfe34b059a437e8c6f7ec6f1b9c378871c3cf95ebea9c/mike-2.2.0.tar.gz", hash = "sha256:1e3858e32c0f125aac14432fc7848434358f9ae0962c5c5cde387ad47f6ad25e", size = 38450, upload-time = "2026-04-14T04:59:03.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/8e/56ccb09c7232a55403a7637caa21922f3b65901a37f5e8bdb405d0de0946/mike-2.2.0-py3-none-any.whl", hash = "sha256:e1f4981c1152eec7c2490a3401142292cc47d686194188416db2648fdfe1d040", size = 34026, upload-time = "2026-04-14T04:59:02.602Z" },
+]
+
+[[package]]
 name = "mistune"
 version = "3.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -7438,6 +7455,7 @@ dev = [
     { name = "scikit-optimize" },
 ]
 docs = [
+    { name = "mike" },
     { name = "mkdocs" },
     { name = "mkdocs-autorefs" },
     { name = "mkdocs-material" },
@@ -7506,6 +7524,7 @@ dev = [
     { name = "scikit-optimize", specifier = ">=0.10.2" },
 ]
 docs = [
+    { name = "mike", specifier = ">=2.1.3,<3" },
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-autorefs", specifier = ">=1.4.3" },
     { name = "mkdocs-material", specifier = ">=9.6.21" },
@@ -7672,6 +7691,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "verspec"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/44/8126f9f0c44319b2efc65feaad589cadef4d77ece200ae3c9133d58464d0/verspec-0.1.0.tar.gz", hash = "sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e", size = 27123, upload-time = "2020-11-30T02:24:09.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/ce/3b6fee91c85626eaf769d617f1be9d2e15c1cca027bbdeb2e0d751469355/verspec-0.1.0-py3-none-any.whl", hash = "sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31", size = 19640, upload-time = "2020-11-30T02:24:08.387Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Docs are now versioned by release, plus a main and latest version.
Also added a recommendation to use FastMCP if creating an MCP server
Warning banners will be displayed for non-latest versions

The nice win here is that updates to the docs will be visible immediately, instead of
only after a new pypi version is pushed

- **feat: publish versioned docs**
- **docs: recommend fastmcp for serving tools with mcp**
