### PR TITLE
fix: compile planner graph with its PlanningState schema

### DIFF
--- a/src/ursa/agents/planning_agent.py
+++ b/src/ursa/agents/planning_agent.py
@@ -83,7 +83,7 @@ class PlanningState(TypedDict, total=False):
 
 
 class PlanningAgent(BaseAgent[PlanningState]):
-    agent_state = PlanningState
+    state_type = PlanningState
 
     def __init__(
         self,

--- a/tests/agents/test_planning_agent/test_planning_agent.py
+++ b/tests/agents/test_planning_agent/test_planning_agent.py
@@ -3,6 +3,7 @@ from collections.abc import Iterator
 import pytest
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
 from pydantic import Field
 
 from ursa.agents.planning_agent import Plan, PlanningAgent
@@ -113,3 +114,88 @@ async def test_planning_agent_treats_empty_reflection_as_approval(tmpdir):
 
     assert result["plan"] == plan
     assert result["messages"][-1].content == "[APPROVED]"
+
+
+class RecordingPlannerChatModel(GenericFakeChatModel):
+    """Fake chat model that records the messages of every planner LLM call."""
+
+    messages: Iterator[AIMessage | str] = Field(
+        default_factory=lambda: iter([AIMessage(content="unused")])
+    )
+    calls: list = Field(default_factory=list)
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+        self.calls.append(list(messages))
+        return ChatResult(
+            generations=[
+                ChatGeneration(message=AIMessage(content="[APPROVED]"))
+            ]
+        )
+
+    def model_copy(self, update=None):
+        return self
+
+    def with_structured_output(self, schema, **kwargs):
+        model = self
+
+        class StructuredOutput:
+            def invoke(self, messages, config=None):
+                model.calls.append(list(messages))
+                return schema(
+                    steps=[
+                        {
+                            "name": "Add numbers",
+                            "description": "Add 1 and 2.",
+                            "requires_code": False,
+                            "expected_outputs": ["sum"],
+                            "success_criteria": ["sum equals 3"],
+                        }
+                    ]
+                )
+
+        return StructuredOutput()
+
+
+@pytest.mark.asyncio
+async def test_planner_requests_never_end_with_assistant_message(tmpdir):
+    """Anthropic removed assistant-message prefill with Claude 4.6, so any
+    request whose final message is an AI message now fails with a 400 error.
+    Every LLM call the planner makes must end with a non-AI message.
+    """
+    llm = RecordingPlannerChatModel()
+    planning_agent = PlanningAgent(
+        llm=llm, workspace=tmpdir, max_reflection_steps=1
+    )
+
+    await planning_agent.ainvoke({
+        "messages": [HumanMessage(content="make a plan")]
+    })
+
+    assert len(llm.calls) >= 2, "expected generation and reflection calls"
+    for call in llm.calls:
+        assert not isinstance(call[-1], AIMessage), (
+            "planner sent a request ending with an AI message, which "
+            "models without assistant-message prefill support reject"
+        )
+
+
+@pytest.mark.asyncio
+async def test_planner_accumulates_messages_across_nodes(tmpdir):
+    """Planner state must append messages rather than replace them, so the
+    reflection step sees the original request alongside the drafted plan.
+    """
+    llm = RecordingPlannerChatModel()
+    planning_agent = PlanningAgent(
+        llm=llm, workspace=tmpdir, max_reflection_steps=1
+    )
+
+    prompt = "make a plan"
+    result = await planning_agent.ainvoke({
+        "messages": [HumanMessage(content=prompt)]
+    })
+
+    contents = [msg.content for msg in result["messages"]]
+    assert contents[0] == prompt, "original request should be preserved"
+    assert any(isinstance(msg, AIMessage) for msg in result["messages"]), (
+        "drafted plan message should be retained in state"
+    )


### PR DESCRIPTION
## Summary

The `plan` command crashes with `This model does not support assistant message prefill. The conversation must end with a user message.` on Claude 4.6 and newer (#283). The planner never intentionally prefills — its graph is compiled without the `PlanningState` schema, so the `add_messages` reducer never applies and each node's `messages` return replaces state instead of appending to it.

`BaseAgent.build_graph()` compiles `StateGraph(self.state_type, ...)`, and `state_type` defaults to `dict`. Every other agent that registers a typed state does so via `state_type`; the planner instead sets `agent_state` — an attribute name introduced in the #142 refactor that nothing reads.

With the plain `dict` schema, by the time `reflection_node` runs, `state["messages"]` holds only the `AIMessage` the generation node returned. The role-swap in `reflection_node` keeps index 0 as-is, so the review request is sent as `[system, assistant]` — a conversation ending on an assistant turn. Models before Claude 4.6 accepted that as a legal prefill and "reviewed" the plan by continuing their own JSON output (likely also the source of the intermittently empty reflections that `reflection_node` currently works around). Claude 4.6+ rejects it with a 400, on both the Anthropic and OpenAI-compatible provider paths.

## Fix

Register `state_type = PlanningState` so the graph compiles with the annotated schema. Messages then accumulate across nodes, the reflection step sees the original request and the drafted plan as user turns, and every planner request ends with a non-assistant message.

## Testing

* Added two regression tests using a recording fake chat model: one asserts no planner LLM request ends with an `AIMessage`, the other asserts planner state accumulates messages across nodes. Both fail on `main` and pass with this change.
* Full test suite: 309 passed. The remaining failures (three dashboard import errors, one config smoke test requiring `OPENAI_API_KEY`) are pre-existing and unrelated.
* Traced the reflect/regenerate loop with a message-recording harness across fresh runs, checkpointed threads, and crash-retry resumes: all requests are user-final after the fix.
* Probed resuming a REPL checkpoint thread created under the old `dict` schema after this change: no error; the old thread simply starts with fresh context (no worse than the status quo, which was already discarding message history on every node).

Note: `rag_agent.py:58` carries the same leftover `agent_state` attribute. `RAGState` holds no messages so it appears inert there, but switching it changes the compiled schema (typed state filters unknown keys), so I left it out of this PR rather than bundle a separate behavior change.

Fixes #283
