### PR TITLE
fix: keep deep-review role prompts out of the message channel

### DIFF
--- a/src/ursa/agents/deep_review_agent.py
+++ b/src/ursa/agents/deep_review_agent.py
@@ -9,7 +9,6 @@ from typing import Annotated, Any, Literal, Mapping, TypedDict, cast
 from langchain.chat_models import BaseChatModel
 from langchain.tools import BaseTool
 from langchain_core.messages import (
-    AIMessage,
     BaseMessage,
     HumanMessage,
     SystemMessage,
@@ -268,24 +267,37 @@ class DeepReviewAgent(AgentWithTools, BaseAgent[DeepReviewState]):
         new_phase_messages: list[BaseMessage] = []
         if state.get("active_phase") != phase:
             new_phase_messages = [
-                SystemMessage(content=self._role_system_prompt(phase)),
                 HumanMessage(content=self._phase_prompt(phase, state)),
             ]
             messages.extend(new_phase_messages)
 
+        # The phase's role prompt is prepended per request and never
+        # persisted: providers such as Anthropic require system messages
+        # to form a leading prefix, so the accumulated channel must stay
+        # system-free. Persisted systems from checkpoints created before
+        # this change are filtered from the outbound request only.
+        request_messages = [
+            SystemMessage(content=self._role_system_prompt(phase)),
+            *(
+                message
+                for message in messages
+                if not isinstance(message, SystemMessage)
+            ),
+        ]
+
         try:
             response = self.tool_llm.invoke(
-                messages,
+                request_messages,
                 self.build_config(tags=["deep_review", phase]),
             )
-        except Exception as exc:  # noqa: BLE001
-            response = AIMessage(content=f"Deep-review phase error: {exc}")
+        except Exception as exc:
             events.emit(
                 "Deep-review phase failed",
                 stage=f"{phase}_error",
                 error_type=type(exc).__name__,
                 error=str(exc),
             )
+            raise
 
         update: dict[str, Any] = {
             "messages": [*new_phase_messages, response],

--- a/tests/agents/test_deep_review_agent/test_deep_review_agent.py
+++ b/tests/agents/test_deep_review_agent/test_deep_review_agent.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
-from langchain_core.messages import AIMessage, ToolMessage
+from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
 
 from ursa.agents.deep_review_agent import DeepReviewAgent
 
@@ -145,3 +145,119 @@ def test_deep_review_agent_exposes_web_tools_only_when_enabled(
     assert "run_web_search" in with_web.tools
     assert "run_arxiv_search" in with_web.tools
     assert "run_osti_search" in with_web.tools
+
+
+def _recording_model(log: list) -> ToolReadyFakeChatModel:
+    """Fake model that records every request's message list."""
+
+    class _Recorder(ToolReadyFakeChatModel):
+        def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+            log.append(list(messages))
+            return super()._generate(
+                messages, stop=stop, run_manager=run_manager, **kwargs
+            )
+
+    return _Recorder(messages=_message_stream("ok"))
+
+
+def _exploding_model(calls: list) -> ToolReadyFakeChatModel:
+    """Fake model that raises on every call and counts the calls."""
+
+    class _Exploder(ToolReadyFakeChatModel):
+        def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+            calls.append(len(messages))
+            raise RuntimeError("provider exploded")
+
+    return _Exploder(messages=_message_stream("unused"))
+
+
+def _system_prefix_ok(messages) -> bool:
+    seen_non_system = False
+    for message in messages:
+        if isinstance(message, SystemMessage):
+            if seen_non_system:
+                return False
+        else:
+            seen_non_system = True
+    return True
+
+
+_QUESTION = {
+    "question": "How can we reduce cooling energy usage?",
+    "current_iteration": 0,
+    "max_iterations": 1,
+}
+
+
+@pytest.mark.asyncio
+async def test_phase_requests_keep_system_prompts_leading(tmpdir):
+    # Issue 294: from the second debate phase onward, requests carried
+    # mid-conversation system messages, which langchain-anthropic rejects.
+    log: list = []
+    agent = DeepReviewAgent(llm=_recording_model(log), workspace=tmpdir)
+
+    await agent.ainvoke(dict(_QUESTION))
+
+    assert log, "no model requests captured"
+    bad = [
+        [type(message).__name__ for message in request]
+        for request in log
+        if not _system_prefix_ok(request)
+    ]
+    assert not bad, f"requests with mid-conversation system messages: {bad}"
+
+
+@pytest.mark.asyncio
+async def test_phase_prompts_not_persisted_as_system_messages(tmpdir):
+    log: list = []
+    agent = DeepReviewAgent(llm=_recording_model(log), workspace=tmpdir)
+
+    result = await agent.ainvoke(dict(_QUESTION))
+
+    persisted_systems = [
+        message
+        for message in result.get("messages", [])
+        if isinstance(message, SystemMessage)
+    ]
+    assert persisted_systems == [], (
+        "phase role prompts must not accumulate in the message channel"
+    )
+
+
+@pytest.mark.asyncio
+async def test_each_phase_request_leads_with_its_own_role_prompt(tmpdir):
+    log: list = []
+    agent = DeepReviewAgent(llm=_recording_model(log), workspace=tmpdir)
+
+    await agent.ainvoke(dict(_QUESTION))
+
+    leading_prompts = [
+        request[0].content
+        for request in log
+        if request and isinstance(request[0], SystemMessage)
+    ]
+    assert len(leading_prompts) >= 3, (
+        "each debate phase should lead its request with a system prompt"
+    )
+    assert len(set(leading_prompts)) >= 3, (
+        "phases received identical leading role prompts"
+    )
+
+
+@pytest.mark.asyncio
+async def test_phase_model_error_propagates_immediately(tmpdir):
+    # Issue 294: phase errors were swallowed into AIMessage critiques
+    # ("Deep-review phase error: ...") and fed to later phases, so a
+    # failing model still produced a normal-looking run. The first
+    # failure must propagate before any further model call happens.
+    calls: list = []
+    agent = DeepReviewAgent(llm=_exploding_model(calls), workspace=tmpdir)
+
+    with pytest.raises(RuntimeError, match="provider exploded"):
+        await agent.ainvoke(dict(_QUESTION))
+
+    assert len(calls) == 1, (
+        "the first phase failure must propagate immediately, not be "
+        "swallowed into critique text while later phases keep calling "
+        f"the model (saw {len(calls)} calls)"
+    )


### PR DESCRIPTION
## Summary

Fixes #294. Each debate phase persisted its role prompt as a SystemMessage into the shared add_messages channel, so from the second phase onward every request carried mid-conversation system messages, which langchain-anthropic rejects (ValueError: "Received multiple non-consecutive system messages."). The phase call sat in a broad except that substituted "Deep-review phase error: ..." as the phase output, so on Anthropic-backed models deep review completed normally while its critiques and perspectives were literally that error string feeding later phases and the final solution. OpenAI-compatible endpoints accept mid-conversation system roles, which is why this went unnoticed.

Of the three fix directions offered in the issue, this implements the middle one: phase role prompts stay out of the accumulated channel entirely and are passed per call.

## The change

The channel now keeps only the human phase prompts, model responses, and tool results. Each request is built as the current phase's role prompt in leading position plus the system-free history, so requests are provider-valid by construction. Three behavior consequences, all intended:

1. The persisted transcript no longer contains SystemMessages. Checkpoints written before this change may still carry them; those are filtered from the outbound request only, never rewritten in state.
2. Tool-loop continuations now also lead with the current phase's role prompt. Previously they reused whatever persisted systems had accumulated, so a continuation request in phase two carried phase one's prompt as its leading system.
3. A phase model failure now emits its telemetry event and propagates instead of being swallowed into critique text. A failing provider call fails the run visibly rather than producing a normal-looking review built on error strings.

## Evidence

Four tests, committed red first and flipped by the fix with no test edits: every request keeps system messages as a leading prefix; role prompts never persist into the channel; each debate phase leads its request with its own distinct role prompt; and a phase failure propagates before any further model call happens (the propagation test counts model calls, because with the old swallow the error only surfaced later from the synthesis step, after three phases of garbage). Running the test commit without the fix commit reproduces the exact 4 failed / 3 passed pattern.

As an end-to-end check against the real provider adapter, every request emitted by a full fixed-agent run passes langchain-anthropic's own message formatter (the function that rejected the old shape). The request shapes from that run:

```
['SystemMessage', 'HumanMessage']
['SystemMessage', 'HumanMessage', 'AIMessage', 'HumanMessage']
['SystemMessage', 'HumanMessage', 'AIMessage', 'HumanMessage', 'AIMessage', 'HumanMessage']
['HumanMessage']
['HumanMessage']
```

The last two are the plain-string synthesis calls. Before the fix, the second request was ['SystemMessage', 'HumanMessage', 'AIMessage', 'SystemMessage', 'HumanMessage'].

Full suite locally: 366 passed, 10 skipped; the only failure is the pre-existing OPENAI_API_KEY smoke test.

## Interaction with #297

The regression harness in #297 pins this bug as a strict xfail referencing #294. Whichever lands second turns that strict xfail into an XPASS failure until the marker is removed, at which point it becomes an enforced invariant; happy to update #297 accordingly after this merges.
