### PR TITLE
fix: give the dashboard chat visible failure feedback

### DIFF
--- a/src/ursa_dashboard/app.py
+++ b/src/ursa_dashboard/app.py
@@ -3667,7 +3667,7 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
     if (!state.activeSession) {
         if (title) title.textContent = 'No session selected';
         if (meta) meta.textContent = '';
-        if (msgs) msgs.innerHTML = '<div class="muted">Pick an agent to start a new session, or select a session on the left.</div>';
+        if (msgs) msgs.innerHTML = '<div class="muted">Start a new session or select an existing session from the panel on the left.</div>';
         if (wsTitle) wsTitle.textContent = 'Session artifacts';
 
         if (badge) {

--- a/src/ursa_dashboard/app.py
+++ b/src/ursa_dashboard/app.py
@@ -776,15 +776,6 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
         prior = session_read_messages(rm.dashboard_root, session_id, limit=200)
         prompt = build_prompt_from_messages(prior, new_user_text=req.text)
 
-        user_msg = session_append_message(
-            rm.dashboard_root,
-            session_id=session_id,
-            role="user",
-            text=req.text,
-            agent_id=agent_id,
-            agent_name=agent_name,
-        )
-
         # Merge global defaults, then per-session settings, then per-message overrides.
         s = settings_store.load().model_dump(mode="json")
         llm = _deep_merge_dicts(
@@ -800,12 +791,23 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
         if agent_id.startswith("demo_") and "disabled" not in llm:
             llm["disabled"] = True
 
+        # Validate before persisting anything: a send rejected here must
+        # not leave an unanswered user message in the transcript.
         try:
             await asyncio.to_thread(
                 rm.validate_credentials, llm=llm, embedding=embedding
             )
         except (CredentialConfigurationError, CredentialStoreError) as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
+
+        user_msg = session_append_message(
+            rm.dashboard_root,
+            session_id=session_id,
+            role="user",
+            text=req.text,
+            agent_id=agent_id,
+            agent_name=agent_name,
+        )
 
         params = dict(req.params or {})
         params.setdefault("prompt", prompt)
@@ -3679,6 +3681,7 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
         state.workspaceInfo = null;
         renderWorkspacePath();
         clearRunView();
+        updateComposerState();
         return;
     }
 
@@ -3852,6 +3855,7 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
     state.activeSession = await api('GET', `/sessions/${encodeURIComponent(sessionId)}`);
     renderSessions();
     renderActiveSession();
+    updateComposerState();
     await refreshWorkspace();
   }
 
@@ -4018,6 +4022,33 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
     return !!state.workspaceInfo?.configured;
   }
 
+  function updateComposerState() {
+    const ta = $('#messageInput');
+    const btn = $('#sendMsgBtn');
+    const ready = !!state.activeSessionId;
+    if (ta) {
+      ta.disabled = !ready;
+      ta.placeholder = ready
+        ? 'Message the agent...'
+        : 'Create a session to start chatting';
+    }
+    if (btn) btn.disabled = !ready;
+  }
+
+  function showSendError(message) {
+    const msgs = $('#sessionMessages');
+    if (!msgs) {
+      alert('Failed to send: ' + message);
+      return;
+    }
+    msgs.querySelectorAll('.sendError').forEach(x => x.remove());
+    const el = document.createElement('div');
+    el.className = 'sendError';
+    el.textContent = 'Failed to send: ' + message;
+    msgs.appendChild(el);
+    msgs.scrollTop = msgs.scrollHeight;
+  }
+
   async function sendMessage() {
     if (!state.activeSessionId) return;
     const ta = $('#messageInput');
@@ -4037,7 +4068,7 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
       await refreshSessions();
       await refreshAgents();
     } catch (e) {
-      alert('Failed to send: ' + e.message);
+      showSendError(e && e.message ? e.message : String(e));
     } finally {
       if (sendBtn) sendBtn.disabled = false;
     }
