### PR TITLE
fix: report missing API key without traceback

### DIFF
--- a/src/ursa/cli/__init__.py
+++ b/src/ursa/cli/__init__.py
@@ -166,6 +166,22 @@ def resolve_config(cfg) -> UrsaConfig:
     return config.update(cli_config)
 
 
+def _initialize_hitl(config: UrsaConfig):
+    """Create the CLI controller and report missing OpenAI credentials cleanly."""
+    from openai import OpenAIError
+
+    from ursa.cli.hitl import HITL
+
+    try:
+        return HITL(config)
+    except OpenAIError as exc:
+        print(  # noqa: T201
+            "Error: unable to initialize the language model. " + str(exc),
+            file=sys.stderr,
+        )
+        raise SystemExit(2) from None
+
+
 def main(args=None):
     inject_truststore_into_ssl()
     parser = build_parser()
@@ -258,21 +274,19 @@ def main(args=None):
 
     match subcommand:
         case None:
-            from ursa.cli.hitl import HITL, UrsaRepl
+            from ursa.cli.hitl import UrsaRepl
 
-            hitl = HITL(ursa_config)
+            hitl = _initialize_hitl(ursa_config)
             UrsaRepl(hitl).run()
 
         case "exec":
-            from ursa.cli.hitl import HITL, UrsaRepl
+            from ursa.cli.hitl import UrsaRepl
 
-            hitl = HITL(ursa_config)
+            hitl = _initialize_hitl(ursa_config)
             UrsaRepl(hitl).run_prompt(cmd_config.prompt)
 
         case "mcp-server":
-            from ursa.cli.hitl import HITL
-
-            hitl = HITL(ursa_config)
+            hitl = _initialize_hitl(ursa_config)
             mcp = hitl.as_mcp_server()
             run_kwargs = {
                 "transport": cmd_config.transport,

--- a/src/ursa/cli/config.py
+++ b/src/ursa/cli/config.py
@@ -1,3 +1,4 @@
+import sys
 import json
 import logging
 import re
@@ -27,6 +28,8 @@ from ursa.util.http import (
     httpx_verify_value,
 )
 from ursa.util.mcp import ServerParameters, _serialize_server_config
+
+logger = logging.getLogger(__name__)
 
 LoggingLevel = Literal[
     "debug", "info", "notice", "warning", "error", "critical"
@@ -96,10 +99,10 @@ class ModelConfig(BaseModel):
             try:
                 kwargs["api_key"] = environ[api_key_env]
             except KeyError:
-                logging.exception(
+                logger.error(
                     f"Env variable '{api_key_env}' for {self.model}'s API key was not set"
                 )
-                raise
+                sys.exit(1)
         return kwargs
 
 

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock
 
+import pytest
 import yaml
+from openai import OpenAIError
 
 from ursa.cli import build_parser, main, resolve_config
 from ursa.cli.config import (
@@ -68,6 +70,25 @@ def test_cli_does_not_warn_without_legacy_checkpoint(
     main(["--workspace", str(tmp_path)])
 
     assert capsys.readouterr().err == ""
+
+
+def test_cli_reports_model_initialization_error_without_traceback(
+    monkeypatch, capsys
+):
+    error = OpenAIError(
+        "The api_key client option must be set by setting the "
+        "OPENAI_API_KEY environment variable"
+    )
+    monkeypatch.setattr("ursa.cli.hitl.HITL", MagicMock(side_effect=error))
+    monkeypatch.setattr("ursa.cli.inject_truststore_into_ssl", lambda: None)
+
+    with pytest.raises(SystemExit, match="2"):
+        main([])
+
+    stderr = capsys.readouterr().err
+    assert stderr.startswith("Error: unable to initialize the language model.")
+    assert "OPENAI_API_KEY" in stderr
+    assert "Traceback" not in stderr
 
 
 def test_mcp_server_passes_only_stdio_run_options(monkeypatch):


### PR DESCRIPTION
## Summary

- centralize CLI controller initialization for interactive, exec, and MCP-server modes
- turn OpenAI model initialization failures such as a missing API key into one concise stderr message
- exit with status 2 and suppress the Python traceback
- add a regression test for the missing OPENAI_API_KEY path

## Reproduction

Before this change, launching ursa without OPENAI_API_KEY prints the full exception traceback from LangChain and the OpenAI client.

After this change, the command prints one actionable line naming OPENAI_API_KEY and exits with status 2.

## Testing

- PYTHONPATH=src .venv/bin/python -m pytest tests/cli/test_cli_parser.py -q — 29 passed
- XDG_CACHE_HOME=/tmp/ursa-pr-cache OPENAI_API_KEY=dummy PYTHONPATH=src .venv/bin/python -m pytest -q -m "not real_llm" — 357 passed, 9 skipped
- PYTHONPATH=src .venv/bin/ruff check . — passed
- PYTHONPATH=src .venv/bin/ruff format --check . — passed

The real_llm test was excluded because it makes a live OpenAI API request.

Fixes #300