### PR TITLE
fix: land context summaries as human-role messages

### DIFF
--- a/src/ursa/agents/base.py
+++ b/src/ursa/agents/base.py
@@ -918,7 +918,24 @@ class BaseAgent(Generic[TState], ABC):
         if system_prompt is not None:
             first_message = SystemMessage(content=system_prompt)
 
-        new_state["messages"] = [first_message, summary] + conversation_to_keep
+        # The summary lands as human-role context rather than as the raw
+        # assistant message: with messages_to_keep=0 (and in the absorbed
+        # tool-tail case) the summary is the final message, and a history
+        # ending on an assistant turn is a request shape Claude 4.6 and
+        # newer reject (issue 296).
+        summary_message = HumanMessage(
+            content="[Summary of the earlier conversation]\n"
+            + (
+                summary.text
+                if isinstance(summary.text, str)
+                else str(summary.content)
+            ),
+            id=summary.id,
+        )
+        new_state["messages"] = [
+            first_message,
+            summary_message,
+        ] + conversation_to_keep
         return new_state, True
 
     def prepare_messages_context(

--- a/tests/agents/test_summarize_context.py
+++ b/tests/agents/test_summarize_context.py
@@ -1,0 +1,192 @@
+"""Acceptance tests for the 296 summarization repair.
+
+Pre-registered before the fix: a summarized history must never end on
+the assistant summary (the request shape Claude 4.6 and newer reject),
+for messages_to_keep=0 and for the tool-tail absorption edge case, with
+the summary landing as framed human-role context.
+"""
+
+from collections.abc import Iterator
+
+from langchain_core.language_models.fake_chat_models import (
+    GenericFakeChatModel,
+)
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+
+from ursa.agents.chat_agent import ChatAgent
+
+
+def _message_stream(content: str) -> Iterator[AIMessage]:
+    while True:
+        yield AIMessage(
+            content=content,
+            usage_metadata={
+                "input_tokens": 1,
+                "output_tokens": 1,
+                "total_tokens": 2,
+            },
+        )
+
+
+def _recording_model(log: list) -> GenericFakeChatModel:
+    class _Recorder(GenericFakeChatModel):
+        def bind_tools(self, tools, **kwargs):
+            return self
+
+        def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+            log.append(list(messages))
+            return super()._generate(
+                messages, stop=stop, run_manager=run_manager, **kwargs
+            )
+
+    return _Recorder(messages=_message_stream("summary of the chat"))
+
+
+def _agent(log: list, keep: int, workspace) -> ChatAgent:
+    return ChatAgent(
+        llm=_recording_model(log),
+        workspace=workspace,
+        tokens_before_summarize=1,
+        messages_to_keep=keep,
+    )
+
+
+def _long(text: str) -> str:
+    return text + " filler" * 50
+
+
+def test_keep_zero_state_does_not_end_on_assistant(tmp_path):
+    log: list = []
+    agent = _agent(log, keep=0, workspace=tmp_path)
+    state = {
+        "messages": [
+            SystemMessage("sys prompt"),
+            HumanMessage(_long("first question")),
+            AIMessage(_long("first answer")),
+            HumanMessage(_long("second question")),
+        ]
+    }
+
+    new_state, changed = agent._summarize_context(state)
+
+    assert changed is True
+    assert not isinstance(new_state["messages"][-1], AIMessage), (
+        "messages_to_keep=0 must not leave the history ending on the "
+        "assistant summary (the request shape Claude 4.6+ rejects)"
+    )
+
+
+def test_summary_lands_as_framed_human_message(tmp_path):
+    log: list = []
+    agent = _agent(log, keep=0, workspace=tmp_path)
+    state = {
+        "messages": [
+            SystemMessage("sys prompt"),
+            HumanMessage(_long("first question")),
+            AIMessage(_long("first answer")),
+            HumanMessage(_long("second question")),
+        ]
+    }
+
+    new_state, changed = agent._summarize_context(state)
+
+    assert changed is True
+    summary_message = new_state["messages"][1]
+    assert isinstance(summary_message, HumanMessage), (
+        "the summary must land as human-role context"
+    )
+    assert summary_message.content.startswith(
+        "[Summary of the earlier conversation]"
+    )
+    assert "summary of the chat" in summary_message.content
+
+
+def test_absorbed_tool_tail_still_ends_human(tmp_path):
+    # The narrow case from issue 296: the kept tail is only tool results
+    # whose calls were summarized away; dangling-pair preservation moves
+    # them into the summarized block, so the summary becomes the final
+    # message even with a nonzero messages_to_keep.
+    log: list = []
+    agent = _agent(log, keep=1, workspace=tmp_path)
+    state = {
+        "messages": [
+            SystemMessage("sys prompt"),
+            HumanMessage(_long("question")),
+            AIMessage(
+                _long("calling a tool"),
+                tool_calls=[
+                    {
+                        "name": "some_tool",
+                        "args": {},
+                        "id": "call-1",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+            ToolMessage(content=_long("tool output"), tool_call_id="call-1"),
+        ]
+    }
+
+    new_state, changed = agent._summarize_context(state)
+
+    assert changed is True
+    assert not isinstance(new_state["messages"][-1], AIMessage), (
+        "an absorbed tool tail must not leave the assistant summary as "
+        "the final message"
+    )
+
+
+def test_nonzero_keep_preserves_the_kept_tail(tmp_path):
+    # Guard (green before and after the fix): a normal nonzero
+    # messages_to_keep keeps the requested tail behind the summary.
+    log: list = []
+    agent = _agent(log, keep=2, workspace=tmp_path)
+    state = {
+        "messages": [
+            SystemMessage("sys prompt"),
+            HumanMessage(_long("first question")),
+            AIMessage(_long("first answer")),
+            HumanMessage(_long("second question")),
+            AIMessage(_long("second answer")),
+            HumanMessage(_long("third question")),
+        ]
+    }
+
+    new_state, changed = agent._summarize_context(state)
+
+    assert changed is True
+    kept = new_state["messages"][-2:]
+    assert [(type(m), m.content) for m in kept] == [
+        (AIMessage, _long("second answer")),
+        (HumanMessage, _long("third question")),
+    ]
+    assert len(new_state["messages"]) == 4
+    assert isinstance(new_state["messages"][0], SystemMessage)
+
+
+def test_post_summarization_request_is_not_assistant_final(tmp_path):
+    # The issue's request-level repro: with messages_to_keep=0 the next
+    # model call after summarization must not end on the assistant
+    # summary.
+    log: list = []
+    agent = _agent(log, keep=0, workspace=tmp_path)
+
+    agent.invoke({
+        "messages": [
+            HumanMessage(_long("first question")),
+            AIMessage(_long("first answer")),
+            HumanMessage(_long("second question")),
+        ]
+    })
+
+    assert len(log) >= 2, "expected a summarizer call and a chat call"
+    post_summarization_request = log[-1]
+    assert not isinstance(post_summarization_request[-1], AIMessage), (
+        "post-summarization request ends on "
+        f"{type(post_summarization_request[-1]).__name__}"
+    )


### PR DESCRIPTION
## Summary

Fixes #296. `_summarize_context` placed the summarizer's raw AIMessage directly into the rebuilt history, so with `messages_to_keep=0` the state became `[first_message, AIMessage(summary)]` and the next model call sent a conversation ending on the assistant summary. Claude 4.6 and newer reject that request shape with "This model does not support assistant message prefill", the same failure class as #283. The issue also documents a narrower path to the same shape with nonzero `messages_to_keep`: when the kept tail is only tool results whose calls were summarized away, dangling-pair preservation absorbs them into the summarized block and the summary is again the final message.

Of the two fix directions offered in the issue, this implements the first: the summary lands as human-role context, which guarantees the rebuilt history continues from a human turn regardless of configuration.

## The change

The summary is now stored as a framed human message ("[Summary of the earlier conversation]" followed by the summary text) instead of the raw assistant reply. The summarizer input is unchanged, byte-for-byte. Request shapes from the issue's own repro (ChatAgent, `tokens_before_summarize=1`, `messages_to_keep=0`, three-message history):

```
before  call 0: ['system', 'ai', 'human', 'human']   (summarizer call, unchanged)
before  call 1: ['human', 'ai']                       (ends on the assistant summary)

after   call 0: ['system', 'ai', 'human', 'human']   (identical)
after   call 1: ['human', 'human']                    (ends on the human summary)
```

One behavior consequence to be aware of: persisted histories now carry the summary as a HumanMessage with that frame, not as an AIMessage. Consecutive human messages are valid for the providers URSA targets, and the one role-sensitive reader, the legacy fallback in ExecutionAgent._get_current_user_request, degrades gracefully: with messages_to_keep=0 it now resolves the framed summary as the latest human message, where before it fell through to the same summary text as the final message; normal invokes capture current_user_request up front and never reach that fallback.

## Scope

The `self.tool_llm` AttributeError of #295 lives in the same function and is deliberately not touched here; that issue has its own thread and a pending direction question.

## Tests

Five tests in a new tests/agents/test_summarize_context.py, four committed red first and flipped by the fix with no test edits: the `messages_to_keep=0` state shape, the framed human-role landing, the absorbed tool-tail edge from the issue, and the issue's request-level repro asserting the post-summarization request does not end on an assistant turn. A green guard pins that a nonzero `messages_to_keep` still preserves the requested tail. Running the test commit without the fix commit reproduces the exact 4 failed / 1 passed pattern. Full suite locally: 367 passed, 1 failed, 10 skipped; the failure is the pre-existing OPENAI_API_KEY smoke test.

## Interaction with #297

The regression harness in #297 pins this bug as two strict xfails referencing #296 (the keep-zero and absorbed tool-tail cases). Whichever lands second turns those xfails into XPASS failures until the markers are removed, at which point they become enforced invariants; happy to update #297 accordingly after this merges.
