### PR TITLE
No default workspace dashboard

### DIFF
--- a/docs/getting-started/dashboard.md
+++ b/docs/getting-started/dashboard.md
@@ -74,7 +74,9 @@ the session is deleted or the dashboard stops.
 The dashboard no longer creates a hidden default session workspace under
 `~/.cache/ursa`. Older sessions without an explicit workspace remain available,
 but the dashboard prompts for a folder or temporary workspace before their next
-run. A user-selected folder is never deleted when its dashboard session is
+run. When an older session still has its former UUID-named cached workspace, the
+folder field is prefilled with that path so existing work remains easy to
+recover. A user-selected folder is never deleted when its dashboard session is
 deleted.
 
 ## Launch an agent team or symposium

--- a/docs/getting-started/dashboard.md
+++ b/docs/getting-started/dashboard.md
@@ -63,6 +63,20 @@ The raw key is never written to dashboard settings, sessions, run records, or
 worker configuration files. In remote dashboard mode, credential changes must
 be served over HTTPS.
 
+## Choose a session workspace
+
+Every new dashboard session requires an explicit workspace choice. Select a
+folder you can find and reuse, or choose **Temporary workspace** for disposable
+work. Temporary mode behaves like `ursa --workspace tmp`: the dashboard creates
+the workspace in the operating system's temporary directory and removes it when
+the session is deleted or the dashboard stops.
+
+The dashboard no longer creates a hidden default session workspace under
+`~/.cache/ursa`. Older sessions without an explicit workspace remain available,
+but the dashboard prompts for a folder or temporary workspace before their next
+run. A user-selected folder is never deleted when its dashboard session is
+deleted.
+
 ## Launch an agent team or symposium
 
 Open **Environment runs** from the dashboard sidebar. The page provides **New

--- a/src/ursa_dashboard/api_models.py
+++ b/src/ursa_dashboard/api_models.py
@@ -143,6 +143,8 @@ class SessionCreateRequest(BaseModel):
     agent_id: str | None = None
     agent_name: str | None = None
     title: str | None = None
+    workspace_path: str | None = None
+    workspace_mode: Literal["folder", "temporary"] | None = None
 
 
 class SessionPatchRequest(BaseModel):
@@ -162,8 +164,9 @@ class SessionMessageRequest(BaseModel):
 
 
 class SessionWorkspaceSetRequest(BaseModel):
-    # Absolute path to use as this session's workspace. Pass null or an empty
-    # string to reset to the dashboard-managed default session workspace.
+    # ``folder`` requires an absolute path; ``temporary`` creates an OS-temp
+    # workspace; ``unset`` removes the selection without choosing a fallback.
+    mode: Literal["folder", "temporary", "unset"] = "folder"
     path: str | None = None
 
 
@@ -211,7 +214,9 @@ class SessionWorkspaceListResponse(BaseModel):
     files: list[dict[str, Any]]
     workspace_path: str | None = None
     default_workspace_path: str | None = None
-    is_default_workspace: bool = True
+    is_default_workspace: bool = False
+    workspace_mode: Literal["folder", "temporary"] | None = None
+    configured: bool = False
 
 
 class SessionFileMetaResponse(BaseModel):

--- a/src/ursa_dashboard/app.py
+++ b/src/ursa_dashboard/app.py
@@ -127,6 +127,7 @@ from .sessions import (
     build_prompt_from_messages,
     create_temporary_workspace,
     delete_temporary_workspace,
+    session_paths,
 )
 from .sessions import (
     create_session as session_create_session,
@@ -1740,10 +1741,27 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
             )
         return workspace
 
+    def _legacy_session_workspace_suggestion(
+        session_id: str, sess: dict[str, Any]
+    ) -> Path | None:
+        """Return the former cached workspace only for pre-migration sessions."""
+
+        if "workspace_path" in sess or "workspace_mode" in sess:
+            return None
+        legacy_workspace = session_paths(
+            rm.dashboard_root, session_id
+        ).workspace_dir.resolve()
+        if legacy_workspace.is_dir():
+            return legacy_workspace
+        return None
+
     def _workspace_response(
         session_id: str, sess: dict[str, Any], files: list[dict[str, Any]]
     ) -> SessionWorkspaceListResponse:
         ws = _session_workspace_dir(session_id, sess)
+        legacy_suggestion = _legacy_session_workspace_suggestion(
+            session_id, sess
+        )
         configured = ws is not None
         mode = str(sess.get("workspace_mode") or "").strip() or None
         if configured and mode not in {"folder", "temporary"}:
@@ -1755,7 +1773,11 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
             "agent_id": str(sess.get("agent_id") or ""),
             "files": files,
             "workspace_path": str(ws) if ws is not None else None,
-            "default_workspace_path": None,
+            "default_workspace_path": (
+                str(legacy_suggestion)
+                if legacy_suggestion is not None
+                else None
+            ),
             "is_default_workspace": False,
             "workspace_mode": mode,
             "configured": configured,
@@ -3621,8 +3643,11 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
     if (!el) return;
     const info = state.workspaceInfo || {};
     if (!state.activeSessionId || !info.workspace_path) {
-      el.textContent = state.activeSessionId ? 'Workspace not configured' : '';
-      el.title = '';
+      const legacyPath = info.default_workspace_path || '';
+      el.textContent = state.activeSessionId
+        ? (legacyPath ? `Workspace not configured · Previous workspace: ${legacyPath}` : 'Workspace not configured')
+        : '';
+      el.title = legacyPath;
       return;
     }
     const prefix = info.workspace_mode === 'temporary' ? 'Temporary workspace' : 'Workspace';
