### PR TITLE
fix: record error samples when on_llm_error has no matching start

### DIFF
--- a/src/ursa/observability/timing.py
+++ b/src/ursa/observability/timing.py
@@ -560,7 +560,7 @@ class PerLLMTimer(BaseCallbackHandler):
 
     def __init__(self, agg: _Agg | None = None, keep_max: int = 1000):
         self.agg = agg or _Agg()
-        self._starts: dict[Any, tuple[str, float, list, dict]] = {}
+        self._starts: dict[Any, tuple[str, float, list, dict, float]] = {}
         self.samples: collections.deque = collections.deque(maxlen=keep_max)
 
     def _name(self, serialized, metadata, tags) -> str:
@@ -769,7 +769,7 @@ class PerLLMTimer(BaseCallbackHandler):
 
     def on_llm_error(self, error, *, run_id, **kwargs):
         name, t0, tags, metadata, wall_t0 = self._starts.pop(
-            run_id, ("llm:unknown", time.perf_counter(), [], {})
+            run_id, ("llm:unknown", time.perf_counter(), [], {}, time.time())
         )
         ms = (time.perf_counter() - t0) * 1000.0
         wall_t1 = time.time()

--- a/tests/observability/test_timing.py
+++ b/tests/observability/test_timing.py
@@ -1,0 +1,33 @@
+from uuid import uuid4
+
+from ursa.observability.timing import PerLLMTimer
+
+
+def test_on_llm_error_records_sample_without_matching_start():
+    timer = PerLLMTimer()
+
+    timer.on_llm_error(RuntimeError("boom"), run_id=uuid4())
+
+    assert len(timer.samples) == 1
+    sample = timer.samples[-1]
+    assert sample["ok"] is False
+    assert sample["name"] == "llm:unknown"
+    assert "boom" in sample["metrics"]["error"]
+    assert isinstance(sample["t_start"], float)
+    assert isinstance(sample["t_end"], float)
+    assert sample["t_end"] >= sample["t_start"]
+
+
+def test_on_llm_error_records_sample_with_matching_start():
+    timer = PerLLMTimer()
+    run_id = uuid4()
+    timer.on_llm_start({"name": "fake-model"}, ["prompt"], run_id=run_id)
+
+    timer.on_llm_error(RuntimeError("boom"), run_id=run_id)
+
+    assert len(timer.samples) == 1
+    sample = timer.samples[-1]
+    assert sample["ok"] is False
+    assert sample["name"].startswith("llm:")
+    assert "boom" in sample["metrics"]["error"]
+    assert sample["t_end"] >= sample["t_start"]


### PR DESCRIPTION
## Summary

`PerLLMTimer.on_llm_error` popped its start entry with a four-element fallback tuple unpacked into five names, so an LLM error arriving without a matching start entry raised `ValueError` inside the handler. LangChain logs and swallows sync-handler exceptions unless `raise_error` is set (it defaults to False), so the visible effect was a logged warning and a silently dropped sample: the failed call never reached the per-LLM aggregates or `llm_events`, undercounting error runs in the metrics.

`on_llm_start` stores five elements and `on_llm_end`'s fallback already carries five; this brings `on_llm_error` in line (adding the missing wall-clock element) and corrects the stale four-element `_starts` type annotation. The tool and chain timers pop two-element fallbacks into two names and are unaffected; the LLM error path was the only mismatch.

## Testing

* New tests in `tests/observability/test_timing.py`: an error without a matching start records a failure sample (this raised `ValueError` before the fix), and the matched-start error path still records correctly.
* Full suite: 329 passed; the remaining failures are the pre-existing environment-dependent ones (dashboard extras, the `OPENAI_API_KEY` smoke test). `ruff check` and `ruff format --check` clean on both files.

Fixes #292
