### PR TITLE
fix: handle missing API key gracefully in CLI

### DIFF
--- a/src/ursa/cli/__init__.py
+++ b/src/ursa/cli/__init__.py
@@ -37,6 +37,8 @@ from ursa.cli.rag_management import (
 )
 from ursa.util.http import inject_truststore_into_ssl
 
+from openai import OpenAIError
+
 set_parsing_settings(docstring_parse_attribute_docstrings=True)
 # NOTE [alui | 26 June, 2026]:
 # Pydantic warnings occured around v0.16.0. Suppress for now.
@@ -260,8 +262,12 @@ def main(args=None):
         case None:
             from ursa.cli.hitl import HITL, UrsaRepl
 
-            hitl = HITL(ursa_config)
-            UrsaRepl(hitl).run()
+            try:
+                hitl = HITL(ursa_config)
+                UrsaRepl(hitl).run()
+            except OpenAIError as exc:
+                print(f"Error: {exc}")
+                return
 
         case "exec":
             from ursa.cli.hitl import HITL, UrsaRepl

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -246,6 +246,33 @@ def test_cli_does_not_apply_chat_only_openai_defaults_to_emb_model():
     assert "use_responses_api" not in config.emb_model.kwargs
 
 
+def test_cli_handles_missing_api_key(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "ursa.cli.inject_truststore_into_ssl",
+        lambda: None,
+    )
+
+    from openai import OpenAIError
+
+    monkeypatch.setattr(
+        "ursa.cli.hitl.HITL",
+        MagicMock(
+            side_effect=OpenAIError(
+                "The api_key client option must be set either by passing "
+                "api_key to the client or by setting the OPENAI_API_KEY "
+                "environment variable"
+            )
+        ),
+    )
+
+    main([])
+
+    output = capsys.readouterr().out
+
+    assert "api_key" in output
+    assert "OPENAI_API_KEY" in output
+
+
 def test_print_config_yaml_round_trip(tmp_path):
     parser = build_parser()
     args = parser.parse_args([


### PR DESCRIPTION
## Summary

Fixes #300.

Previously, running `ursa` without an API key produced a full Python
exception traceback.

This change catches the missing API key error at CLI startup and prints
a concise error message before exiting.

## Testing

Ran:

`uv run pytest tests/cli`

Result:
- 64 passed
- 1 skipped
- 1 failed

The remaining failure is `test_example_config_smoke`, which requires
`OPENAI_API_KEY` and is unrelated to this change.