@@ -3975,7 +4000,9 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
     }
     const selection = await chooseWorkspaceSelection({
       title: state.workspaceInfo?.configured ? 'Change session workspace' : 'Choose a session workspace',
-      currentPath: state.workspaceInfo?.workspace_mode === 'folder' ? (state.workspaceInfo?.workspace_path || '') : '',
+      currentPath: state.workspaceInfo?.workspace_mode === 'folder'
+        ? (state.workspaceInfo?.workspace_path || '')
+        : (state.workspaceInfo?.default_workspace_path || ''),
     });
     if (!selection) return;
     try {

--- a/src/ursa_dashboard/app.py
+++ b/src/ursa_dashboard/app.py
@@ -125,7 +125,8 @@ from .sessions import (
 )
 from .sessions import (
     build_prompt_from_messages,
-    session_paths,
+    create_temporary_workspace,
+    delete_temporary_workspace,
 )
 from .sessions import (
     create_session as session_create_session,
@@ -292,6 +293,7 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
     async def _shutdown() -> None:
         await environment_rm.shutdown()
         await rm.shutdown()
+        _cleanup_temporary_session_workspaces()
 
     # ----------------------------
     # Agents
@@ -602,13 +604,28 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
             agent_id.startswith("demo_") and not _include_demo_agents()
         ):
             raise HTTPException(status_code=404, detail="Unknown agent_id")
-        settings_snapshot = settings_store.load().model_dump(mode="json")
-        sess = session_create_session(
-            rm.dashboard_root,
-            agent_id=agent_id,
-            agent_name=agent_name,
-            title=req.title,
+        workspace_mode, workspace_path = _prepare_workspace_selection(
+            mode=req.workspace_mode,
+            path=req.workspace_path,
+            require_selection=True,
         )
+        settings_snapshot = settings_store.load().model_dump(mode="json")
+        try:
+            sess = session_create_session(
+                rm.dashboard_root,
+                agent_id=agent_id,
+                agent_name=agent_name,
+                title=req.title,
+                workspace_path=workspace_path,
+                workspace_mode=workspace_mode,
+            )
+        except Exception:
+            if workspace_mode == "temporary":
+                delete_temporary_workspace({
+                    "workspace_mode": workspace_mode,
+                    "workspace_path": str(workspace_path or ""),
+                })
+            raise
         sess = session_update_session(
             rm.dashboard_root,
             sess["session_id"],
@@ -738,6 +755,7 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
             sess = session_read_session(rm.dashboard_root, session_id)
         except Exception:
             raise HTTPException(status_code=404, detail="Unknown session_id")
+        workspace_dir = _require_session_workspace_dir(session_id, sess)
 
         try:
             assert_no_raw_api_key(req.llm or {}, context="message.llm")
@@ -798,8 +816,7 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
             agent_init["agent_name"] = agent_name
         agent_init["group"] = dashboard_group
 
-        # Use a shared per-session workspace directory so artifacts persist across turns.
-        workspace_dir = _session_workspace_dir(session_id, sess)
+        # Use the workspace explicitly selected for this session.
         workspace_dir.mkdir(parents=True, exist_ok=True)
 
         run = await rm.create_run(
@@ -1626,13 +1643,70 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
     # Session workspace (shared across turns)
     # ----------------------------
 
-    def _session_default_workspace_dir(session_id: str) -> Path:
-        sp = session_paths(rm.dashboard_root, session_id)
-        return sp.workspace_dir.resolve()
+    def _cleanup_temporary_session_workspaces() -> None:
+        for sess in session_list_sessions(rm.dashboard_root, limit=100_000):
+            if sess.get("workspace_mode") != "temporary":
+                continue
+            delete_temporary_workspace(sess)
+            with contextlib.suppress(Exception):
+                session_update_session(
+                    rm.dashboard_root,
+                    str(sess["session_id"]),
+                    {"workspace_path": None, "workspace_mode": None},
+                )
+
+    def _prepare_workspace_selection(
+        *,
+        mode: str | None,
+        path: str | None,
+        require_selection: bool = False,
+    ) -> tuple[str | None, Path | None]:
+        normalized_mode = str(mode or "").strip().lower() or None
+        if normalized_mode is None:
+            if require_selection:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "A workspace is required. Choose a workspace folder "
+                        "or use a temporary workspace."
+                    ),
+                )
+            return None, None
+
+        if normalized_mode == "temporary":
+            return "temporary", create_temporary_workspace()
+        if normalized_mode != "folder":
+            raise HTTPException(
+                status_code=400, detail="Invalid workspace mode"
+            )
+
+        raw = str(path or "").strip()
+        if not raw:
+            raise HTTPException(
+                status_code=400,
+                detail="Choose or enter a workspace folder.",
+            )
+        workspace = Path(raw).expanduser()
+        if not workspace.is_absolute():
+            raise HTTPException(
+                status_code=400, detail="Workspace path must be absolute"
+            )
+        try:
+            workspace.mkdir(parents=True, exist_ok=True)
+        except Exception as e:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Could not create or access workspace folder: {e}",
+            ) from e
+        if not workspace.is_dir():
+            raise HTTPException(
+                status_code=400, detail="Workspace path is not a directory"
+            )
+        return "folder", workspace.resolve()
 
     def _session_workspace_dir(
         session_id: str, sess: dict[str, Any] | None = None
-    ) -> Path:
+    ) -> Path | None:
         if sess is None:
             sess = session_read_session(rm.dashboard_root, session_id)
         custom = str(sess.get("workspace_path") or "").strip()