@@ -4838,6 +4869,8 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
     if (!state.activeSessionId && state.sessions.length) {
       const exists = remembered && state.sessions.some(s => s.session_id === remembered);
       await loadSession(exists ? remembered : state.sessions[0].session_id);
+    } else if (!state.activeSessionId) {
+      renderActiveSession();
     }
 
     // periodic refresh
@@ -5150,6 +5183,7 @@ body::before {
 }
 
 .msgRow { margin-bottom: 12px; }
+.sendError { color: #dc2626; background: rgba(220,38,38,0.08); border: 1px solid rgba(220,38,38,0.4); border-radius: 8px; padding: 8px 10px; margin: 8px 0; white-space: pre-wrap; }
 .msgHead { font-weight: 650; margin-bottom: 6px; display:flex; gap: 8px; align-items: baseline; }
 .msgHead .who { font-weight: 700; }
 
@@ -5315,6 +5349,13 @@ textarea.input { width: 100%; box-sizing: border-box; resize: vertical; }
             except Exception:
                 continue
         return None
+
+    @app.get("/favicon.ico", include_in_schema=False)
+    def favicon() -> FileResponse:
+        p = _find_logo_path()
+        if not p:
+            raise HTTPException(status_code=404, detail="favicon not found")
+        return FileResponse(str(p), media_type="image/png")
 
     @app.get(
         "/ui/ursa_logo.png",
@@ -5748,9 +5789,9 @@ textarea.input { width: 100%; box-sizing: border-box; resize: vertical; }
               <select id="composerAgentType" style="min-width:220px"></select>
             </div>
           </div>
-          <textarea id="messageInput" placeholder="Message the agent..."></textarea>
+          <textarea id="messageInput" placeholder="Create a session to start chatting" disabled></textarea>
           <div class="row" style="margin-top: 8px">
-            <button class="btn primary" id="sendMsgBtn" type="button">Send</button>
+            <button class="btn primary" id="sendMsgBtn" type="button" disabled>Send</button>
             <div class="muted small" id="runStatus"></div>
             <a class="muted small" href="/ui/workspace" style="margin-left:auto">Run workspace browser</a>
           </div>

--- a/src/ursa_dashboard/credentials.py
+++ b/src/ursa_dashboard/credentials.py
@@ -257,6 +257,11 @@ def resolve_api_key(
 
     expected_id = credential_id(group, kind)
     configured_id = str(config.get("credential_id") or "")
+    if not configured_id:
+        raise CredentialConfigurationError(
+            f"No {kind} API key has been saved yet. Save one in Settings "
+            "or switch the credential source."
+        )
     if configured_id != expected_id:
         raise CredentialConfigurationError(
             f"The stored {kind} credential reference is invalid."

--- a/tests/dashboard/test_send_feedback.py
+++ b/tests/dashboard/test_send_feedback.py
@@ -1,0 +1,91 @@
+"""Acceptance tests for the #301 send-feedback repairs.
+
+Pre-registered before the fix: a fresh install's stored-credential error
+must name the real problem, a send rejected before a run starts must not
+orphan the user message in the transcript, and the favicon must resolve.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ursa import security
+from ursa_dashboard.app import create_app
+from ursa_dashboard.credentials import (
+    CredentialConfigurationError,
+    MemoryCredentialStore,
+    resolve_api_key,
+)
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(security, "URSA_CACHE_DIR", tmp_path / "ursa-cache")
+    app = create_app(credential_store=MemoryCredentialStore())
+    with TestClient(app) as test_client:
+        yield test_client, tmp_path
+
+
+def _make_session(test_client) -> str:
+    response = test_client.post(
+        "/sessions",
+        json={"agent_id": "chat_agent", "workspace_mode": "temporary"},
+    )
+    assert response.status_code == 200
+    return response.json()["session"]["session_id"]
+
+
+def test_fresh_install_stored_source_names_the_real_problem():
+    # A fresh install defaults to credential_source="stored" with no
+    # credential_id; the error must say no key has been saved yet, not
+    # that a stored reference is invalid.
+    with pytest.raises(CredentialConfigurationError, match="saved yet"):
+        resolve_api_key(
+            {"credential_source": "stored", "credential_id": None},
+            group="default",
+            kind="llm",
+            store=MemoryCredentialStore(),
+        )
+
+
+def test_mismatched_stored_reference_stays_invalid():
+    # Characterization: a non-empty wrong reference keeps the
+    # invalid-reference wording.
+    with pytest.raises(CredentialConfigurationError, match="invalid"):
+        resolve_api_key(
+            {
+                "credential_source": "stored",
+                "credential_id": "llm:not-this-group",
+            },
+            group="default",
+            kind="llm",
+            store=MemoryCredentialStore(),
+        )
+
+
+def test_failed_send_does_not_orphan_the_user_message(client):
+    test_client, _ = client
+    session_id = _make_session(test_client)
+
+    response = test_client.post(
+        f"/sessions/{session_id}/message", json={"text": "hello"}
+    )
+
+    assert response.status_code == 400
+    transcript = test_client.get(f"/sessions/{session_id}/messages").json()
+    assert transcript == [], (
+        "a send rejected before a run starts must not persist the user "
+        "message as an unanswered transcript entry"
+    )
+
+
+def test_favicon_is_served(client):
+    test_client, _ = client
+
+    response = test_client.get("/favicon.ico")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("image/")


### PR DESCRIPTION
## Summary

Addresses the behaviors reported in #301 (full diagnosis with reproduction evidence in that thread). On current main a brand new install's chat composer accepts input while Send silently does nothing, and once a session exists, a send that fails before a run starts surfaces only as a browser alert with a misleading message while storing the user message as an unanswered transcript entry. This PR makes every pre-run failure visible and honest. The session snapshot semantics discussed in #301 are deliberately untouched pending direction.

## Changes

1. The composer starts disabled with a "Create a session to start chatting" placeholder and is enabled per session state. The no-session hint that already existed in the code now renders on first load, so a fresh install shows guidance instead of a blank chat column and a dead but live-looking Send button.
2. Credential validation now runs before the user message is persisted in the message route. A rejected send returns its 400 without storing an unanswered "You" entry that would reappear on the next load. The typed text stays in the composer for retry.
3. A fresh install's stored-credential failure now says what is actually wrong: "No llm API key has been saved yet. Save one in Settings or switch the credential source." The previous wording ("The stored llm credential reference is invalid.") remains for a genuinely mismatched non-empty reference and is pinned by a characterization test.
4. Send failures render as an inline error in the chat column instead of a browser alert.
5. /favicon.ico serves the packaged logo, removing the console 404 on every load. The route is unauthenticated by design since browsers fetch favicons without credentials; the logo is already shipped in the wheel.

## Behavior changes to be aware of

- A send rejected during validation no longer appends the user message to the transcript. Previously it did, which orphaned messages; the message is preserved client side instead.
- Error feedback for failed sends moved from alert dialogs to inline chat-column rendering.

## Tests

Four new tests in tests/dashboard/test_send_feedback.py, written and committed red first (f7bf353) and flipped green by the fix commit with zero test edits: the fresh-install error wording, the no-orphan guarantee through the real route with a TestClient and the in-memory credential store, the favicon route, and the characterization pin for the mismatched-reference wording. Running the test commit without the fix commit reproduces the exact 3 failed / 1 passed pattern. Full suite locally: 366 passed, 10 skipped; the only failure is the pre-existing OPENAI_API_KEY smoke test.

The frontend half was acceptance-tested against a real Chrome on a pristine instance: fresh load shows the disabled composer, the placeholder, and the rendered hint, and typing is refused; with a session under fresh defaults, a send produces the inline error with the corrected message, fires no dialog, keeps the typed text, and leaves the transcript empty. Happy to attach the screenshots and the scripted run if useful.

## Non-goals

The per-session llm snapshot behavior (a session created before a key is configured keeps failing after Settings are fixed, and the session settings dialog does not expose credential source) is documented in #301 with a workaround and a direction question. Whichever way you prefer, that change belongs in its own PR.
