### PR TITLE
fix: return only the visited-sites update from print_visited_sites

### DIFF
--- a/src/ursa/agents/deep_review_agent.py
+++ b/src/ursa/agents/deep_review_agent.py
@@ -387,7 +387,13 @@ class DeepReviewAgent(AgentWithTools, BaseAgent[DeepReviewState]):
         state: DeepReviewState,
         config: RunnableConfig | None = None,
     ) -> DeepReviewState:
-        return state.copy()
+        # Return only this node's own update: langgraph applies a node's
+        # return value through each key's reducer, so returning the full
+        # accumulated state re-adds every operator.add key to itself.
+        return cast(
+            DeepReviewState,
+            {"visited_sites": self._collect_visited_sites(state)},
+        )
 
     @staticmethod
     def _escape_latex(text: Any) -> str:

--- a/tests/agents/test_deep_review_agent/test_deep_review_agent.py
+++ b/tests/agents/test_deep_review_agent/test_deep_review_agent.py
@@ -145,3 +145,117 @@ def test_deep_review_agent_exposes_web_tools_only_when_enabled(
     assert "run_web_search" in with_web.tools
     assert "run_arxiv_search" in with_web.tools
     assert "run_osti_search" in with_web.tools
+
+
+def _distinct_stream() -> Iterator[AIMessage]:
+    n = 0
+    while True:
+        n += 1
+        yield AIMessage(
+            content=f"turn-{n:02d}",
+            usage_metadata={
+                "input_tokens": 1,
+                "output_tokens": 1,
+                "total_tokens": 2,
+            },
+        )
+
+
+_DD_QUESTION = {
+    "question": "How can we reduce cooling energy usage?",
+    "current_iteration": 0,
+    "max_iterations": 1,
+}
+
+
+@pytest.mark.asyncio
+async def test_output_lists_have_exactly_one_entry_per_iteration(tmpdir):
+    # One real iteration must produce exactly one entry per output list;
+    # the previous >= 1 assertions were green with every entry doubled.
+    agent = DeepReviewAgent(
+        llm=ToolReadyFakeChatModel(messages=_message_stream("ok")),
+        workspace=tmpdir,
+    )
+
+    result = await agent.ainvoke(dict(_DD_QUESTION))
+
+    assert result["agent1_solution"] == ["ok"]
+    assert result["agent2_critiques"] == ["ok"]
+    assert result["agent3_perspectives"] == ["ok"]
+
+
+@pytest.mark.asyncio
+async def test_output_lists_scale_with_iterations(tmpdir):
+    agent = DeepReviewAgent(
+        llm=ToolReadyFakeChatModel(messages=_message_stream("ok")),
+        workspace=tmpdir,
+    )
+
+    result = await agent.ainvoke({**_DD_QUESTION, "max_iterations": 2})
+
+    for key in ("agent1_solution", "agent2_critiques", "agent3_perspectives"):
+        assert len(result[key]) == 2, f"{key}: {result[key]}"
+
+
+@pytest.mark.asyncio
+async def test_chained_runs_report_real_iterations_only(tmpdir):
+    # Chaining a second run on the first run's returned state (the HITL
+    # pattern) must report exactly the real iterations, with each report
+    # section attributed to its own iteration's content.
+    agent = DeepReviewAgent(
+        llm=ToolReadyFakeChatModel(messages=_distinct_stream()),
+        workspace=tmpdir,
+    )
+
+    run1 = await agent.ainvoke(dict(_DD_QUESTION))
+    run2 = await agent.ainvoke(
+        agent.format_query(
+            "How can we reduce cooling energy usage?", state=run1
+        )
+    )
+
+    for key in ("agent1_solution", "agent2_critiques", "agent3_perspectives"):
+        assert len(run2[key]) == 2, f"{key}: {run2[key]}"
+    details = sorted(agent.workspace.glob("iteration_details_*.txt"))
+    text = details[-1].read_text(encoding="utf-8")
+    sections = text.split("\\subsection")
+    assert len(sections) - 1 == 2, (
+        f"expected 2 report sections, found {len(sections) - 1}"
+    )
+    assert "turn-01" in sections[1]
+    assert "turn-06" in sections[2]
+
+
+@pytest.mark.asyncio
+async def test_seeded_visited_sites_survive(tmpdir):
+    # Guard (green before and after the fix): visited sites provided in
+    # the input state survive to the returned state.
+    agent = DeepReviewAgent(
+        llm=ToolReadyFakeChatModel(messages=_message_stream("ok")),
+        workspace=tmpdir,
+    )
+
+    result = await agent.ainvoke({
+        **_DD_QUESTION,
+        "visited_sites": {"https://seeded.example/x"},
+    })
+
+    assert "https://seeded.example/x" in result["visited_sites"]
+
+
+@pytest.mark.asyncio
+async def test_details_file_has_one_section_per_iteration(tmpdir):
+    # Guard (green before and after the fix): a single run's report has
+    # exactly one section per real iteration, protecting the
+    # finalize-summarize-print ordering against future rewiring.
+    agent = DeepReviewAgent(
+        llm=ToolReadyFakeChatModel(messages=_message_stream("ok")),
+        workspace=tmpdir,
+    )
+
+    await agent.ainvoke({**_DD_QUESTION, "max_iterations": 2})
+
+    text = sorted(agent.workspace.glob("iteration_details_*.txt"))[
+        -1
+    ].read_text(encoding="utf-8")
+    assert text.count("\\subsection") == 2


### PR DESCRIPTION
## Summary

Fixes #312. The final graph node returned the entire accumulated state, and langgraph folds a node's return value through each key's reducer, so the three `operator.add` output lists re-added their own contents once per run: every per-iteration entry came back doubled, and because the HITL REPL chains each run's returned state into the next invocation, a chained run reported phantom iterations with duplicated content and fed them to the final-solution and LaTeX summary prompts. The full diagnosis, with the mechanism and its scope, is in the issue.

## The change

One line of behavior: `print_visited_sites` now returns only the update it is responsible for, `{"visited_sites": self._collect_visited_sites(state)}`, adding one defensive effect (the same fold of tool-message URLs into the visited set that the phase nodes already perform, idempotent under the `or_` reducer) and touching nothing else. Single-run reports, phase prompts, and all other state keys were already correct and are unchanged.

## Tests

Five tests, three committed red first and flipped by the one-line fix with no test edits: one entry per output list per real iteration, exact scaling with `max_iterations`, and a chained two-run scenario with distinct per-call content asserting exactly two report sections with each section attributed to its own iteration's content. Two green guards pin that seeded `visited_sites` survive to the returned state and that a single run's report keeps one section per iteration. The pre-existing assertions checked only `len(...) >= 1`, which is why the doubling passed unnoticed; they are superseded by the exact counts. Running the test commit without the fix commit reproduces the exact 3 failed / 5 passed pattern. Full suite locally: 374 passed, 1 failed, 10 skipped; the failure is the pre-existing test_example_config_smoke, which requires OPENAI_API_KEY.