@@ -1643,24 +1717,48 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
                     status_code=400,
                     detail="Session workspace path is not absolute",
                 )
-            return p.resolve()
-        return _session_default_workspace_dir(session_id)
+            resolved = p.resolve()
+            if (
+                sess.get("workspace_mode") == "temporary"
+                and not resolved.is_dir()
+            ):
+                return None
+            return resolved
+        return None
+
+    def _require_session_workspace_dir(
+        session_id: str, sess: dict[str, Any] | None = None
+    ) -> Path:
+        workspace = _session_workspace_dir(session_id, sess)
+        if workspace is None:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "This session does not have a workspace. Choose a workspace "
+                    "folder or use a temporary workspace before continuing."
+                ),
+            )
+        return workspace
 
     def _workspace_response(
         session_id: str, sess: dict[str, Any], files: list[dict[str, Any]]
     ) -> SessionWorkspaceListResponse:
         ws = _session_workspace_dir(session_id, sess)
+        configured = ws is not None
+        mode = str(sess.get("workspace_mode") or "").strip() or None
+        if configured and mode not in {"folder", "temporary"}:
+            # Backwards compatibility for sessions that already used an explicit
+            # custom workspace before workspace modes were recorded.
+            mode = "folder"
         data = {
             "session_id": session_id,
             "agent_id": str(sess.get("agent_id") or ""),
             "files": files,
-            "workspace_path": str(ws),
-            "default_workspace_path": str(
-                _session_default_workspace_dir(session_id)
-            ),
-            "is_default_workspace": not bool(
-                str(sess.get("workspace_path") or "").strip()
-            ),
+            "workspace_path": str(ws) if ws is not None else None,
+            "default_workspace_path": None,
+            "is_default_workspace": False,
+            "workspace_mode": mode,
+            "configured": configured,
         }
         return SessionWorkspaceListResponse(**data)
 
@@ -1678,7 +1776,11 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
             raise HTTPException(status_code=404, detail="Unknown session_id")
 
         ws = _session_workspace_dir(session_id, sess)
-        files = scan_artifacts(ws, exclude_dirs={"__pycache__"})
+        files = (
+            scan_artifacts(ws, exclude_dirs={"__pycache__"})
+            if ws is not None
+            else []
+        )
         return _workspace_response(session_id, sess, files)
 
     @app.patch(
@@ -1700,32 +1802,29 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
                 detail="Cannot change the workspace while this session has an active run",
             )
 
-        raw = "" if req.path is None else str(req.path).strip()
-        patch: dict[str, Any]
-        if not raw:
-            patch = {"workspace_path": None}
+        old_session = dict(sess)
+        if req.mode == "unset":
+            mode, workspace = None, None
         else:
-            p = Path(raw).expanduser()
-            if not p.is_absolute():
-                raise HTTPException(
-                    status_code=400, detail="Workspace path must be absolute"
-                )
-            try:
-                p.mkdir(parents=True, exist_ok=True)
-            except Exception as e:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Could not create or access workspace folder: {e}",
-                )
-            if not p.is_dir():
-                raise HTTPException(
-                    status_code=400, detail="Workspace path is not a directory"
-                )
-            patch = {"workspace_path": str(p.resolve())}
+            mode, workspace = _prepare_workspace_selection(
+                mode=req.mode,
+                path=req.path,
+                require_selection=True,
+            )
+        patch = {
+            "workspace_path": str(workspace) if workspace is not None else None,
+            "workspace_mode": mode,
+        }
 
         sess2 = session_update_session(rm.dashboard_root, session_id, patch)
+        if old_session.get("workspace_path") != sess2.get("workspace_path"):
+            delete_temporary_workspace(old_session)
         ws = _session_workspace_dir(session_id, sess2)
-        files = scan_artifacts(ws, exclude_dirs={"__pycache__"})
+        files = (
+            scan_artifacts(ws, exclude_dirs={"__pycache__"})
+            if ws is not None
+            else []
+        )
         return _workspace_response(session_id, sess2, files)
 
     def _choose_folder_with_tk(initial_dir: str | None = None) -> str | None:
@@ -1830,6 +1929,33 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
         raise RuntimeError(msg)
 
     @app.post(
+        "/workspace/choose",
+        dependencies=[Depends(require_auth)],
+    )
+    async def choose_workspace_folder() -> dict[str, str | None]:
+        """Open the dashboard host's folder chooser before a session exists."""
+
+        try:
+            selected = await asyncio.to_thread(
+                _choose_workspace_folder, str(Path.home())
+            )
+        except Exception as e:
+            raise HTTPException(
+                status_code=501,
+                detail=(
+                    "Could not open a native folder chooser on the dashboard host. "
+                    "If the dashboard is running remotely or headlessly, enter the "
+                    f"path manually. Details: {e}"
+                ),
+            ) from e
+        if not selected:
+            return {"path": None}
+        _, workspace = _prepare_workspace_selection(
+            mode="folder", path=selected, require_selection=True
+        )
+        return {"path": str(workspace)}
+
+    @app.post(
         "/sessions/{session_id}/workspace/choose",
         response_model=SessionWorkspaceListResponse,
         dependencies=[Depends(require_auth)],
@@ -1851,7 +1977,8 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
         current = _session_workspace_dir(session_id, sess)
         try:
             selected = await asyncio.to_thread(
-                _choose_workspace_folder, str(current)
+                _choose_workspace_folder,
+                str(current) if current is not None else str(Path.home()),
             )
         except Exception as e:
             raise HTTPException(
@@ -1864,33 +1991,26 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
             )
 
         if not selected:
-            files = scan_artifacts(current, exclude_dirs={"__pycache__"})
+            files = (
+                scan_artifacts(current, exclude_dirs={"__pycache__"})
+                if current is not None
+                else []
+            )
             return _workspace_response(session_id, sess, files)
 
-        p = Path(selected).expanduser()
-        if not p.is_absolute():
-            raise HTTPException(
-                status_code=400,
-                detail="Selected workspace path is not absolute",
-            )
-        try:
-            p.mkdir(parents=True, exist_ok=True)
-        except Exception as e:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Could not create or access selected workspace folder: {e}",
-            )
-        if not p.is_dir():
-            raise HTTPException(
-                status_code=400,
-                detail="Selected workspace path is not a directory",
-            )
+        _, workspace = _prepare_workspace_selection(
+            mode="folder", path=selected, require_selection=True
+        )
 
         sess2 = session_update_session(
-            rm.dashboard_root, session_id, {"workspace_path": str(p.resolve())}
+            rm.dashboard_root,
+            session_id,
+            {"workspace_path": str(workspace), "workspace_mode": "folder"},
         )
+        if sess.get("workspace_path") != sess2.get("workspace_path"):
+            delete_temporary_workspace(sess)
         ws = _session_workspace_dir(session_id, sess2)
-        files = scan_artifacts(ws, exclude_dirs={"__pycache__"})
+        files = scan_artifacts(ws, exclude_dirs={"__pycache__"}) if ws else []
         return _workspace_response(session_id, sess2, files)
 
     async def _save_upload(
@@ -1943,7 +2063,7 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
         except Exception:
             raise HTTPException(status_code=404, detail="Unknown session_id")
 
-        ws = _session_workspace_dir(session_id, sess)
+        ws = _require_session_workspace_dir(session_id, sess)
 
         MAX_FILE_BYTES = 100 * 1024 * 1024  # 100MB per file
         saved: list[dict[str, Any]] = []
@@ -1996,7 +2116,7 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
         except Exception:
             raise HTTPException(status_code=404, detail="Unknown session_id")
 
-        ws = _session_workspace_dir(session_id, sess)
+        ws = _require_session_workspace_dir(session_id, sess)
         try:
             fp = safe_join(ws, path)
         except WorkspaceJailError:
@@ -2028,7 +2148,7 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
         except Exception:
             raise HTTPException(status_code=404, detail="Unknown session_id")
 
-        ws = _session_workspace_dir(session_id, sess)
+        ws = _require_session_workspace_dir(session_id, sess)
         try:
             fp = safe_join(ws, path)
         except WorkspaceJailError:
@@ -2165,7 +2285,7 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
         except Exception:
             raise HTTPException(status_code=404, detail="Unknown session_id")
 
-        ws = _session_workspace_dir(session_id, sess)
+        ws = _require_session_workspace_dir(session_id, sess)
         try:
             fp = safe_join(ws, path)
         except WorkspaceJailError:
@@ -3198,6 +3318,74 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
     });
   }
 
+  function chooseWorkspaceSelection({ title='Choose a workspace', currentPath='' } = {}) {
+    return new Promise((resolve) => {
+      const modal = $('#workspaceChoiceModal');
+      const titleEl = $('#workspaceChoiceTitle');
+      const input = $('#workspaceFolderInput');
+      const errorEl = $('#workspaceChoiceError');
+      const browseBtn = $('#browseWorkspaceBtn');
+      const folderBtn = $('#useWorkspaceFolderBtn');
+      const temporaryBtn = $('#useTemporaryWorkspaceBtn');
+      const closeBtn = $('#closeWorkspaceChoiceBtn');
+      const backdrop = $('#workspaceChoiceBackdrop');
+      if (!modal || !input || !browseBtn || !folderBtn || !temporaryBtn || !closeBtn || !backdrop) {
+        resolve(null);
+        return;
+      }
+
+      if (titleEl) titleEl.textContent = title;
+      input.value = currentPath || '';
+      if (errorEl) errorEl.textContent = '';
+
+      const cleanup = (choice) => {
+        modal.classList.remove('open');
+        browseBtn.onclick = null;
+        folderBtn.onclick = null;
+        temporaryBtn.onclick = null;
+        closeBtn.onclick = null;
+        backdrop.onclick = null;
+        document.removeEventListener('keydown', onKeydown);
+        resolve(choice);
+      };
+      const showError = (message) => {
+        if (errorEl) errorEl.textContent = String(message || '');
+      };
+      const onKeydown = (e) => {
+        if (e.key === 'Escape') cleanup(null);
+      };
+
+      browseBtn.onclick = async () => {
+        browseBtn.disabled = true;
+        showError('');
+        try {
+          const result = await api('POST', '/workspace/choose');
+          if (result?.path) input.value = result.path;
+        } catch (e) {
+          showError(e && e.message ? e.message : e);
+          input.focus();
+        } finally {
+          browseBtn.disabled = false;
+        }
+      };
+      folderBtn.onclick = () => {
+        const path = String(input.value || '').trim();
+        if (!path) {
+          showError('Choose or enter a workspace folder.');
+          input.focus();
+          return;
+        }
+        cleanup({ workspace_mode: 'folder', workspace_path: path });
+      };
+      temporaryBtn.onclick = () => cleanup({ workspace_mode: 'temporary' });
+      closeBtn.onclick = () => cleanup(null);
+      backdrop.onclick = () => cleanup(null);
+      document.addEventListener('keydown', onKeydown);
+      modal.classList.add('open');
+      input.focus();
+    });
+  }
+
   function renderAgents() {
     const list = $('#agentList');
     if (!list) return;
@@ -3433,11 +3621,11 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
     if (!el) return;
     const info = state.workspaceInfo || {};
     if (!state.activeSessionId || !info.workspace_path) {
-      el.textContent = '';
+      el.textContent = state.activeSessionId ? 'Workspace not configured' : '';
       el.title = '';
       return;
     }
-    const prefix = info.is_default_workspace ? 'Default workspace' : 'Workspace';
+    const prefix = info.workspace_mode === 'temporary' ? 'Temporary workspace' : 'Workspace';
     el.textContent = `${prefix}: ${info.workspace_path}`;
     el.title = info.workspace_path;
   }
