### PR TITLE
feat: add a metrics command to the HITL REPL

### DIFF
--- a/src/ursa/cli/hitl.py
+++ b/src/ursa/cli/hitl.py
@@ -26,6 +26,7 @@ from ursa.agents import BaseAgent
 from ursa.agents.base import AgentWithTools
 from ursa.cli.callbacks import HITLLogEventHandler
 from ursa.cli.config import UrsaConfig
+from ursa.observability.timing import render_session_summary
 from ursa.security import (
     enforce_group_base_url_policy,
     enforce_model_group_policy,
@@ -246,6 +247,10 @@ class HITL:
 
         assert agent._agent is not None
         return agent
+
+    def render_metrics(self) -> None:
+        """Render the timing and cost summary for this session's agents."""
+        render_session_summary(self.thread_id)
 
     async def run_agent(
         self,
@@ -494,6 +499,10 @@ class UrsaRepl(Cmd):
                     self.console.print(f" {k}: {v}")
             else:
                 self.console.print(name + ": {}")
+
+    def do_metrics(self, _: str):
+        """Show timing and cost metrics for agents run this session"""
+        self.hitl.render_metrics()
 
 
 def get_provider_and_model(model_str: str | None):

--- a/tests/cli/test_hitl.py
+++ b/tests/cli/test_hitl.py
@@ -814,3 +814,19 @@ async def test_mcp_smoke(mcp_server: Client):
 async def test_mcp_agents(mcp_server: Client, agent: str, query: str):
     response = await mcp_server.call_tool(agent, {"prompt": query})
     assert isinstance(response.structured_content["result"], str)
+
+
+def test_metrics_command_renders_session_summary(tmp_path, monkeypatch):
+    _stub_hitl_dependencies(monkeypatch)
+    hitl = HITL(UrsaConfig(workspace=tmp_path / "workspace"))
+
+    rendered: list[str] = []
+    monkeypatch.setattr(
+        "ursa.cli.hitl.render_session_summary",
+        lambda thread_id: rendered.append(thread_id),
+    )
+
+    repl = UrsaRepl(hitl)
+    repl.do_metrics("")
+
+    assert rendered == [hitl.thread_id]


### PR DESCRIPTION
## Summary

Implements the `metrics` REPL command sketched by @luiarthur in #58: typing `metrics` in the HITL session renders the session timing and cost summary (per-node, per-tool, and per-LLM timing tables plus cost by model) for the current thread.

Two simplifications relative to the original sketch, both consequences of how the CLI has evolved since:

* Metrics are enabled by default now, so no opt-in plumbing is needed.
* Every REPL agent is instantiated with the session's shared thread id, so the session rollup already aggregates all agents on the thread and lists them in the summary. That removes the need for per-agent thread ids and last-agent tracking, and `metrics` therefore takes no argument.

Before any agent has run, the command prints the existing "No session data" panel rather than erroring. That panel is also what the original report ran into: at the time, metrics were off by default and the REPL gave each agent its own suffixed thread id, so no rollup existed under the session's thread.

## Testing

* New test in `tests/cli/test_hitl.py` (using the existing stubbed-dependency helper) verifies the command renders the summary for the session's thread.
* Manually exercised both paths in a stubbed REPL: the no-data panel, and the full summary with a seeded rollup.
* `tests/cli/` passes apart from the pre-existing `test_example_config_smoke` failure, which requires `OPENAI_API_KEY` and is unrelated. `ruff check` and `ruff format --check` are clean on both changed files.

Closes #58