@@ -3581,9 +3769,15 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
   }
 
   async function startSession(agentId, agentName='') {
+    const workspace = await chooseWorkspaceSelection({
+      title: 'Choose a workspace for this session',
+    });
+    if (!workspace) return;
     const payload = {};
     if (String(agentId || '').trim()) payload.agent_id = String(agentId || '').trim();
     if (String(agentName || '').trim()) payload.agent_name = String(agentName || '').trim();
+    payload.workspace_mode = workspace.workspace_mode;
+    if (workspace.workspace_path) payload.workspace_path = workspace.workspace_path;
     const res = await api('POST', '/sessions', payload);
     await refreshAgents();
     await refreshSessions();
@@ -3609,7 +3803,7 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
       alert('Cannot delete a session with an active run');
       return;
     }
-    if (!confirm('Delete this session? This will remove its messages and dashboard-managed session folder. Custom external workspace folders are not deleted.')) return;
+    if (!confirm('Delete this session? This removes its messages and any temporary workspace created for it. User-selected workspace folders are not deleted.')) return;
 
     await api('DELETE', `/sessions/${encodeURIComponent(sessionId)}`);
 
@@ -3700,7 +3894,9 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
       if (hint) hint.textContent = 'Select a session to view its workspace.';
       return;
     }
-    if (hint) hint.textContent = 'Click a file to preview, or download it.';
+    if (hint) hint.textContent = state.workspaceInfo?.configured
+      ? 'Click a file to preview, or download it.'
+      : 'Choose a workspace folder or use a temporary workspace to continue.';
 
     for (const f of (files || [])) {
       const row = document.createElement('div');
@@ -3726,7 +3922,9 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
     }
 
     if (!files || !files.length) {
-      list.innerHTML = '<div class="muted">No files in this session workspace yet.</div>';
+      list.innerHTML = state.workspaceInfo?.configured
+        ? '<div class="muted">No files in this session workspace yet.</div>'
+        : '<div class="muted">No workspace configured.</div>';
     }
   }
 
@@ -3759,9 +3957,12 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
     };
   }
 
-  async function setSessionWorkspace(path) {
+  async function setSessionWorkspace(selection) {
     if (!state.activeSessionId) return;
-    const res = await api('PATCH', `/sessions/${encodeURIComponent(state.activeSessionId)}/workspace`, { path });
+    const payload = selection?.workspace_mode === 'temporary'
+      ? { mode: 'temporary' }
+      : { mode: 'folder', path: selection?.workspace_path || '' };
+    const res = await api('PATCH', `/sessions/${encodeURIComponent(state.activeSessionId)}/workspace`, payload);
     state.workspaceInfo = res;
     renderWorkspace(res.files || []);
     await refreshSessions();
@@ -3772,39 +3973,22 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
       alert('Select a session first');
       return;
     }
+    const selection = await chooseWorkspaceSelection({
+      title: state.workspaceInfo?.configured ? 'Change session workspace' : 'Choose a session workspace',
+      currentPath: state.workspaceInfo?.workspace_mode === 'folder' ? (state.workspaceInfo?.workspace_path || '') : '',
+    });
+    if (!selection) return;
     try {
-      const res = await api('POST', `/sessions/${encodeURIComponent(state.activeSessionId)}/workspace/choose`);
-      state.workspaceInfo = res;
-      renderWorkspace(res.files || []);
-      await refreshSessions();
-      return;
-    } catch (e) {
-      const msg = String(e && e.message ? e.message : e);
-      const useManual = confirm(`${msg}\n\nOpen the manual path entry fallback instead?`);
-      if (!useManual) return;
-    }
-
-    const cur = state.workspaceInfo?.workspace_path || '';
-    const next = prompt('Workspace folder path\n\nEnter an absolute folder path. The folder will be created if needed. Leave blank to reset to the dashboard-managed default workspace.', cur);
-    if (next === null) return;
-    try {
-      await setSessionWorkspace(next);
+      await setSessionWorkspace(selection);
     } catch (e) {
       alert(String(e && e.message ? e.message : e));
     }
   }
 
-  async function resetWorkspaceFolder() {
-    if (!state.activeSessionId) {
-      alert('Select a session first');
-      return;
-    }
-    if (!confirm('Reset this session to its dashboard-managed default workspace? Existing files in the current folder will not be moved or deleted.')) return;
-    try {
-      await setSessionWorkspace('');
-    } catch (e) {
-      alert(String(e && e.message ? e.message : e));
-    }
+  async function ensureSessionWorkspaceConfigured() {
+    if (state.workspaceInfo?.configured) return true;
+    await chooseWorkspaceFolder();
+    return !!state.workspaceInfo?.configured;
   }
 
   async function sendMessage() {
@@ -3812,6 +3996,7 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
     const ta = $('#messageInput');
     const text = (ta && ta.value || '').trim();
     if (!text) return;
+    if (!(await ensureSessionWorkspaceConfigured())) return;
 
     const sendBtn = $('#sendMsgBtn');
     if (sendBtn) sendBtn.disabled = true;
@@ -4512,11 +4697,12 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
     const uploadBtn = $('#uploadFilesBtn');
     const uploadInput = $('#uploadInput');
     if (uploadBtn && uploadInput) {
-      uploadBtn.onclick = () => {
+      uploadBtn.onclick = async () => {
         if (!state.activeSessionId) {
           alert('Select a session first');
           return;
         }
+        if (!(await ensureSessionWorkspaceConfigured())) return;
         uploadInput.value = '';
         uploadInput.click();
       };
@@ -5018,8 +5204,21 @@ pre.plain { margin:0; white-space: pre; overflow:auto; font-family: var(--mono);
   grid-template-columns: 1fr 1fr;
   gap: 10px;
 }
+.workspaceChoiceBody { display: grid; gap: 14px; }
+.workspaceChoiceSection {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  background: var(--panelSolid);
+}
+.workspaceChoiceInputRow { display: grid; grid-template-columns: 1fr auto; gap: 8px; margin-top: 10px; }
+.workspaceChoiceInputRow .input { width: 100%; min-width: 0; }
+.workspaceChoiceSection code { white-space: nowrap; }
+.workspaceChoiceError { min-height: 1.25em; color: #b3261e; }
+:root[data-theme="dark"] .workspaceChoiceError { color: #ffb4ab; }
 @media (max-width: 560px) {
   .modalActions { grid-template-columns: 1fr; }
+  .workspaceChoiceInputRow { grid-template-columns: 1fr; }
 }
 
 .settingsShell {
@@ -5567,7 +5766,7 @@ textarea.input { width: 100%; box-sizing: border-box; resize: vertical; }
         <div class="muted small" id="workspaceHint">Select a session to view its workspace.</div>
       </div>
       <div class="row" style="justify-content:flex-end">
-        <button class="btn" id="setWorkspaceBtn" type="button">Set folder</button>
+        <button class="btn" id="setWorkspaceBtn" type="button">Set workspace</button>
         <button class="btn" id="refreshFilesBtn" type="button">Refresh</button>
         <button class="btn" id="uploadFilesBtn" type="button">Upload</button>
       </div>
@@ -5599,6 +5798,41 @@ textarea.input { width: 100%; box-sizing: border-box; resize: vertical; }
     <div class="modalActions">
       <button class="btn primary" id="newSessionNamedBtn" type="button">New Named Agent Session</button>
       <button class="btn" id="newSessionNonPersistentBtn" type="button">Non-persistent Session</button>
+    </div>
+  </div>
+</div>
+
+
+<div class="modal" id="workspaceChoiceModal" aria-hidden="true">
+  <div class="backdrop" id="workspaceChoiceBackdrop"></div>
+  <div class="modalCard smallModalCard" role="dialog" aria-modal="true" aria-labelledby="workspaceChoiceTitle">
+    <div class="topbar">
+      <div>
+        <div class="title" id="workspaceChoiceTitle">Choose a workspace</div>
+        <div class="muted small">URSA needs an explicit place for session files and artifacts.</div>
+      </div>
+      <button class="btn" id="closeWorkspaceChoiceBtn" type="button">Cancel</button>
+    </div>
+    <div class="workspaceChoiceBody">
+      <div class="workspaceChoiceSection">
+        <div class="sectionHead">Workspace folder</div>
+        <div class="muted small">Use a folder you can easily find and return to later.</div>
+        <div class="workspaceChoiceInputRow">
+          <input class="input" id="workspaceFolderInput" placeholder="/absolute/path/to/workspace" autocomplete="off" />
+          <button class="btn" id="browseWorkspaceBtn" type="button">Browse…</button>
+        </div>
+        <div style="margin-top:10px">
+          <button class="btn primary" id="useWorkspaceFolderBtn" type="button">Use this folder</button>
+        </div>
+      </div>
+      <div class="workspaceChoiceSection">
+        <div class="sectionHead">Temporary workspace</div>
+        <div class="muted small">Create an OS-managed temporary folder for disposable work, like <code>ursa --workspace tmp</code>. It is removed when you delete the session or stop the dashboard.</div>
+        <div style="margin-top:10px">
+          <button class="btn" id="useTemporaryWorkspaceBtn" type="button">Use temporary workspace</button>
+        </div>
+      </div>
+      <div class="workspaceChoiceError small" id="workspaceChoiceError" role="alert"></div>
     </div>
   </div>
 </div>

--- a/src/ursa_dashboard/sessions.py
+++ b/src/ursa_dashboard/sessions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import re
 import shutil
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
@@ -46,10 +47,12 @@ def create_session(
     agent_id: str,
     agent_name: str | None = None,
     title: str | None = None,
+    workspace_path: str | Path | None = None,
+    workspace_mode: str | None = None,
 ) -> dict[str, Any]:
     session_id = new_ulid()
     paths = session_paths(dashboard_root, session_id)
-    paths.workspace_dir.mkdir(parents=True, exist_ok=True)
+    paths.session_dir.mkdir(parents=True, exist_ok=True)
 
     now = utc_now()
     resolved_agent_name = str(agent_name or "").strip() or None
@@ -67,6 +70,12 @@ def create_session(
         "updated_at": now,
         "active_run_id": None,
         "last_run_id": None,
+        "workspace_path": (
+            str(Path(workspace_path).expanduser().resolve())
+            if workspace_path is not None
+            else None
+        ),
+        "workspace_mode": workspace_mode,
     }
     write_json(paths.meta_path, rec)
     return rec
@@ -110,10 +119,36 @@ def list_sessions(
     return recs[:limit]
 
 
-def delete_session(dashboard_root: Path, session_id: str) -> None:
-    """Delete the session directory (messages + per-session workspace).
+def create_temporary_workspace() -> Path:
+    """Create a workspace with the same system-temp semantics as CLI ``tmp``."""
 
-    Note: does not delete global run records; runs are stored separately.
+    return Path(tempfile.mkdtemp(prefix="ursa")).resolve()
+
+
+def delete_temporary_workspace(session: dict[str, Any]) -> None:
+    """Delete a dashboard-created temporary workspace, never a user folder."""
+
+    if session.get("workspace_mode") != "temporary":
+        return
+    raw = str(session.get("workspace_path") or "").strip()
+    if not raw:
+        return
+
+    path = Path(raw).expanduser()
+    temp_root = Path(tempfile.gettempdir()).resolve()
+    try:
+        path.resolve().relative_to(temp_root)
+    except (OSError, ValueError):
+        return
+    if not path.name.startswith("ursa") or path.is_symlink():
+        return
+    shutil.rmtree(path, ignore_errors=True)
+
+
+def delete_session(dashboard_root: Path, session_id: str) -> None:
+    """Delete session metadata and any dashboard-created temporary workspace.
+
+    User-selected external workspace folders and global run records are retained.
     """
 
     paths = session_paths(dashboard_root, session_id)
@@ -127,6 +162,8 @@ def delete_session(dashboard_root: Path, session_id: str) -> None:
     except Exception:
         raise ValueError("Refusing to delete outside sessions root")
 
+    session = read_json(paths.meta_path)
+    delete_temporary_workspace(session)
     shutil.rmtree(sess_real)
 
 

--- a/tests/dashboard/test_session_workspaces.py
+++ b/tests/dashboard/test_session_workspaces.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ursa import security
+from ursa_dashboard.app import create_app
+from ursa_dashboard.credentials import MemoryCredentialStore
+from ursa_dashboard.sessions import create_session, read_session, session_paths
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(security, "URSA_CACHE_DIR", tmp_path / "ursa-cache")
+    app = create_app(credential_store=MemoryCredentialStore())
+    with TestClient(app) as test_client:
+        yield test_client, tmp_path
+
+
+def test_session_creation_requires_explicit_workspace(client) -> None:
+    test_client, _ = client
+
+    response = test_client.post("/sessions", json={"agent_id": "chat_agent"})
+
+    assert response.status_code == 400
+    assert "workspace is required" in response.json()["detail"].lower()
+    assert test_client.get("/sessions").json()["sessions"] == []
+
+
+def test_folder_workspace_is_used_without_cached_default(client) -> None:
+    test_client, tmp_path = client
+    workspace = tmp_path / "visible-workspace"
+
+    response = test_client.post(
+        "/sessions",
+        json={
+            "agent_id": "chat_agent",
+            "workspace_mode": "folder",
+            "workspace_path": str(workspace),
+        },
+    )
+
+    assert response.status_code == 200
+    session = response.json()["session"]
+    info = test_client.get(
+        f"/sessions/{session['session_id']}/workspace"
+    ).json()
+    assert info["configured"] is True
+    assert info["workspace_mode"] == "folder"
+    assert info["workspace_path"] == str(workspace.resolve())
+    assert info["default_workspace_path"] is None
+    cached_paths = session_paths(
+        tmp_path / "ursa-cache" / "default" / "dashboard",
+        session["session_id"],
+    )
+    assert not cached_paths.workspace_dir.exists()
+
+
+def test_temporary_workspace_is_outside_cache_and_deleted_with_session(
+    client,
+) -> None:
+    test_client, tmp_path = client
+
+    response = test_client.post(
+        "/sessions",
+        json={"agent_id": "chat_agent", "workspace_mode": "temporary"},
+    )
+
+    assert response.status_code == 200
+    session = response.json()["session"]
+    workspace = Path(session["workspace_path"])
+    assert workspace.is_dir()
+    assert not workspace.is_relative_to(tmp_path / "ursa-cache")
+
+    deleted = test_client.delete(f"/sessions/{session['session_id']}")
+    assert deleted.status_code == 204
+    assert not workspace.exists()
+
+
+def test_unconfigured_legacy_session_is_guarded_until_workspace_is_set(
+    client,
+) -> None:
+    test_client, tmp_path = client
+    dashboard_root = tmp_path / "ursa-cache" / "default" / "dashboard"
+    session = create_session(dashboard_root, agent_id="chat_agent")
+    session_id = session["session_id"]
+
+    info = test_client.get(f"/sessions/{session_id}/workspace")
+    assert info.status_code == 200
+    assert info.json()["configured"] is False
+    assert info.json()["workspace_path"] is None
+
+    blocked = test_client.post(
+        f"/sessions/{session_id}/message", json={"text": "hello"}
+    )
+    assert blocked.status_code == 409
+    assert "does not have a workspace" in blocked.json()["detail"]
+    assert test_client.get(f"/sessions/{session_id}/messages").json() == []
+
+    configured = test_client.patch(
+        f"/sessions/{session_id}/workspace", json={"mode": "temporary"}
+    )
+    assert configured.status_code == 200
+    assert configured.json()["workspace_mode"] == "temporary"
+    assert configured.json()["configured"] is True
+
+
+def test_replacing_temporary_workspace_removes_it(client) -> None:
+    test_client, tmp_path = client
+    created = test_client.post(
+        "/sessions",
+        json={"agent_id": "chat_agent", "workspace_mode": "temporary"},
+    ).json()["session"]
+    temporary_workspace = Path(created["workspace_path"])
+    visible_workspace = tmp_path / "follow-on-work"
+
+    changed = test_client.patch(
+        f"/sessions/{created['session_id']}/workspace",
+        json={"mode": "folder", "path": str(visible_workspace)},
+    )
+
+    assert changed.status_code == 200
+    assert changed.json()["workspace_path"] == str(visible_workspace.resolve())
+    assert not temporary_workspace.exists()
+
+
+def test_dashboard_shutdown_removes_temporary_workspace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(security, "URSA_CACHE_DIR", tmp_path / "ursa-cache")
+    app = create_app(credential_store=MemoryCredentialStore())
+
+    with TestClient(app) as test_client:
+        session = test_client.post(
+            "/sessions",
+            json={"agent_id": "chat_agent", "workspace_mode": "temporary"},
+        ).json()["session"]
+        session_id = session["session_id"]
+        workspace = Path(session["workspace_path"])
+        assert workspace.is_dir()
+
+    assert not workspace.exists()
+    saved = read_session(
+        tmp_path / "ursa-cache" / "default" / "dashboard", session_id
+    )
+    assert saved["workspace_mode"] is None
+    assert saved["workspace_path"] is None
+
+
+def test_dashboard_contains_workspace_choice_dialog(client) -> None:
+    test_client, _ = client
+
+    html = test_client.get("/ui").text
+
+    assert 'id="workspaceChoiceModal"' in html
+    assert "Use temporary workspace" in html
+    assert "chooseWorkspaceSelection" in html
+    assert "dashboard-managed default workspace" not in html

--- a/tests/dashboard/test_session_workspaces.py
+++ b/tests/dashboard/test_session_workspaces.py
@@ -9,6 +9,7 @@ from ursa import security
 from ursa_dashboard.app import create_app
 from ursa_dashboard.credentials import MemoryCredentialStore
 from ursa_dashboard.sessions import create_session, read_session, session_paths
+from ursa_dashboard.storage import write_json
 
 
 @pytest.fixture
@@ -86,11 +87,22 @@ def test_unconfigured_legacy_session_is_guarded_until_workspace_is_set(
     dashboard_root = tmp_path / "ursa-cache" / "default" / "dashboard"
     session = create_session(dashboard_root, agent_id="chat_agent")
     session_id = session["session_id"]
+    paths = session_paths(dashboard_root, session_id)
+    paths.workspace_dir.mkdir(parents=True)
+    (paths.workspace_dir / "previous-work.txt").write_text(
+        "keep me", encoding="utf-8"
+    )
+    session.pop("workspace_path")
+    session.pop("workspace_mode")
+    write_json(paths.meta_path, session)
 
     info = test_client.get(f"/sessions/{session_id}/workspace")
     assert info.status_code == 200
     assert info.json()["configured"] is False
     assert info.json()["workspace_path"] is None
+    assert info.json()["default_workspace_path"] == str(
+        paths.workspace_dir.resolve()
+    )
 
     blocked = test_client.post(
         f"/sessions/{session_id}/message", json={"text": "hello"}
@@ -100,11 +112,16 @@ def test_unconfigured_legacy_session_is_guarded_until_workspace_is_set(
     assert test_client.get(f"/sessions/{session_id}/messages").json() == []
 
     configured = test_client.patch(
-        f"/sessions/{session_id}/workspace", json={"mode": "temporary"}
+        f"/sessions/{session_id}/workspace",
+        json={"mode": "folder", "path": str(paths.workspace_dir)},
     )
     assert configured.status_code == 200
-    assert configured.json()["workspace_mode"] == "temporary"
+    assert configured.json()["workspace_mode"] == "folder"
     assert configured.json()["configured"] is True
+    assert configured.json()["default_workspace_path"] is None
+    assert (paths.workspace_dir / "previous-work.txt").read_text(
+        encoding="utf-8"
+    ) == "keep me"
 
 
 def test_replacing_temporary_workspace_removes_it(client) -> None:
@@ -157,4 +174,5 @@ def test_dashboard_contains_workspace_choice_dialog(client) -> None:
     assert 'id="workspaceChoiceModal"' in html
     assert "Use temporary workspace" in html
     assert "chooseWorkspaceSelection" in html
+    assert "state.workspaceInfo?.default_workspace_path" in html
     assert "dashboard-managed default workspace" not in html


### PR DESCRIPTION
Problem:
- The URSA dashboard makes default workspaces in the .cache/ursa/<group>/dashboard/sessions directory. This is hard to reach for non-technical users and a bit awkward for anyone. 

Fix:
- When users create a new session, they are prompted to pick a workspace folder or select a temporary folder.
- This forces users to pick a location for the work but in a smooth, natural manner so they know where files will go.

Legacy behavior:
- For cases where the user used a default workspace in .cache before, ursa will prompt the user to select a workspace but default to the random one in cache, so the user does not lose track of their previous work, but now has explicitly selected where it is.