### PR TITLE
Layered Config Files and Reusable Inference Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ A reusable YAML configuration file is the preferred way to select endpoints and 
 ```yaml
 llm_model:
   model: openai:gpt-5.2
-  api_key_env: OPENAI_API_KEY
+  api_key:
+    env: OPENAI_API_KEY
 workspace: .
 ```
 

--- a/configs/README.md
+++ b/configs/README.md
@@ -19,25 +19,17 @@ Supported environmental variables for the CLI can be viewed by running: `ursa --
 
 ## Default Configuration Options
 
-The default configuration is defined by [src/ursa/cli/config.py](../src/ursa/cli/config.py).
-An [example configuration file](./example.yaml) is provided.
-
-For configuration concepts, precedence, and printing merged vs resolved config, see:
-
-- <https://lanl.github.io/ursa/configuration/>
-- <https://lanl.github.io/ursa/configuration/files-and-env/>
-
-To see the full resolved configuration, including defaults, run:
-`ursa --print-config`.
+See the [example configuration file](./example.yaml) and the
+[configuration guide](https://lanl.github.io/ursa/configuration/). To print the
+full active configuration, including defaults, run `ursa --print-config`.
 
 Configuration files can be provided in [JSON](https://www.json.org/) or [YAML](https://yaml.org/) formats.
 
 ## Configuring Agents
 
-For `agent_config`, `use_web`, and per-agent configuration behavior, see:
-
-- <https://lanl.github.io/ursa/configuration/>
-- <https://lanl.github.io/ursa/getting-started/cli/>
+Set per-agent options under `agent_config`, keyed by the agent's HITL command
+name. See the [configuration guide](https://lanl.github.io/ursa/configuration/)
+for an example.
 
 The current agent configuration (excluding defaults) can be viewed using the `agents` command
 from URSA's HITL (run `ursa` then type `agents`).

--- a/configs/README.md
+++ b/configs/README.md
@@ -27,7 +27,11 @@ For configuration concepts, precedence, and printing merged vs resolved config, 
 - <https://lanl.github.io/ursa/configuration/>
 - <https://lanl.github.io/ursa/configuration/files-and-env/>
 
-To see the default resolved configuration run: `ursa --print-config`
+To see active non-default resolved settings run: `ursa --print-config`
+
+Configuration sources are sparse: omitted keys preserve lower-precedence or
+provider values, while explicit `null` clears nullable settings. The
+`ssl_verify` setting is boolean and defaults to `true`.
 
 Configuration files can be provided in [JSON](https://www.json.org/) or [YAML](https://yaml.org/) formats.
 

--- a/configs/README.md
+++ b/configs/README.md
@@ -20,23 +20,23 @@ Supported environmental variables for the CLI can be viewed by running: `ursa --
 ## Default Configuration Options
 
 The default configuration is defined by [src/ursa/cli/config.py](../src/ursa/cli/config.py).
-However, for many options (Agent config, MCP servers) the available options are documented by
-their respective subsystems. An [example configuration file](./example.yaml) is provided.
+An [example configuration file](./example.yaml) is provided.
 
-To see the default configuration run: `ursa --print-config`
+For configuration concepts, precedence, and printing merged vs resolved config, see:
+
+- <https://lanl.github.io/ursa/configuration/>
+- <https://lanl.github.io/ursa/configuration/files-and-env/>
+
+To see the default resolved configuration run: `ursa --print-config`
 
 Configuration files can be provided in [JSON](https://www.json.org/) or [YAML](https://yaml.org/) formats.
 
 ## Configuring Agents
 
-URSA Agents can be configured using the `agent_config` field in a configuration file.
-Exact options are dependent on the agent (see their documentation) and is limited to
-options that can be expressed in a YAML file.
+For `agent_config`, `use_web`, and per-agent configuration behavior, see:
 
-Agent configurations are keyed by their subcommand name in the HITL. For example,
-the ExecutionAgent's config is under `execute`.
-
-The Memory agent (used by the ExecutionAgent and RecallAgent) is keyed under `memory`.
+- <https://lanl.github.io/ursa/configuration/>
+- <https://lanl.github.io/ursa/getting-started/cli/>
 
 The current agent configuration (excluding defaults) can be viewed using the `agents` command
 from URSA's HITL (run `ursa` then type `agents`).

--- a/configs/README.md
+++ b/configs/README.md
@@ -27,11 +27,7 @@ For configuration concepts, precedence, and printing merged vs resolved config, 
 - <https://lanl.github.io/ursa/configuration/>
 - <https://lanl.github.io/ursa/configuration/files-and-env/>
 
-To see active non-default resolved settings run: `ursa --print-config`
-
-Configuration sources are sparse: omitted keys preserve lower-precedence or
-provider values, while explicit `null` clears nullable settings. The
-`ssl_verify` setting is boolean and defaults to `true`.
+To see active non-default resolved settings, run: `ursa --print-config`
 
 Configuration files can be provided in [JSON](https://www.json.org/) or [YAML](https://yaml.org/) formats.
 

--- a/configs/README.md
+++ b/configs/README.md
@@ -27,7 +27,8 @@ For configuration concepts, precedence, and printing merged vs resolved config, 
 - <https://lanl.github.io/ursa/configuration/>
 - <https://lanl.github.io/ursa/configuration/files-and-env/>
 
-To see active non-default resolved settings, run: `ursa --print-config`
+To see the full resolved configuration, including defaults, run:
+`ursa --print-config`.
 
 Configuration files can be provided in [JSON](https://www.json.org/) or [YAML](https://yaml.org/) formats.
 

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -2,7 +2,7 @@
 # For most keys, the exact configuration options are a combination of model/agent dependent
 # A subset of these options are surfaced via command line flags or environmental variables.
 # The rest must be set by providing a configuration file via the `--config` flag
-# To see active non-default resolved settings run `ursa --print-config`
+# To see the full resolved configuration, including defaults, run `ursa --print-config`
 workspace: tmp
 group: default
 use_web: true

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -2,7 +2,7 @@
 # For most keys, the exact configuration options are a combination of model/agent dependent
 # A subset of these options are surfaced via command line flags or environmental variables.
 # The rest must be set by providing a configuration file via the `--config` flag
-# To see the default resolved configuration run `ursa --print-config`
+# To see active non-default resolved settings run `ursa --print-config`
 workspace: tmp
 group: default
 use_web: true
@@ -10,6 +10,7 @@ inference_providers:
   openai_public:
     base_url: https://api.openai.com/v1
     api_key_env: OPENAI_API_KEY
+    # ssl_verify is boolean and defaults to true.
 llm_model:
   # Additional configuration options can be specified here
   # Exact options are model dependent, see the LangGraph docs
@@ -18,6 +19,7 @@ llm_model:
   model: openai:gpt-5.2
   max_completion_tokens: 10000
   inference_provider: openai_public
+  # Omitted provider settings are inherited. Use null only to clear a nullable value.
 emb_model:
   # The embedding model (default none) can similarly be configured
   # Exact options are model/provider dependent, see the LangGraph docs

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -1,8 +1,5 @@
-# The URSA configuration options are defined by UrsaConfig in src/ursa/cli/config.py
-# For most keys, the exact configuration options are a combination of model/agent dependent
-# A subset of these options are surfaced via command line flags or environmental variables.
-# The rest must be set by providing a configuration file via the `--config` flag
-# To see the full resolved configuration, including defaults, run `ursa --print-config`
+# Example URSA configuration. Run with `ursa --config configs/example.yaml`.
+# Add `--print-config` to that command to inspect the full configuration.
 workspace: tmp
 group: default
 use_web: true
@@ -11,38 +8,29 @@ inference_providers:
     base_url: https://api.openai.com/v1
     api_key_env: OPENAI_API_KEY
 llm_model:
-  # Additional configuration options can be specified here
-  # Exact options are model dependent, see the LangGraph docs
+  # Model options depend on the selected provider:
   # https://reference.langchain.com/python/langchain/models/#langchain.chat_models.init_chat_model
-  # Provider Overview: https://docs.langchain.com/oss/python/integrations/providers/overview
   model: openai:gpt-5.2
   max_completion_tokens: 10000
   inference_provider: openai_public
 emb_model:
-  # The embedding model (default none) can similarly be configured
-  # Exact options are model/provider dependent, see the LangGraph docs
+  # Embedding options also depend on the provider:
   # https://reference.langchain.com/python/langchain/embeddings/#langchain.embeddings.init_embeddings
   model: ollama:nomic-embed-text:latest
   base_url: http://localhost:11434
 agent_config:
-  # Top-level use_web: true fills in missing use_web values for chat, execute,
-  # deep_review, and prompt, but explicit per-agent values win.
+  # Per-agent values override top-level settings such as use_web.
   prompt:
     use_web: false
   chat:
     temperature: 0.2
-  # Agents can be configured by providing configuration dicts keyed to the Agents name in the HITL
-  # To get a list of agent names, launch the URSA HITL (`ursa`) then type `help`
   execute:
     safe_codes:
       - python
       - julia
       - fortran
-# MCP Servers can be connected to agents by providing a dict of MCP servers
 mcp_servers:
-  # Servers should specify a transport (stdio, streamable-http) and additional configuration
-  # parameters. The following gives an example of a stdio and streamable-http configurations
-  # Additional options are documented at:
+  # MCP transport options:
   #   stdio: https://modelcontextprotocol.github.io/python-sdk/api/?h=stdioserverparameters#mcp.StdioServerParameters
   #   streamable-http: https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/client/session_group.py#L49
   ursa:
@@ -54,13 +42,10 @@ mcp_servers:
       - --llm_model.model
       - openai:gpt-5-nano
     env:
-      # Ursa will interpolate env variables into ${VAR}
-      # fallbacks can be specified as ${VAR:Default}
+      # `${VAR:default}` supplies a fallback when VAR is unset.
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       ANOTHER_VAR: ${ANOTHER_VAR:4}
-      # More environmental variables to set for the mcp server
   ursa-http:
-    # streamable-http servers are configured when started, not here
     transport: streamable-http
     url: http://localhost:8000/mcp
-    timeout: 60 # Time out in seconds
+    timeout: 60

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -10,7 +10,6 @@ inference_providers:
   openai_public:
     base_url: https://api.openai.com/v1
     api_key_env: OPENAI_API_KEY
-    # ssl_verify is boolean and defaults to true.
 llm_model:
   # Additional configuration options can be specified here
   # Exact options are model dependent, see the LangGraph docs
@@ -19,7 +18,6 @@ llm_model:
   model: openai:gpt-5.2
   max_completion_tokens: 10000
   inference_provider: openai_public
-  # Omitted provider settings are inherited. Use null only to clear a nullable value.
 emb_model:
   # The embedding model (default none) can similarly be configured
   # Exact options are model/provider dependent, see the LangGraph docs

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -2,7 +2,14 @@
 # For most keys, the exact configuration options are a combination of model/agent dependent
 # A subset of these options are surfaced via command line flags or environmental variables.
 # The rest must be set by providing a configuration file via the `--config` flag
-# To see the default configuration run `ursa --print-config`
+# To see the default resolved configuration run `ursa --print-config`
+workspace: tmp
+group: default
+use_web: true
+inference_providers:
+  openai_public:
+    base_url: https://api.openai.com/v1
+    api_key_env: OPENAI_API_KEY
 llm_model:
   # Additional configuration options can be specified here
   # Exact options are model dependent, see the LangGraph docs
@@ -10,13 +17,20 @@ llm_model:
   # Provider Overview: https://docs.langchain.com/oss/python/integrations/providers/overview
   model: openai:gpt-5.2
   max_completion_tokens: 10000
-  api_key_env: OPENAI_API_KEY
+  inference_provider: openai_public
 emb_model:
   # The embedding model (default none) can similarly be configured
   # Exact options are model/provider dependent, see the LangGraph docs
   # https://reference.langchain.com/python/langchain/embeddings/#langchain.embeddings.init_embeddings
   model: ollama:nomic-embed-text:latest
+  base_url: http://localhost:11434
 agent_config:
+  # Top-level use_web: true fills in missing use_web values for chat, execute,
+  # deep_review, and prompt, but explicit per-agent values win.
+  prompt:
+    use_web: false
+  chat:
+    temperature: 0.2
   # Agents can be configured by providing configuration dicts keyed to the Agents name in the HITL
   # To get a list of agent names, launch the URSA HITL (`ursa`) then type `help`
   execute:

--- a/docs/best-practices/sandboxing.md
+++ b/docs/best-practices/sandboxing.md
@@ -76,7 +76,7 @@ MCP servers can expose powerful external tools. Only connect MCP servers that yo
 
 ## Protect secrets
 
-- Prefer `api_key_env` rather than literal API keys in YAML files.
+- Prefer `api_key` environment references rather than literal API keys in YAML files.
 - In the desktop dashboard, prefer **Secure system storage** so keys are kept
   in the operating system credential manager instead of configuration files.
 - Do not store API keys in persistent agent names or prompts.

--- a/docs/configuration/files-and-env.md
+++ b/docs/configuration/files-and-env.md
@@ -1,16 +1,13 @@
 # Configuration files, CLI flags, and environment variables
 
-URSA supports layered configuration. Higher-precedence sources are merged on
-top of lower-precedence sources to produce a single merged configuration, which
-is then resolved into the effective runtime configuration. Prefer YAML files
-for reusable settings, CLI flags for temporary overrides, and environment
-variables for secrets or automation.
+URSA configs can be layered. Use YAML files for reusable settings, environment
+variables for secrets or automation, and CLI flags for temporary overrides.
 
 ## Configuration precedence
 
 URSA loads configuration in this order, with later sources overriding earlier ones:
 
-1. XDG-compliant user config, typically `~/.config/ursa/config.yaml`
+1. XDG system and user config files, including `~/.config/ursa/config.yaml`
 2. The file passed to `--config`
 3. Environment variables
 4. CLI flags
@@ -18,8 +15,7 @@ URSA loads configuration in this order, with later sources overriding earlier on
 Higher-precedence sources only override settings they specify. Set a nullable
 setting to `null` to clear it.
 
-See the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/)
-for background on XDG-compliant config locations.
+XDG files follow the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/).
 
 ## YAML files: preferred
 
@@ -112,38 +108,26 @@ mcp_servers:
 
 ## Inspect the active configuration
 
-By default, `--print-config` prints the full resolved final configuration,
-including default and null values:
+`--print-config` prints the full active configuration, including defaults and
+null values:
 
 ```bash
 ursa --print-config
 ursa --print-config=resolved
 ```
 
-To see the full configuration before final resolution:
+To inspect values before provider settings and other derived values are applied:
 
 ```bash
 ursa --print-config=merged
 ```
 
-Without a suffix, a level selects only that source:
+You can also inspect a particular file layer:
 
 ```bash
-ursa --print-config=user,merged
 ursa --config ./.ursa/config.yaml --print-config=file,resolved
 ```
 
-Levels are:
-
-- `user`: XDG configuration files
-- `file`: only the file passed with `--config`
-- `final`: all files plus environment and CLI overrides
-
-Add `+` to include lower-precedence sources. For example, use
-`ursa --config ./.ursa/config.yaml --print-config=file+,resolved` when an
-explicit file selects a provider defined in the user config. Stages are
-`merged` and `resolved`.
-
-Resolved output shows the complete effective configuration. Merged output shows
-the complete configuration before provider inheritance and other resolution
-steps.
+The complete form is `--print-config=LEVEL[+],STAGE`. Levels are `user`, `file`,
+and `final`; stages are `merged` and `resolved`. Add `+` to include
+lower-precedence sources.

--- a/docs/configuration/files-and-env.md
+++ b/docs/configuration/files-and-env.md
@@ -1,6 +1,17 @@
 # Configuration files, CLI flags, and environment variables
 
-URSA supports three configuration mechanisms. Prefer YAML files for project settings, CLI flags for temporary overrides, and environment variables for secrets or automation.
+URSA supports layered configuration. Higher-precedence sources are merged on top of lower-precedence sources to produce a single effective configuration. Prefer YAML files for reusable settings, CLI flags for temporary overrides, and environment variables for secrets or automation.
+
+## Configuration precedence
+
+URSA loads configuration in this order, with later sources overriding earlier ones:
+
+1. XDG-compliant user config, typically `~/.config/ursa/config.yaml`
+2. Project-local `./.ursa/config.yaml`
+3. The file passed to `--config`
+4. CLI flags
+
+See the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/) for background on XDG-compliant config locations.
 
 ## YAML files: preferred
 

--- a/docs/configuration/files-and-env.md
+++ b/docs/configuration/files-and-env.md
@@ -16,6 +16,19 @@ URSA loads configuration in this order, with later sources overriding earlier on
 4. Environment variables
 5. CLI flags
 
+This precedence order is unchanged by sparse merging. Each source contributes
+only the keys it explicitly sets: an absent key leaves the lower-precedence
+value alone, while an explicit `null` clears a nullable value. For example, a
+project config can clear a user-level custom endpoint with:
+
+```yaml
+llm_model:
+  base_url: null
+```
+
+Non-nullable settings still require their declared type. In particular,
+`ssl_verify` is a boolean, defaults to `true`, and does not accept `null`.
+
 See the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/)
 for background on XDG-compliant config locations.
 
@@ -110,26 +123,41 @@ mcp_servers:
 
 ## Inspect the active configuration
 
-By default, `--print-config` prints the resolved final configuration:
+By default, `--print-config` prints non-default values from the resolved final configuration. Null and default-valued fields are omitted:
 
 ```bash
 ursa --print-config
 ursa --print-config=resolved
 ```
 
-To see the configuration before final resolution:
+To see non-default values before final resolution:
 
 ```bash
 ursa --print-config=merged
 ```
 
-You can also inspect a specific configuration level before or after resolution:
+Without a suffix, a level selects only that source. Add `+` to include all lower-precedence sources through that level:
 
 ```bash
 ursa --print-config=user,merged
 ursa --print-config=project,merged
+ursa --print-config=project+,resolved
 ursa --print-config=file,resolved
+ursa --print-config=file+,resolved
 ursa --print-config=final,resolved
 ```
 
-Levels are `user`, `project`, `file`, and `final` (default). Stages are `merged` and `resolved`.
+Levels are:
+
+- `user`: XDG configuration files
+- `project`: only `./.ursa/config.yaml`
+- `file`: only the file passed with `--config`
+- `final`: all files plus environment and CLI overrides
+
+For example, `project,resolved` resolves the project file by itself, while `project+,resolved` first merges the XDG configuration and project file. The cumulative form is useful when a project selects an inference provider defined in the user configuration. `final` is already cumulative. Stages are `merged` and `resolved`.
+
+Resolved output materializes inherited provider fields and omits the consumed `inference_provider` name. Use merged output when you need to see which provider name a model selected. `ssl_verify` is always boolean after parsing; if omitted from a model, it inherits the provider value or defaults to `true`.
+
+Resolution can also materialize derived values. For example, `workspace: tmp`
+may appear as the allocated temporary-directory path in resolved output; merged
+output retains the configured value.

--- a/docs/configuration/files-and-env.md
+++ b/docs/configuration/files-and-env.md
@@ -1,6 +1,10 @@
 # Configuration files, CLI flags, and environment variables
 
-URSA supports layered configuration. Higher-precedence sources are merged on top of lower-precedence sources to produce a single effective configuration. Prefer YAML files for reusable settings, CLI flags for temporary overrides, and environment variables for secrets or automation.
+URSA supports layered configuration. Higher-precedence sources are merged on
+top of lower-precedence sources to produce a single merged configuration, which
+is then resolved into the effective runtime configuration. Prefer YAML files
+for reusable settings, CLI flags for temporary overrides, and environment
+variables for secrets or automation.
 
 ## Configuration precedence
 
@@ -12,7 +16,8 @@ URSA loads configuration in this order, with later sources overriding earlier on
 4. Environment variables
 5. CLI flags
 
-See the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/) for background on XDG-compliant config locations.
+See the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/)
+for background on XDG-compliant config locations.
 
 ## YAML files: preferred
 
@@ -20,10 +25,13 @@ See the [XDG Base Directory Specification](https://specifications.freedesktop.or
 llm_model:
   model: openai:gpt-5.4
   api_key_env: OPENAI_API_KEY
-
 workspace: ./ursa-workspace
 group: default
 use_web: false
+agent_config:
+  execute:
+    safe_codes:
+      - python
 ```
 
 Run:
@@ -102,6 +110,26 @@ mcp_servers:
 
 ## Inspect the active configuration
 
+By default, `--print-config` prints the resolved final configuration:
+
 ```bash
 ursa --print-config
+ursa --print-config=resolved
 ```
+
+To see the configuration before final resolution:
+
+```bash
+ursa --print-config=merged
+```
+
+You can also inspect a specific configuration level before or after resolution:
+
+```bash
+ursa --print-config=user,merged
+ursa --print-config=project,merged
+ursa --print-config=file,resolved
+ursa --print-config=final,resolved
+```
+
+Levels are `user`, `project`, `file`, and `final` (default). Stages are `merged` and `resolved`.

--- a/docs/configuration/files-and-env.md
+++ b/docs/configuration/files-and-env.md
@@ -9,7 +9,8 @@ URSA loads configuration in this order, with later sources overriding earlier on
 1. XDG-compliant user config, typically `~/.config/ursa/config.yaml`
 2. Project-local `./.ursa/config.yaml`
 3. The file passed to `--config`
-4. CLI flags
+4. Environment variables
+5. CLI flags
 
 See the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/) for background on XDG-compliant config locations.
 

--- a/docs/configuration/files-and-env.md
+++ b/docs/configuration/files-and-env.md
@@ -21,6 +21,18 @@ setting to `null` to clear it.
 `XDG_CONFIG_HOME` is supported on every platform and only affects the user
 configuration layer.
 
+### Default configuration paths
+
+| Platform | System config | Native user config |
+| --- | --- | --- |
+| Linux and other Unix | `/etc/ursa/config.yaml` | `~/.config/ursa/config.yaml` |
+| macOS | `/Library/Application Support/ursa/config.yaml` | `~/Library/Application Support/ursa/config.yaml` |
+| Windows | `%PROGRAMDATA%\ursa\config.yaml` | `%APPDATA%\ursa\config.yaml` |
+
+On every platform, URSA then checks `~/.config/ursa/config.yaml` and, when
+`XDG_CONFIG_HOME` is set, `$XDG_CONFIG_HOME/ursa/config.yaml`. These user files
+are loaded in that order, with duplicates skipped. A missing file is ignored.
+
 ## YAML files: preferred
 
 ```yaml
@@ -136,4 +148,5 @@ ursa --config ./.ursa/config.yaml --print-config=file,resolved
 
 The complete form is `--print-config=LEVEL[+],STAGE`. Levels are `system`,
 `user`, `file`, and `final`; stages are `merged` and `resolved`. Add `+` to include
-lower-precedence sources.
+lower-precedence sources. If you provide only a level, URSA uses the `resolved`
+stage; for example, `--print-config=user` shows resolved user configuration.

--- a/docs/configuration/files-and-env.md
+++ b/docs/configuration/files-and-env.md
@@ -16,18 +16,8 @@ URSA loads configuration in this order, with later sources overriding earlier on
 4. Environment variables
 5. CLI flags
 
-This precedence order is unchanged by sparse merging. Each source contributes
-only the keys it explicitly sets: an absent key leaves the lower-precedence
-value alone, while an explicit `null` clears a nullable value. For example, a
-project config can clear a user-level custom endpoint with:
-
-```yaml
-llm_model:
-  base_url: null
-```
-
-Non-nullable settings still require their declared type. In particular,
-`ssl_verify` is a boolean, defaults to `true`, and does not accept `null`.
+Higher-precedence sources only override settings they specify. Set a nullable
+setting to `null` to clear it.
 
 See the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/)
 for background on XDG-compliant config locations.
@@ -136,15 +126,12 @@ To see non-default values before final resolution:
 ursa --print-config=merged
 ```
 
-Without a suffix, a level selects only that source. Add `+` to include all lower-precedence sources through that level:
+Without a suffix, a level selects only that source:
 
 ```bash
 ursa --print-config=user,merged
 ursa --print-config=project,merged
-ursa --print-config=project+,resolved
 ursa --print-config=file,resolved
-ursa --print-config=file+,resolved
-ursa --print-config=final,resolved
 ```
 
 Levels are:
@@ -154,10 +141,9 @@ Levels are:
 - `file`: only the file passed with `--config`
 - `final`: all files plus environment and CLI overrides
 
-For example, `project,resolved` resolves the project file by itself, while `project+,resolved` first merges the XDG configuration and project file. The cumulative form is useful when a project selects an inference provider defined in the user configuration. `final` is already cumulative. Stages are `merged` and `resolved`.
+Add `+` to include lower-precedence sources. For example, use
+`--print-config=project+,resolved` when a project selects a provider defined in
+the user config. Stages are `merged` and `resolved`.
 
-Resolved output materializes inherited provider fields and omits the consumed `inference_provider` name. Use merged output when you need to see which provider name a model selected. `ssl_verify` is always boolean after parsing; if omitted from a model, it inherits the provider value or defaults to `true`.
-
-Resolution can also materialize derived values. For example, `workspace: tmp`
-may appear as the allocated temporary-directory path in resolved output; merged
-output retains the configured value.
+Resolved output shows effective non-default settings. Merged output shows the
+configuration before provider inheritance and other resolution steps.

--- a/docs/configuration/files-and-env.md
+++ b/docs/configuration/files-and-env.md
@@ -7,22 +7,27 @@ variables for secrets or automation, and CLI flags for temporary overrides.
 
 URSA loads configuration in this order, with later sources overriding earlier ones:
 
-1. XDG system and user config files, including `~/.config/ursa/config.yaml`
-2. The file passed to `--config`
-3. Environment variables
-4. CLI flags
+1. Built-in defaults
+2. The native platform system config
+3. User configs: native platform location, `~/.config/ursa/config.yaml`, then
+   `$XDG_CONFIG_HOME/ursa/config.yaml`
+4. Environment variables
+5. The file passed to `--config`
+6. CLI flags
 
 Higher-precedence sources only override settings they specify. Set a nullable
 setting to `null` to clear it.
 
-XDG files follow the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/).
+`XDG_CONFIG_HOME` is supported on every platform and only affects the user
+configuration layer.
 
 ## YAML files: preferred
 
 ```yaml
 llm_model:
   model: openai:gpt-5.4
-  api_key_env: OPENAI_API_KEY
+  api_key:
+    env: OPENAI_API_KEY
 workspace: ./ursa-workspace
 group: default
 use_web: false
@@ -56,7 +61,7 @@ Common flags include:
 --name
 --llm_model.model
 --llm_model.base_url
---llm_model.api_key_env
+--llm_model.api_key.env
 --llm_model.ssl_verify
 --llm_model.max_completion_tokens
 --emb_model
@@ -81,7 +86,8 @@ Then in YAML:
 ```yaml
 llm_model:
   model: openai:gpt-5.4
-  api_key_env: OPENAI_API_KEY
+  api_key:
+    env: OPENAI_API_KEY
 ```
 
 You can also set URSA configuration options directly:
@@ -128,6 +134,6 @@ You can also inspect a particular file layer:
 ursa --config ./.ursa/config.yaml --print-config=file,resolved
 ```
 
-The complete form is `--print-config=LEVEL[+],STAGE`. Levels are `user`, `file`,
-and `final`; stages are `merged` and `resolved`. Add `+` to include
+The complete form is `--print-config=LEVEL[+],STAGE`. Levels are `system`,
+`user`, `file`, and `final`; stages are `merged` and `resolved`. Add `+` to include
 lower-precedence sources.

--- a/docs/configuration/files-and-env.md
+++ b/docs/configuration/files-and-env.md
@@ -11,10 +11,9 @@ variables for secrets or automation.
 URSA loads configuration in this order, with later sources overriding earlier ones:
 
 1. XDG-compliant user config, typically `~/.config/ursa/config.yaml`
-2. Project-local `./.ursa/config.yaml`
-3. The file passed to `--config`
-4. Environment variables
-5. CLI flags
+2. The file passed to `--config`
+3. Environment variables
+4. CLI flags
 
 Higher-precedence sources only override settings they specify. Set a nullable
 setting to `null` to clear it.
@@ -113,14 +112,15 @@ mcp_servers:
 
 ## Inspect the active configuration
 
-By default, `--print-config` prints non-default values from the resolved final configuration. Null and default-valued fields are omitted:
+By default, `--print-config` prints the full resolved final configuration,
+including default and null values:
 
 ```bash
 ursa --print-config
 ursa --print-config=resolved
 ```
 
-To see non-default values before final resolution:
+To see the full configuration before final resolution:
 
 ```bash
 ursa --print-config=merged
@@ -130,20 +130,20 @@ Without a suffix, a level selects only that source:
 
 ```bash
 ursa --print-config=user,merged
-ursa --print-config=project,merged
-ursa --print-config=file,resolved
+ursa --config ./.ursa/config.yaml --print-config=file,resolved
 ```
 
 Levels are:
 
 - `user`: XDG configuration files
-- `project`: only `./.ursa/config.yaml`
 - `file`: only the file passed with `--config`
 - `final`: all files plus environment and CLI overrides
 
 Add `+` to include lower-precedence sources. For example, use
-`--print-config=project+,resolved` when a project selects a provider defined in
-the user config. Stages are `merged` and `resolved`.
+`ursa --config ./.ursa/config.yaml --print-config=file+,resolved` when an
+explicit file selects a provider defined in the user config. Stages are
+`merged` and `resolved`.
 
-Resolved output shows effective non-default settings. Merged output shows the
-configuration before provider inheritance and other resolution steps.
+Resolved output shows the complete effective configuration. Merged output shows
+the complete configuration before provider inheritance and other resolution
+steps.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -52,7 +52,7 @@ Use:
 ursa --print-config
 ```
 
-to inspect the active resolved configuration and defaults. Use `ursa --print-config=merged` to inspect the merged pre-resolution view.
+to inspect active, non-default resolved settings. Use `ursa --print-config=merged` to inspect non-default settings before resolution.
 
 ## Model configuration
 
@@ -115,7 +115,7 @@ emb_model:
   inference_provider: openai_public
 ```
 
-This is useful when multiple model configs share the same endpoint, credentials, or SSL settings. Model-specific settings override values inherited from the referenced provider. For example, this keeps the shared endpoint but uses a different credential source for just the LLM:
+This is useful when multiple model configs share the same endpoint, credentials, or SSL settings. A model inherits provider settings that it does not specify. Model-specific settings override inherited values. For example, this keeps the shared endpoint but uses a different credential source for just the LLM:
 
 ```yaml
 inference_providers:
@@ -128,7 +128,21 @@ llm_model:
   api_key_env: PROJECT_OPENAI_API_KEY
 ```
 
-Provider references must name an entry in `inference_providers`. During config resolution, provider defaults are merged into `llm_model` and `emb_model`, with model-specific values taking precedence.
+Provider references must name an entry in the final merged `inference_providers` catalog. During config resolution, provider defaults are merged into `llm_model` and `emb_model`, with model-specific values taking precedence. Resolution consumes the reference, so resolved output contains the inherited values and omits `inference_provider`; use merged output to see the selected provider name.
+
+For nullable settings, an explicit `null` is different from omission. Omit a
+setting to inherit it from the provider; set it to `null` to clear the provider
+value. This model uses the provider's credential setting but clears its custom
+endpoint:
+
+```yaml
+llm_model:
+  model: openai:gpt-5.4
+  inference_provider: openai_public
+  base_url: null
+```
+
+`ssl_verify` is a boolean and defaults to `true`. Omit it from a model to inherit the referenced provider's value. Set it explicitly to `true` or `false` to override the provider; `null` is not valid. If neither the model nor provider specifies it, certificate verification remains enabled.
 
 ### Managing multiple inference providers across config layers
 
@@ -204,6 +218,9 @@ workspace: tmp
 
 URSA will use a temporary directory for the run instead of literal folder named `tmp`.
 If a literal `tmp` folder exists in the current directory, URSA *will* use that instead.
+Because this happens during resolution, resolved `--print-config` output may
+show the allocated temporary-directory path. Merged output continues to show
+`workspace: tmp`.
 
 ## More configuration topics
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1,9 +1,9 @@
 # Configuration
 
 YAML files make model, workspace, agent, RAG, and MCP settings easy to reuse.
-URSA configs can also be layered with environment variables and CLI flags. See
-[Configuration files, CLI flags, and environment variables][configuration-files-cli-flags-and-environment-variables]
-for the precedence order and inspection commands.
+URSA configs can also be
+[layered with environment variables and CLI flags][configuration-files-cli-flags-and-environment-variables],
+with commands to inspect the resulting configuration.
 
 ## Minimal config file
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -12,7 +12,8 @@ Create `config.yaml`:
 ```yaml
 llm_model:
   model: openai:gpt-5.4
-  api_key_env: OPENAI_API_KEY
+  api_key:
+    env: OPENAI_API_KEY
 workspace: ./ursa-workspace
 ```
 
@@ -31,7 +32,8 @@ thread_id: null
 use_web: false
 llm_model:
   model: openai:gpt-5.4
-  api_key_env: OPENAI_API_KEY
+  api_key:
+    env: OPENAI_API_KEY
   max_completion_tokens: 10000
 emb_model: null
 rag_tools: []
@@ -78,14 +80,15 @@ llm_model:
   base_url: http://localhost:11434
 ```
 
-## Prefer `api_key_env` for secrets
+## Prefer `api_key` environment references for secrets
 
 Avoid hard-coding API keys in YAML files. Prefer:
 
 ```yaml
 llm_model:
   model: openai:gpt-5.4
-  api_key_env: OPENAI_API_KEY
+  api_key:
+    env: OPENAI_API_KEY
 ```
 
 Then set the key in your shell or secret manager.
@@ -99,7 +102,8 @@ models:
 inference_providers:
   openai_public:
     base_url: https://api.openai.com/v1
-    api_key_env: OPENAI_API_KEY
+    api_key:
+      env: OPENAI_API_KEY
 llm_model:
   model: openai:gpt-5.4
   inference_provider: openai_public

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -128,21 +128,12 @@ llm_model:
   api_key_env: PROJECT_OPENAI_API_KEY
 ```
 
-Provider references must name an entry in the final merged `inference_providers` catalog. During config resolution, provider defaults are merged into `llm_model` and `emb_model`, with model-specific values taking precedence. Resolution consumes the reference, so resolved output contains the inherited values and omits `inference_provider`; use merged output to see the selected provider name.
+The selected provider must exist in `inference_providers`. Omit a model setting
+to inherit it from the provider. For nullable settings, use `null` to clear an
+inherited value.
 
-For nullable settings, an explicit `null` is different from omission. Omit a
-setting to inherit it from the provider; set it to `null` to clear the provider
-value. This model uses the provider's credential setting but clears its custom
-endpoint:
-
-```yaml
-llm_model:
-  model: openai:gpt-5.4
-  inference_provider: openai_public
-  base_url: null
-```
-
-`ssl_verify` is a boolean and defaults to `true`. Omit it from a model to inherit the referenced provider's value. Set it explicitly to `true` or `false` to override the provider; `null` is not valid. If neither the model nor provider specifies it, certificate verification remains enabled.
+`ssl_verify` accepts `true` or `false` and defaults to `true`. Omit it to
+inherit the provider's value.
 
 ### Managing multiple inference providers across config layers
 
@@ -218,9 +209,6 @@ workspace: tmp
 
 URSA will use a temporary directory for the run instead of literal folder named `tmp`.
 If a literal `tmp` folder exists in the current directory, URSA *will* use that instead.
-Because this happens during resolution, resolved `--print-config` output may
-show the allocated temporary-directory path. Merged output continues to show
-`workspace: tmp`.
 
 ## More configuration topics
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -96,6 +96,73 @@ llm_model:
 
 Then set the key in your shell or secret manager.
 
+## Inference providers
+
+Use `inference_providers` to define reusable provider-level settings once, then reference them from `llm_model` or `emb_model` with `inference_provider`.
+
+```yaml
+inference_providers:
+  openai_public:
+    base_url: https://api.openai.com/v1
+    api_key_env: OPENAI_API_KEY
+    ssl_verify: true
+
+llm_model:
+  model: openai:gpt-5.4
+  inference_provider: openai_public
+
+emb_model:
+  model: openai:text-embedding-3-large
+  inference_provider: openai_public
+```
+
+This is useful when multiple model configs share the same endpoint, credentials, or SSL settings. Model-specific settings override values inherited from the referenced provider. For example, this keeps the shared endpoint but uses a different credential source for just the LLM:
+
+```yaml
+inference_providers:
+  openai_public:
+    base_url: https://api.openai.com/v1
+    api_key_env: OPENAI_API_KEY
+
+llm_model:
+  model: openai:gpt-5.4
+  inference_provider: openai_public
+  api_key_env: PROJECT_OPENAI_API_KEY
+```
+
+Provider references must name an entry in `inference_providers`.
+
+### Managing multiple inference providers across config layers
+
+`inference_providers` works especially well with URSA's layered configuration. A user-level config can define the available providers once, while a project-local config can choose which provider or model to use for that project, or override the API key environment variable for billing or access control purposes. See [Configuration files, CLI flags, and environment variables][configuration-files-cli-flags-and-environment-variables] for how those layers are merged.
+
+For example, a user config might define reusable providers:
+
+```yaml
+inference_providers:
+  openai_personal:
+    base_url: https://api.openai.com/v1
+    api_key_env: OPENAI_API_KEY
+
+  openai_project:
+    base_url: https://api.openai.com/v1
+    api_key_env: PROJECT_OPENAI_API_KEY
+
+llm_model:
+  model: openai:gpt-5.4
+  inference_provider: openai_personal
+```
+
+Then a project-local config can switch billing or model selection without redefining the provider details:
+
+```yaml
+llm_model:
+  model: openai:gpt-5.4-mini
+  inference_provider: openai_project
+```
+
+This pattern lets you keep a stable catalog of providers in user config while allowing each project to select the right provider, API key, or model.
+
 ## More configuration topics
 
 - [OpenAI-compatible endpoints][openai-compatible-endpoints]

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -6,11 +6,9 @@ URSA configuration has two useful views:
 - **merged config**: the result of applying configuration layers in precedence order
 - **resolved config**: the merged config plus derived behavior.
 
-URSA can also be configured with CLI flags and environment variables, but the recommended order is:
-
-1. **YAML configuration files** for reusable project settings.
-2. **CLI arguments** for one-off overrides.
-3. **Environment variables** mainly for secrets and automation.
+URSA also accepts CLI flags and environment variables. See
+[Configuration files, CLI flags, and environment variables][configuration-files-cli-flags-and-environment-variables]
+for the authoritative precedence order.
 
 ## Minimal config file
 
@@ -52,7 +50,9 @@ Use:
 ursa --print-config
 ```
 
-to inspect active, non-default resolved settings. Use `ursa --print-config=merged` to inspect non-default settings before resolution.
+to inspect the full resolved configuration, including defaults and null values.
+Use `ursa --print-config=merged` to inspect the full configuration before
+resolution.
 
 ## Model configuration
 
@@ -132,9 +132,13 @@ The selected provider must exist in `inference_providers`. Omit a model setting
 to inherit it from the provider. For nullable settings, use `null` to clear an
 inherited value.
 
-### Managing multiple inference providers across config layers
+### Sharing inference providers across configuration files
 
-`inference_providers` works especially well with URSA's layered configuration. A user-level config can define the available providers once, while a project-local config can choose which provider or model to use for that project, or override the API key environment variable for billing or access control purposes. See [Configuration files, CLI flags, and environment variables][configuration-files-cli-flags-and-environment-variables] for how those layers are merged.
+`inference_providers` works especially well with URSA's layered configuration.
+A user-level config can define the available providers once, while a file passed
+with `--config` can choose a provider or model for a particular project. See
+[Configuration files, CLI flags, and environment variables][configuration-files-cli-flags-and-environment-variables]
+for how those sources are merged.
 
 For example, a user config might define reusable providers:
 
@@ -151,7 +155,8 @@ llm_model:
   inference_provider: openai_personal
 ```
 
-Then a project-local config can switch billing or model selection without redefining the provider details:
+Then an explicitly selected config file can switch billing or model selection
+without redefining the provider details:
 
 ```yaml
 llm_model:
@@ -159,7 +164,9 @@ llm_model:
   inference_provider: openai_project
 ```
 
-This pattern lets you keep a stable catalog of providers in user config while allowing each project to select the right provider, API key, or model.
+Pass that file with `ursa --config ./.ursa/config.yaml`. This keeps a stable
+provider catalog in user config while allowing each invocation to select the
+right provider, API key, or model.
 
 ## `use_web` and `agent_config`
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -132,9 +132,6 @@ The selected provider must exist in `inference_providers`. Omit a model setting
 to inherit it from the provider. For nullable settings, use `null` to clear an
 inherited value.
 
-`ssl_verify` accepts `true` or `false` and defaults to `true`. Omit it to
-inherit the provider's value.
-
 ### Managing multiple inference providers across config layers
 
 `inference_providers` works especially well with URSA's layered configuration. A user-level config can define the available providers once, while a project-local config can choose which provider or model to use for that project, or override the API key environment variable for billing or access control purposes. See [Configuration files, CLI flags, and environment variables][configuration-files-cli-flags-and-environment-variables] for how those layers are merged.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -80,18 +80,11 @@ llm_model:
   base_url: http://localhost:11434
 ```
 
-## Prefer `api_key` environment references for secrets
+## Credential references
 
-Avoid hard-coding API keys in YAML files. Prefer:
-
-```yaml
-llm_model:
-  model: openai:gpt-5.4
-  api_key:
-    env: OPENAI_API_KEY
-```
-
-Then set the key in your shell or secret manager.
+Keep credentials out of configuration files by referencing environment
+variables or the operating system keyring. See [Secrets][secrets] for keyring
+and MCP header examples.
 
 ## Inference providers
 
@@ -113,8 +106,14 @@ emb_model:
 ```
 
 Models inherit unspecified provider settings; model-specific values override
-them. The selected provider must exist. Set a nullable model value to `null` to
-clear an inherited value.
+them. URSA validates provider values and rejects any model whose selected
+provider does not exist. Set a nullable model value to `null` to clear an
+inherited value.
+
+URSA includes an explicit `openai` provider by default, with
+`https://api.openai.com/v1` as its base URL and `OPENAI_API_KEY` as its API-key
+environment reference. The default chat model selects this provider. You can
+override its settings by defining `inference_providers.openai`.
 
 ## `use_web` and `agent_config`
 
@@ -138,5 +137,6 @@ directory named `tmp` already exists, URSA uses that directory.
 - [OpenAI-compatible endpoints][openai-compatible-endpoints]
 - [Ollama and local endpoints][ollama-and-local-endpoints]
 - [LangChain providers][langchain-providers]
+- [Secrets][secrets]
 - [Configuration files, CLI flags, and environment variables][configuration-files-cli-flags-and-environment-variables]
 - [MCP server configuration][mcp-server-configuration]

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -2,6 +2,10 @@
 
 YAML configuration files are the preferred way to configure URSA. They make model settings, workspaces, groups, agent options, RAG tools, and MCP servers easy to reuse and version with a project.
 
+URSA configuration has two useful views:
+- **merged config**: the result of applying configuration layers in precedence order
+- **resolved config**: the merged config plus derived behavior.
+
 URSA can also be configured with CLI flags and environment variables, but the recommended order is:
 
 1. **YAML configuration files** for reusable project settings.
@@ -16,7 +20,6 @@ Create `config.yaml`:
 llm_model:
   model: openai:gpt-5.4
   api_key_env: OPENAI_API_KEY
-
 workspace: ./ursa-workspace
 ```
 
@@ -33,15 +36,13 @@ workspace: ./ursa-workspace
 group: default
 thread_id: null
 use_web: false
-
 llm_model:
   model: openai:gpt-5.4
   api_key_env: OPENAI_API_KEY
   max_completion_tokens: 10000
-
 emb_model: null
 rag_tools: []
-agent_config: null
+agent_config: {}
 mcp_servers: {}
 ```
 
@@ -51,7 +52,7 @@ Use:
 ursa --print-config
 ```
 
-to inspect the active configuration and defaults.
+to inspect the active resolved configuration and defaults. Use `ursa --print-config=merged` to inspect the merged pre-resolution view.
 
 ## Model configuration
 
@@ -106,11 +107,9 @@ inference_providers:
     base_url: https://api.openai.com/v1
     api_key_env: OPENAI_API_KEY
     ssl_verify: true
-
 llm_model:
   model: openai:gpt-5.4
   inference_provider: openai_public
-
 emb_model:
   model: openai:text-embedding-3-large
   inference_provider: openai_public
@@ -123,14 +122,13 @@ inference_providers:
   openai_public:
     base_url: https://api.openai.com/v1
     api_key_env: OPENAI_API_KEY
-
 llm_model:
   model: openai:gpt-5.4
   inference_provider: openai_public
   api_key_env: PROJECT_OPENAI_API_KEY
 ```
 
-Provider references must name an entry in `inference_providers`.
+Provider references must name an entry in `inference_providers`. During config resolution, provider defaults are merged into `llm_model` and `emb_model`, with model-specific values taking precedence.
 
 ### Managing multiple inference providers across config layers
 
@@ -143,11 +141,9 @@ inference_providers:
   openai_personal:
     base_url: https://api.openai.com/v1
     api_key_env: OPENAI_API_KEY
-
   openai_project:
     base_url: https://api.openai.com/v1
     api_key_env: PROJECT_OPENAI_API_KEY
-
 llm_model:
   model: openai:gpt-5.4
   inference_provider: openai_personal
@@ -162,6 +158,52 @@ llm_model:
 ```
 
 This pattern lets you keep a stable catalog of providers in user config while allowing each project to select the right provider, API key, or model.
+
+## `use_web` and `agent_config`
+
+`use_web` is a top-level convenience setting. During config resolution, `use_web: true` fills in missing `use_web` values for these agents:
+- `chat`
+- `execute`
+- `deep_review`
+- `prompt`
+
+Explicit agent settings win. For example:
+
+```yaml
+use_web: true
+agent_config:
+  prompt:
+    use_web: false
+```
+
+Keeps web tools enabled for the other affected agents while leaving `prompt` with `use_web: false`.
+
+`agent_config` is the main way to set per-agent options. It is a mapping from HITL agent name to that agent's configuration dictionary.
+
+Example:
+
+```yaml
+agent_config:
+  chat:
+    use_web: true
+  execute:
+    safe_codes:
+      - python
+      - julia
+  prompt:
+    use_web: false
+```
+
+## `workspace: tmp`
+
+If you set:
+
+```yaml
+workspace: tmp
+```
+
+URSA will use a temporary directory for the run instead of literal folder named `tmp`.
+If a literal `tmp` folder exists in the current directory, URSA *will* use that instead.
 
 ## More configuration topics
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1,14 +1,9 @@
 # Configuration
 
-YAML configuration files are the preferred way to configure URSA. They make model settings, workspaces, groups, agent options, RAG tools, and MCP servers easy to reuse and version with a project.
-
-URSA configuration has two useful views:
-- **merged config**: the result of applying configuration layers in precedence order
-- **resolved config**: the merged config plus derived behavior.
-
-URSA also accepts CLI flags and environment variables. See
+YAML files make model, workspace, agent, RAG, and MCP settings easy to reuse.
+URSA configs can also be layered with environment variables and CLI flags. See
 [Configuration files, CLI flags, and environment variables][configuration-files-cli-flags-and-environment-variables]
-for the authoritative precedence order.
+for the precedence order and inspection commands.
 
 ## Minimal config file
 
@@ -50,9 +45,7 @@ Use:
 ursa --print-config
 ```
 
-to inspect the full resolved configuration, including defaults and null values.
-Use `ursa --print-config=merged` to inspect the full configuration before
-resolution.
+to inspect the full active configuration, including defaults and null values.
 
 ## Model configuration
 
@@ -99,14 +92,14 @@ Then set the key in your shell or secret manager.
 
 ## Inference providers
 
-Use `inference_providers` to define reusable provider-level settings once, then reference them from `llm_model` or `emb_model` with `inference_provider`.
+Use `inference_providers` to share endpoint and credential settings between
+models:
 
 ```yaml
 inference_providers:
   openai_public:
     base_url: https://api.openai.com/v1
     api_key_env: OPENAI_API_KEY
-    ssl_verify: true
 llm_model:
   model: openai:gpt-5.4
   inference_provider: openai_public
@@ -115,68 +108,14 @@ emb_model:
   inference_provider: openai_public
 ```
 
-This is useful when multiple model configs share the same endpoint, credentials, or SSL settings. A model inherits provider settings that it does not specify. Model-specific settings override inherited values. For example, this keeps the shared endpoint but uses a different credential source for just the LLM:
-
-```yaml
-inference_providers:
-  openai_public:
-    base_url: https://api.openai.com/v1
-    api_key_env: OPENAI_API_KEY
-llm_model:
-  model: openai:gpt-5.4
-  inference_provider: openai_public
-  api_key_env: PROJECT_OPENAI_API_KEY
-```
-
-The selected provider must exist in `inference_providers`. Omit a model setting
-to inherit it from the provider. For nullable settings, use `null` to clear an
-inherited value.
-
-### Sharing inference providers across configuration files
-
-`inference_providers` works especially well with URSA's layered configuration.
-A user-level config can define the available providers once, while a file passed
-with `--config` can choose a provider or model for a particular project. See
-[Configuration files, CLI flags, and environment variables][configuration-files-cli-flags-and-environment-variables]
-for how those sources are merged.
-
-For example, a user config might define reusable providers:
-
-```yaml
-inference_providers:
-  openai_personal:
-    base_url: https://api.openai.com/v1
-    api_key_env: OPENAI_API_KEY
-  openai_project:
-    base_url: https://api.openai.com/v1
-    api_key_env: PROJECT_OPENAI_API_KEY
-llm_model:
-  model: openai:gpt-5.4
-  inference_provider: openai_personal
-```
-
-Then an explicitly selected config file can switch billing or model selection
-without redefining the provider details:
-
-```yaml
-llm_model:
-  model: openai:gpt-5.4-mini
-  inference_provider: openai_project
-```
-
-Pass that file with `ursa --config ./.ursa/config.yaml`. This keeps a stable
-provider catalog in user config while allowing each invocation to select the
-right provider, API key, or model.
+Models inherit unspecified provider settings; model-specific values override
+them. The selected provider must exist. Set a nullable model value to `null` to
+clear an inherited value.
 
 ## `use_web` and `agent_config`
 
-`use_web` is a top-level convenience setting. During config resolution, `use_web: true` fills in missing `use_web` values for these agents:
-- `chat`
-- `execute`
-- `deep_review`
-- `prompt`
-
-Explicit agent settings win. For example:
+Use `agent_config` for per-agent options. Top-level `use_web: true` enables web
+tools for supported agents unless an agent overrides it:
 
 ```yaml
 use_web: true
@@ -185,34 +124,10 @@ agent_config:
     use_web: false
 ```
 
-Keeps web tools enabled for the other affected agents while leaving `prompt` with `use_web: false`.
-
-`agent_config` is the main way to set per-agent options. It is a mapping from HITL agent name to that agent's configuration dictionary.
-
-Example:
-
-```yaml
-agent_config:
-  chat:
-    use_web: true
-  execute:
-    safe_codes:
-      - python
-      - julia
-  prompt:
-    use_web: false
-```
-
 ## `workspace: tmp`
 
-If you set:
-
-```yaml
-workspace: tmp
-```
-
-URSA will use a temporary directory for the run instead of literal folder named `tmp`.
-If a literal `tmp` folder exists in the current directory, URSA *will* use that instead.
+Set `workspace: tmp` to create a temporary workspace for the run. If a local
+directory named `tmp` already exists, URSA uses that directory.
 
 ## More configuration topics
 

--- a/docs/configuration/langchain-providers.md
+++ b/docs/configuration/langchain-providers.md
@@ -13,7 +13,8 @@ The following provider integrations are installed with URSA's core dependencies 
 ```yaml
 llm_model:
   model: openai:gpt-5.4
-  api_key_env: OPENAI_API_KEY
+  api_key:
+    env: OPENAI_API_KEY
 ```
 
 ## Anthropic
@@ -21,7 +22,8 @@ llm_model:
 ```yaml
 llm_model:
   model: anthropic:claude-sonnet-4-5
-  api_key_env: ANTHROPIC_API_KEY
+  api_key:
+    env: ANTHROPIC_API_KEY
 ```
 
 ## Google GenAI
@@ -29,7 +31,8 @@ llm_model:
 ```yaml
 llm_model:
   model: google_genai:gemini-2.5-pro
-  api_key_env: GOOGLE_API_KEY
+  api_key:
+    env: GOOGLE_API_KEY
 ```
 
 ## Ollama
@@ -46,7 +49,8 @@ llm_model:
 llm_model:
   model: azure_openai:deployment-name
   base_url: https://your-resource.openai.azure.com/
-  api_key_env: AZURE_OPENAI_API_KEY
+  api_key:
+    env: AZURE_OPENAI_API_KEY
 ```
 
 Azure deployments often need provider-specific settings. LangChain accepts additional provider keyword arguments, and URSA allows extra model fields in the YAML model configuration.

--- a/docs/configuration/mcp.md
+++ b/docs/configuration/mcp.md
@@ -29,7 +29,32 @@ mcp_servers:
     transport: streamable-http
     url: http://localhost:8000/mcp
     timeout: 60
+    headers:
+      Authorization:
+        keyring: true
+        template: "Bearer %s"
 ```
+
+Secret header values can use either `env: VARIABLE_NAME` or `keyring`. When
+`keyring` is `true`, URSA uses the MCP server name (`remote-tools` above) as
+the username; a string selects a different username. Keyring secrets are
+always read from the `ursa` service. The template defaults to `%s`.
+
+```bash
+keyring set ursa remote-tools
+```
+
+For an environment-backed header, use the same shape with `env`:
+
+```yaml
+headers:
+  Authorization:
+    env: REMOTE_TOOLS_TOKEN
+    template: "Bearer %s"
+```
+
+URSA resolves the reference when the MCP client starts and reports an error if
+the configured secret is unavailable.
 
 ## Use the config
 

--- a/docs/configuration/mcp.md
+++ b/docs/configuration/mcp.md
@@ -41,7 +41,7 @@ the username; a string selects a different username. Keyring secrets are
 always read from the `ursa` service. The template defaults to `%s`.
 
 ```bash
-keyring set ursa remote-tools
+ursa auth login remote-tools
 ```
 
 For an environment-backed header, use the same shape with `env`:

--- a/docs/configuration/openai-compatible.md
+++ b/docs/configuration/openai-compatible.md
@@ -8,7 +8,8 @@ Many hosted and self-hosted model services expose an OpenAI-compatible API. Conf
 llm_model:
   model: openai:my-model-name
   base_url: https://my-endpoint.example.com/v1
-  api_key_env: MY_ENDPOINT_API_KEY
+  api_key:
+    env: MY_ENDPOINT_API_KEY
 ```
 
 Run:
@@ -23,7 +24,7 @@ ursa --config config.yaml
 ursa \
   --llm_model.model openai:my-model-name \
   --llm_model.base_url https://my-endpoint.example.com/v1 \
-  --llm_model.api_key_env MY_ENDPOINT_API_KEY
+  --llm_model.api_key.env MY_ENDPOINT_API_KEY
 ```
 
 ## SSL verification
@@ -34,7 +35,8 @@ By default URSA verifies TLS certificates. If you are using a test endpoint with
 llm_model:
   model: openai:my-model-name
   base_url: https://my-endpoint.example.com/v1
-  api_key_env: MY_ENDPOINT_API_KEY
+  api_key:
+    env: MY_ENDPOINT_API_KEY
   ssl_verify: false
 ```
 

--- a/docs/configuration/secrets.md
+++ b/docs/configuration/secrets.md
@@ -1,0 +1,62 @@
+# Secrets
+
+Avoid storing API keys and other credentials directly in configuration files.
+URSA can read secrets from environment variables or from the operating system's
+credential store through the Python [keyring package](https://pypi.org/project/keyring/).
+
+## Store a secret in the keyring
+
+Reference a keyring entry from an inference provider:
+
+```yaml
+inference_providers:
+  openai:
+    api_key:
+      keyring: true
+```
+
+Then store its value with URSA:
+
+```bash
+ursa auth login openai
+```
+
+When `keyring: true` is used for an inference provider, its name is also used
+as the keyring username. A string can select another username instead:
+
+```yaml
+api_key:
+  keyring: shared-openai-key
+```
+
+Environment-backed secrets use the same reference form:
+
+```yaml
+api_key:
+  env: OPENAI_API_KEY
+```
+
+URSA resolves the reference only when the credential is needed. Resolved
+values remain masked in Pydantic models and configuration output.
+
+## Format a secret with `SecretTemplate`
+
+MCP headers often need a scheme or another prefix around the credential. Add a
+`template` containing `%s`, which URSA replaces with the resolved secret:
+
+```yaml
+mcp_servers:
+  remote-tools:
+    transport: streamable-http
+    url: https://tools.example.com/mcp
+    headers:
+      Authorization:
+        keyring: true
+        template: "Bearer %s"
+```
+
+Here, `keyring: true` uses `remote-tools`, the MCP server name, as the keyring
+username.
+
+The `ursa auth login` and `ursa auth list` commands are useful for populating
+and checking the secrets referenced by a configuration.

--- a/docs/environments/agent-symposia.md
+++ b/docs/environments/agent-symposia.md
@@ -147,13 +147,21 @@ name: multi_model_symposium
 group: default
 revision_rounds: 1
 
+inference_providers:
+  openai:
+    api_key:
+      keyring: true
+  anthropic:
+    api_key:
+      keyring: true
+
 organizer:
   name: organizer
   role: Synthesizes consensus, disagreement, and evidence quality
   agent: ChatAgent
   model:
     model: openai:gpt-4o-mini
-    api_key_env: OPENAI_API_KEY
+    inference_provider: openai
 
 members:
   - name: coding_model
@@ -161,7 +169,7 @@ members:
     agent: ExecutionAgent
     model:
       model: openai:gpt-4o-mini
-      api_key_env: OPENAI_API_KEY
+      inference_provider: openai
 
   - name: local_critic
     role: Reviews assumptions from an independent local-model perspective
@@ -175,7 +183,16 @@ members:
     agent: ChatAgent
     model:
       model: anthropic:claude-3-5-sonnet-latest
-      api_key_env: ANTHROPIC_API_KEY
+      inference_provider: anthropic
+```
+
+With `keyring: true`, the inference-provider name is the keyring username.
+Store these credentials under URSA's fixed `ursa` service before loading the
+symposium:
+
+```bash
+keyring set ursa openai
+keyring set ursa anthropic
 ```
 
 The environment-level `llm` is still required when you construct the symposium.

--- a/docs/environments/agent-symposia.md
+++ b/docs/environments/agent-symposia.md
@@ -191,8 +191,7 @@ Store these credentials under URSA's fixed `ursa` service before loading the
 symposium:
 
 ```bash
-keyring set ursa openai
-keyring set ursa anthropic
+ursa auth login --config symposium.yaml
 ```
 
 The environment-level `llm` is still required when you construct the symposium.

--- a/docs/environments/agent-teams.md
+++ b/docs/environments/agent-teams.md
@@ -208,7 +208,7 @@ Here `keyring: true` uses `openai`, the inference-provider name, as the
 username under the fixed `ursa` keyring service:
 
 ```bash
-keyring set ursa openai
+ursa auth login openai
 ```
 
 This is optional for teams, but it can be a good way to match model cost,

--- a/docs/environments/agent-teams.md
+++ b/docs/environments/agent-teams.md
@@ -183,13 +183,18 @@ A team member can inherit the default `llm` passed to the environment, or provid
 `model:` block to use a different model endpoint:
 
 ```yaml
+inference_providers:
+  openai:
+    api_key:
+      keyring: true
+
 members:
   - name: fast_researcher
     role: Drafts quick background summaries
     agent: ChatAgent
     model:
       model: openai:gpt-4o-mini
-      api_key_env: OPENAI_API_KEY
+      inference_provider: openai
 
   - name: local_checker
     role: Checks reasoning with a local model
@@ -197,6 +202,13 @@ members:
     model:
       model: ollama:llama3.1
       base_url: http://localhost:11434
+```
+
+Here `keyring: true` uses `openai`, the inference-provider name, as the
+username under the fixed `ursa` keyring service:
+
+```bash
+keyring set ursa openai
 ```
 
 This is optional for teams, but it can be a good way to match model cost,

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -13,7 +13,7 @@ This guide walks through starting URSA from the terminal, configuring a model, c
 
 ## 1. Create a configuration file
 
-YAML configuration files are the recommended way to configure URSA because they are reusable and easy to edit.
+YAML configuration files are the recommended way to configure URSA because they are reusable and easy to edit. URSA also layers config from an XDG-compliant user config, a project-local `./.ursa/config.yaml`, any file passed by `--config`, and finally CLI flags.
 
 Create `config.yaml`:
 

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -13,7 +13,11 @@ This guide walks through starting URSA from the terminal, configuring a model, c
 
 ## 1. Create a configuration file
 
-YAML configuration files are the recommended way to configure URSA because they are reusable and easy to edit. URSA also layers config from an XDG-compliant user config, a project-local `./.ursa/config.yaml`, any file passed by `--config`, and finally CLI flags.
+YAML configuration files are the recommended way to configure URSA because
+they are reusable and easy to edit. URSA can combine files, environment
+variables, and CLI flags; see
+[Configuration files, CLI flags, and environment variables][configuration-files-cli-flags-and-environment-variables]
+for the authoritative precedence order.
 
 Create `config.yaml`:
 
@@ -108,7 +112,7 @@ For detailed commands to list, save, copy, share, import, and delete agents, see
 ursa --help
 ursa --print-config
 ursa --print-config=merged
-ursa --print-config=file,resolved
+ursa --config ./.ursa/config.yaml --print-config=file,resolved
 ursa --config config.yaml
 ursa --config config.yaml --name my-agent
 ursa --config config.yaml --use-web

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -108,19 +108,11 @@ For detailed commands to list, save, copy, share, import, and delete agents, see
 ursa --help
 ursa --print-config
 ursa --print-config=merged
-ursa --print-config=project+,resolved
 ursa --print-config=file,resolved
 ursa --config config.yaml
 ursa --config config.yaml --name my-agent
 ursa --config config.yaml --use-web
 ```
-
-Configuration sources remain ordered from user files through project and
-explicit files to environment variables and CLI flags. Sources are sparse: an
-omitted key leaves a lower-precedence value unchanged, while `null` clears a
-nullable setting. For model provider settings, omission means inheritance.
-`ssl_verify` is a boolean that defaults to `true`; use `true` or `false`, not
-`null`.
 
 Web tools are opt in. Use `--use-web` or `use_web: true` only when you want
 URSA to make network requests through its web-search tools. The top-level

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -21,8 +21,11 @@ Create `config.yaml`:
 llm_model:
   model: openai:gpt-5.4
   api_key_env: OPENAI_API_KEY
-
 workspace: .
+agent_config:
+  execute:
+    safe_codes:
+      - python
 ```
 
 Then set your API key in the shell:
@@ -104,12 +107,18 @@ For detailed commands to list, save, copy, share, import, and delete agents, see
 ```bash
 ursa --help
 ursa --print-config
+ursa --print-config=merged
+ursa --print-config=file,resolved
 ursa --config config.yaml
 ursa --config config.yaml --name my-agent
 ursa --config config.yaml --use-web
 ```
 
-Web tools are opt in. Use `--use-web` or `use_web: true` only when you want URSA to make network requests through its web-search tools.
+Web tools are opt in. Use `--use-web` or `use_web: true` only when you want
+URSA to make network requests through its web-search tools. The top-level
+`use_web` setting fills in missing `use_web` values for `chat`, `execute`,
+`deep_review`, and `prompt`; explicit `agent_config` values still take
+precedence.
 
 ## Where next?
 

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -108,11 +108,19 @@ For detailed commands to list, save, copy, share, import, and delete agents, see
 ursa --help
 ursa --print-config
 ursa --print-config=merged
+ursa --print-config=project+,resolved
 ursa --print-config=file,resolved
 ursa --config config.yaml
 ursa --config config.yaml --name my-agent
 ursa --config config.yaml --use-web
 ```
+
+Configuration sources remain ordered from user files through project and
+explicit files to environment variables and CLI flags. Sources are sparse: an
+omitted key leaves a lower-precedence value unchanged, while `null` clears a
+nullable setting. For model provider settings, omission means inheritance.
+`ssl_verify` is a boolean that defaults to `true`; use `true` or `false`, not
+`null`.
 
 Web tools are opt in. Use `--use-web` or `use_web: true` only when you want
 URSA to make network requests through its web-search tools. The top-level

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -23,7 +23,8 @@ Create `config.yaml`:
 ```yaml
 llm_model:
   model: openai:gpt-5.4
-  api_key_env: OPENAI_API_KEY
+  api_key:
+    env: OPENAI_API_KEY
 workspace: .
 ```
 

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -13,11 +13,10 @@ This guide walks through starting URSA from the terminal, configuring a model, c
 
 ## 1. Create a configuration file
 
-YAML configuration files are the recommended way to configure URSA because
-they are reusable and easy to edit. URSA can combine files, environment
-variables, and CLI flags; see
+YAML configuration files are reusable and easy to edit. URSA configs can be
+layered; see
 [Configuration files, CLI flags, and environment variables][configuration-files-cli-flags-and-environment-variables]
-for the authoritative precedence order.
+for the precedence order.
 
 Create `config.yaml`:
 
@@ -26,10 +25,6 @@ llm_model:
   model: openai:gpt-5.4
   api_key_env: OPENAI_API_KEY
 workspace: .
-agent_config:
-  execute:
-    safe_codes:
-      - python
 ```
 
 Then set your API key in the shell:
@@ -111,18 +106,13 @@ For detailed commands to list, save, copy, share, import, and delete agents, see
 ```bash
 ursa --help
 ursa --print-config
-ursa --print-config=merged
-ursa --config ./.ursa/config.yaml --print-config=file,resolved
 ursa --config config.yaml
 ursa --config config.yaml --name my-agent
 ursa --config config.yaml --use-web
 ```
 
-Web tools are opt in. Use `--use-web` or `use_web: true` only when you want
-URSA to make network requests through its web-search tools. The top-level
-`use_web` setting fills in missing `use_web` values for `chat`, `execute`,
-`deep_review`, and `prompt`; explicit `agent_config` values still take
-precedence.
+Web tools are opt in. Use `--use-web` or `use_web: true` only when you want URSA
+to make network requests through its web-search tools.
 
 ## Where next?
 

--- a/docs/getting-started/mcp-server.md
+++ b/docs/getting-started/mcp-server.md
@@ -21,7 +21,8 @@ Create `config.yaml`:
 ```yaml
 llm_model:
   model: openai:gpt-5.4
-  api_key_env: OPENAI_API_KEY
+  api_key:
+    env: OPENAI_API_KEY
 workspace: ./ursa-mcp-workspace
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,7 +55,8 @@ Create a reusable configuration file, for example `config.yaml`:
 ```yaml
 llm_model:
   model: openai:gpt-5.4
-  api_key_env: OPENAI_API_KEY
+  api_key:
+    env: OPENAI_API_KEY
 ```
 
 Then run:

--- a/docs/persistence/groups-and-security.md
+++ b/docs/persistence/groups-and-security.md
@@ -51,7 +51,8 @@ If your model config uses a custom `base_url`:
 llm_model:
   model: openai:my-model
   base_url: https://my-approved-endpoint.example.com/v1
-  api_key_env: MY_ENDPOINT_API_KEY
+  api_key:
+    env: MY_ENDPOINT_API_KEY
 ```
 
 then the group allowlist should include the approved base URL domain.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -17,9 +17,8 @@ ursa rag-query --help
 
 ## Common top-level commands
 
-URSA configs can be layered. See
-[Configuration files, CLI flags, and environment variables][configuration-files-cli-flags-and-environment-variables]
-for the precedence order.
+URSA configs can be
+[layered with environment variables and CLI flags][configuration-files-cli-flags-and-environment-variables].
 
 ```bash
 ursa --config config.yaml

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -17,6 +17,8 @@ ursa rag-query --help
 
 ## Common top-level commands
 
+URSA merges configuration from XDG-compliant user config, project-local config, `--config`, and CLI flags, in that order.
+
 ```bash
 ursa --config config.yaml
 ursa --print-config

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -17,7 +17,9 @@ ursa rag-query --help
 
 ## Common top-level commands
 
-URSA merges configuration from XDG-compliant user config, project-local config, `--config`, and CLI flags, in that order.
+URSA can combine configuration files, environment variables, and CLI flags.
+See [Configuration files, CLI flags, and environment variables][configuration-files-cli-flags-and-environment-variables]
+for the authoritative precedence order.
 
 ```bash
 ursa --config config.yaml

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -17,9 +17,9 @@ ursa rag-query --help
 
 ## Common top-level commands
 
-URSA can combine configuration files, environment variables, and CLI flags.
-See [Configuration files, CLI flags, and environment variables][configuration-files-cli-flags-and-environment-variables]
-for the authoritative precedence order.
+URSA configs can be layered. See
+[Configuration files, CLI flags, and environment variables][configuration-files-cli-flags-and-environment-variables]
+for the precedence order.
 
 ```bash
 ursa --config config.yaml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
       - OpenAI-compatible endpoints: configuration/openai-compatible.md
       - Ollama and local endpoints: configuration/ollama.md
       - LangChain providers: configuration/langchain-providers.md
+      - Secrets: configuration/secrets.md
       - Files, CLI flags, and environment variables: configuration/files-and-env.md
       - MCP server configuration: configuration/mcp.md
   - Persistence:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "fastmcp~=3.0",
     "pyyaml>=6.0.3",
     "justext>=3.0.2",
+    "keyring>=25.0.0,<26.0.0",
 ]
 classifiers = [
     "Operating System :: OS Independent",
@@ -70,7 +71,6 @@ Issues = "https://github.com/lanl/ursa/issues"
 [project.optional-dependencies]
 dashboard = [
     "fastapi>=0.120.0",
-    "keyring>=25.0.0,<26.0.0",
     "uvicorn>=0.37.0",
 ]
 fm = [

--- a/src/ursa/cli/__init__.py
+++ b/src/ursa/cli/__init__.py
@@ -76,11 +76,17 @@ def build_parser() -> ArgumentParser:
         help="URSA configuration",
         skip={"agent_name", "rag_tools"},
     )
-    parser.add_argument(
-        "--llm_model.api_key_env", default=SUPPRESS, help=SUPPRESS
+    parser._option_string_actions["--llm_model"].container.add_argument(
+        "--llm_model.api_key_env",
+        dest="llm_model.api_key.env",
+        default=SUPPRESS,
+        help="Environment variable containing the chat model API key",
     )
-    parser.add_argument(
-        "--emb_model.api_key_env", default=SUPPRESS, help=SUPPRESS
+    parser._option_string_actions["--emb_model"].container.add_argument(
+        "--emb_model.api_key_env",
+        dest="emb_model.api_key.env",
+        default=SUPPRESS,
+        help="Environment variable containing the embedding model API key",
     )
     parser.add_argument(
         "--rag-tools",

--- a/src/ursa/cli/__init__.py
+++ b/src/ursa/cli/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 from pathlib import Path
 from warnings import filterwarnings
@@ -43,6 +44,27 @@ set_parsing_settings(docstring_parse_attribute_docstrings=True)
 filterwarnings("ignore", message="Pydantic serializer warnings:*")
 
 
+def _xdg_config_search_paths() -> list[Path]:
+    """Return candidate XDG config paths in increasing precedence order."""
+    candidates: list[Path] = []
+
+    config_dirs = os.getenv("XDG_CONFIG_DIRS", "/etc/xdg")
+    for config_dir in config_dirs.split(":"):
+        if not config_dir:
+            continue
+        candidates.append(Path(config_dir).expanduser() / "ursa" / "config.yaml")
+
+    config_home = os.getenv("XDG_CONFIG_HOME")
+    if config_home:
+        candidates.append(
+            Path(config_home).expanduser() / "ursa" / "config.yaml"
+        )
+    else:
+        candidates.append(Path.home() / ".config" / "ursa" / "config.yaml")
+
+    return candidates
+
+
 def build_parser() -> ArgumentParser:
     parser = ArgumentParser(
         prog="ursa",
@@ -58,7 +80,10 @@ def build_parser() -> ArgumentParser:
         "--config",
         default=None,
         type=Path,
-        help="Path to a YAML/JSON file with additional configuration. CLI Opts have priority",
+        help=(
+            "Path to a YAML/JSON file with additional configuration. "
+            "Higher-precedence configuration layers override lower-precedence ones."
+        ),
     )
     parser.add_argument("--log-level", default="error", type=LoggingLevel)
     parser.add_argument(
@@ -100,7 +125,8 @@ def build_parser() -> ArgumentParser:
         help=(
             "Path to a YAML/JSON file with additional configuration "
             "(LLM model, endpoint, embedding model, MCP servers, etc.) "
-            "for the URSA instance hosted by the MCP server. CLI opts have priority."
+            "for the URSA instance hosted by the MCP server. "
+            "Higher-precedence configuration layers override lower-precedence ones."
         ),
     )
     mcp_parser.add_class_arguments(MCPServerConfig, help="MCP server options")
@@ -144,6 +170,29 @@ def _config_path_from_namespace(cfg) -> Path | None:
     return config_path
 
 
+def _config_search_paths(cfg) -> list[Path]:
+    """Return config files in increasing precedence order."""
+    paths: list[Path] = []
+    explicit_config = _config_path_from_namespace(cfg)
+    implicit_paths = [
+        *_xdg_config_search_paths(),
+        Path.cwd() / ".ursa" / "config.yaml",
+    ]
+    seen: set[Path] = set()
+    for candidate in implicit_paths:
+        candidate = candidate.expanduser()
+        if candidate == explicit_config:
+            continue
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        if candidate.is_file():
+            paths.append(candidate)
+    if explicit_config:
+        paths.append(explicit_config)
+    return paths
+
+
 def resolve_config(cfg) -> UrsaConfig:
     """Produce the effective UrsaConfig from the parsed arguments."""
     cfg_dict = cfg.as_dict()
@@ -159,9 +208,8 @@ def resolve_config(cfg) -> UrsaConfig:
         cfg_dict.pop("name", None)
 
     cli_config = UrsaConfig.model_validate(cfg_dict, extra="ignore")
-    config_path = _config_path_from_namespace(cfg)
     config = UrsaConfig()
-    if config_path:
+    for config_path in _config_search_paths(cfg):
         config.update(UrsaConfig.from_file(config_path))
     return config.update(cli_config)
 
@@ -279,19 +327,25 @@ def main(args=None):
             hitl = _initialize_hitl(ursa_config)
             UrsaRepl(hitl).run()
 
-        case "exec":
-            from ursa.cli.hitl import UrsaRepl
-
-            hitl = _initialize_hitl(ursa_config)
-            UrsaRepl(hitl).run_prompt(cmd_config.prompt)
-
         case "mcp-server":
-            hitl = _initialize_hitl(ursa_config)
+            from ursa.cli.hitl import HITL
+
+            hitl = HITL(ursa_config)
             mcp = hitl.as_mcp_server()
+
             run_kwargs = {
                 "transport": cmd_config.transport,
                 "log_level": cmd_config.log_level.upper(),
             }
-            if cmd_config.transport == "streamable-http":
-                run_kwargs.update(host=cmd_config.host, port=cmd_config.port)
+            if cmd_config.transport != "stdio":
+                run_kwargs["host"] = cmd_config.host
+                run_kwargs["port"] = cmd_config.port
             mcp.run(**run_kwargs)
+        case "exec":
+            from ursa.cli.hitl import UrsaExec
+
+            hitl = _initialize_hitl(ursa_config)
+            UrsaExec(hitl).run([cmd_config.prompt])
+        case _:
+            logging.error(f"Unknown subcommand {subcommand}")
+            raise NotImplementedError

--- a/src/ursa/cli/__init__.py
+++ b/src/ursa/cli/__init__.py
@@ -22,6 +22,7 @@ from ursa.cli.config import (
     LoggingLevel,
     MCPServerConfig,
     UrsaConfig,
+    resolve_ursa_config,
 )
 from ursa.cli.groups import (
     add_group_subcommands,
@@ -213,7 +214,18 @@ def resolve_config(cfg) -> UrsaConfig:
     config = UrsaConfig()
     for config_path in _config_search_paths(cfg):
         config.update(UrsaConfig.from_file(config_path))
-    return config.update(cli_config)
+    config.update(cli_config)
+
+    if str(config.workspace) == "tmp":
+        return resolve_ursa_config(config)
+
+    if config.use_web:
+        return resolve_ursa_config(config)
+
+    if config.group != "default":
+        return resolve_ursa_config(config)
+
+    return config
 
 
 def _initialize_hitl(config: UrsaConfig):

--- a/src/ursa/cli/__init__.py
+++ b/src/ursa/cli/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from argparse import SUPPRESS
 from os import getenv
 from pathlib import Path
 from warnings import filterwarnings, warn
@@ -75,6 +76,12 @@ def build_parser() -> ArgumentParser:
         skip={"agent_name", "rag_tools"},
     )
     parser.add_argument(
+        "--llm_model.api_key_env", default=SUPPRESS, help=SUPPRESS
+    )
+    parser.add_argument(
+        "--emb_model.api_key_env", default=SUPPRESS, help=SUPPRESS
+    )
+    parser.add_argument(
         "--rag-tools",
         dest="rag_tools",
         default=None,
@@ -136,7 +143,9 @@ def build_parser() -> ArgumentParser:
     return parser
 
 
-def resolve_config(cfg, overrides, *, group: str | None = None) -> UrsaConfig:
+def resolve_config(
+    cfg, overrides, cli_overrides=None, *, group: str | None = None
+) -> UrsaConfig:
     """Produce the fully resolved UrsaConfig from the parsed arguments.
 
     This function merges configuration layers in precedence order and then
@@ -145,21 +154,21 @@ def resolve_config(cfg, overrides, *, group: str | None = None) -> UrsaConfig:
     group-based endpoint policy enforcement. Consumers with a more specific
     effective group supply it before resolution.
     """
-    merged = merge_ursa_config(cfg, overrides=overrides)
+    merged = merge_ursa_config(
+        cfg, overrides=overrides, cli_overrides=cli_overrides
+    )
     if group is not None:
         merged = merged.model_copy(update={"group": group})
     return resolve_ursa_config(merged)
 
 
 def _initialize_hitl(config: UrsaConfig):
-    """Create the CLI controller and report missing OpenAI credentials cleanly."""
-    from openai import OpenAIError
-
+    """Create the CLI controller and report provider initialization errors cleanly."""
     from ursa.cli.hitl import HITL
 
     try:
         return HITL(config)
-    except OpenAIError as exc:
+    except Exception as exc:
         print(  # noqa: T201
             "Error: unable to initialize the language model. " + str(exc),
             file=sys.stderr,
@@ -187,7 +196,8 @@ def main(args=None):
     inject_truststore_into_ssl()
     parser = build_parser()
     cfg = parser.parse_args(args=args)
-    overrides = parser.parse_args(args=args, defaults=False)
+    overrides = parser.parse_args(args=[], defaults=False)
+    cli_overrides = parser.parse_args(args=args, defaults=False, env=False)
 
     subcommand = cfg.get("subcommand", None)
     logging.basicConfig(level=getattr(cfg, "log_level", "error").upper())
@@ -257,14 +267,16 @@ def main(args=None):
 
     if subcommand in RAG_COMMANDS:
         cmd_config = cfg.get(subcommand, None)
-        ursa_config = resolve_config(cfg, overrides, group=cmd_config.group)
+        ursa_config = resolve_config(
+            cfg, overrides, cli_overrides, group=cmd_config.group
+        )
         if handle_rag_command(cfg, ursa_config):
             return
 
-    if print_config(cfg, overrides):
+    if print_config(cfg, overrides, cli_overrides):
         exit(0)
 
-    ursa_config = resolve_config(cfg, overrides)
+    ursa_config = resolve_config(cfg, overrides, cli_overrides)
     cmd_config = cfg.get(subcommand, None) if subcommand is not None else None
 
     legacy_checkpoint = ursa_config.workspace / "db" / "checkpointer.db"

--- a/src/ursa/cli/__init__.py
+++ b/src/ursa/cli/__init__.py
@@ -4,7 +4,6 @@ import sys
 from pathlib import Path
 from warnings import filterwarnings
 
-import yaml
 from jsonargparse import ArgumentParser, set_parsing_settings
 
 from ursa import __version__
@@ -32,6 +31,7 @@ from ursa.cli.groups import (
     show_group,
     update_group,
 )
+from ursa.cli.print_config import print_config
 from ursa.cli.rag_management import (
     RAG_COMMANDS,
     add_rag_subcommands,
@@ -91,8 +91,16 @@ def build_parser() -> ArgumentParser:
     parser.add_argument("--log-level", default="error", type=LoggingLevel)
     parser.add_argument(
         "--print-config",
-        action="store_true",
-        help="Print the Ursa configuration and exit",
+        nargs="?",
+        const="resolved",
+        default=None,
+        type=str,
+        help=(
+            "Print configuration and exit. Defaults to resolved output. "
+            "Accepted forms: --print-config, --print-config=resolved, "
+            "--print-config=merged, or --print-config=LEVEL,STAGE where "
+            "LEVEL is one of final, file, project, user and STAGE is merged or resolved."
+        ),
     )
     parser.add_class_arguments(
         UrsaConfig,
@@ -160,23 +168,12 @@ def build_parser() -> ArgumentParser:
     return parser
 
 
-def _config_path_from_namespace(cfg) -> Path | None:
-    """Return a root or subcommand-local config path from parsed CLI args."""
-    config_path = getattr(cfg, "config", None)
-    subcommand = cfg.get("subcommand", None)
-    if subcommand is not None:
-        cmd_cfg = cfg.get(subcommand, None)
-        cmd_config_path = (
-            getattr(cmd_cfg, "config", None) if cmd_cfg is not None else None
-        )
-        config_path = cmd_config_path or config_path
-    return config_path
-
-
 def _config_search_paths(cfg) -> list[Path]:
     """Return config files in increasing precedence order."""
     paths: list[Path] = []
-    explicit_config = _config_path_from_namespace(cfg)
+    from ursa.cli.print_config import config_path_from_namespace
+
+    explicit_config = config_path_from_namespace(cfg)
     implicit_paths = [
         *_xdg_config_search_paths(),
         Path.cwd() / ".ursa" / "config.yaml",
@@ -197,7 +194,13 @@ def _config_search_paths(cfg) -> list[Path]:
 
 
 def resolve_config(cfg) -> UrsaConfig:
-    """Produce the effective UrsaConfig from the parsed arguments."""
+    """Produce the fully resolved UrsaConfig from the parsed arguments.
+
+    This function merges configuration layers in precedence order and then
+    applies derived resolution semantics such as temporary workspace
+    materialization, top-level ``use_web`` promotion into ``agent_config``,
+    and group-based model endpoint policy enforcement.
+    """
     cfg_dict = cfg.as_dict()
     # Change `name` to `agent_name` for consistency with agent
     #    arguments.
@@ -210,22 +213,19 @@ def resolve_config(cfg) -> UrsaConfig:
     else:
         cfg_dict.pop("name", None)
 
-    cli_config = UrsaConfig.model_validate(cfg_dict, extra="ignore")
     config = UrsaConfig()
     for config_path in _config_search_paths(cfg):
         config.update(UrsaConfig.from_file(config_path))
-    config.update(cli_config)
 
-    if str(config.workspace) == "tmp":
-        return resolve_ursa_config(config)
+    cli_updates = cfg_dict.copy()
+    cli_updates.pop("subcommand", None)
+    cli_updates.pop("config", None)
+    cli_updates.pop("print_config", None)
+    if cli_updates.get("rag_tools") is None:
+        cli_updates.pop("rag_tools", None)
 
-    if config.use_web:
-        return resolve_ursa_config(config)
-
-    if config.group != "default":
-        return resolve_ursa_config(config)
-
-    return config
+    config.update(UrsaConfig.model_validate(cli_updates, extra="ignore"))
+    return resolve_ursa_config(config)
 
 
 def _initialize_hitl(config: UrsaConfig):
@@ -315,12 +315,11 @@ def main(args=None):
         if handle_rag_command(cfg, ursa_config):
             return
 
+    if print_config(cfg, _config_search_paths(cfg)):
+        exit(0)
+
     ursa_config = resolve_config(cfg)
     cmd_config = cfg.get(subcommand, None) if subcommand is not None else None
-
-    if cfg["print_config"]:
-        print(yaml.safe_dump(ursa_config.model_dump(), sort_keys=False))  # noqa: T201
-        exit(0)
 
     legacy_checkpoint = ursa_config.workspace / "db" / "checkpointer.db"
     if ursa_config.agent_name is None and legacy_checkpoint.is_file():

--- a/src/ursa/cli/__init__.py
+++ b/src/ursa/cli/__init__.py
@@ -18,6 +18,7 @@ from ursa.cli.agent_management import (
     share_agent,
     show_agent,
 )
+from ursa.cli.auth import add_auth_subcommands
 from ursa.cli.config import (
     LoggingLevel,
     MCPServerConfig,
@@ -132,6 +133,9 @@ def build_parser() -> ArgumentParser:
     # Persistent RAG management commands
     add_rag_subcommands(subparsers)
 
+    # Credential management commands
+    add_auth_subcommands(subparsers)
+
     exec_parser = ArgumentParser()
     exec_parser.add_argument("prompt", type=str)
     subparsers.add_subcommand(
@@ -204,6 +208,13 @@ def main(args=None):
     _apply_legacy_name_env(cfg, overrides)
 
     match subcommand:
+        case "auth":
+            auth_config = cfg.auth
+            command_config = auth_config[auth_config.subcommand]
+            command_values = command_config.as_dict()
+            handler = command_values.pop("handler")
+            handler(**command_values)
+            return
         case "list-groups":
             list_groups()
             return

--- a/src/ursa/cli/__init__.py
+++ b/src/ursa/cli/__init__.py
@@ -24,7 +24,6 @@ from ursa.cli.config import (
     MCPServerConfig,
     UrsaConfig,
     merge_ursa_config,
-    resolve_ursa_config,
 )
 from ursa.cli.groups import (
     add_group_subcommands,
@@ -153,25 +152,6 @@ def build_parser() -> ArgumentParser:
     return parser
 
 
-def resolve_config(
-    cfg, overrides, cli_overrides=None, *, group: str | None = None
-) -> UrsaConfig:
-    """Produce the fully resolved UrsaConfig from the parsed arguments.
-
-    This function merges configuration layers in precedence order and then
-    applies derived resolution semantics such as temporary workspace
-    materialization, top-level ``use_web`` promotion into ``agent_config``, and
-    group-based endpoint policy enforcement. Consumers with a more specific
-    effective group supply it before resolution.
-    """
-    merged = merge_ursa_config(
-        cfg, overrides=overrides, cli_overrides=cli_overrides
-    )
-    if group is not None:
-        merged = merged.model_copy(update={"group": group})
-    return resolve_ursa_config(merged)
-
-
 def _initialize_hitl(config: UrsaConfig):
     """Create the CLI controller and report provider initialization errors cleanly."""
     from ursa.cli.hitl import HITL
@@ -206,12 +186,12 @@ def main(args=None):
     inject_truststore_into_ssl()
     parser = build_parser()
     cfg = parser.parse_args(args=args)
-    overrides = parser.parse_args(args=[], defaults=False)
+    env_overrides = parser.parse_args(args=[], defaults=False)
     cli_overrides = parser.parse_args(args=args, defaults=False, env=False)
 
     subcommand = cfg.get("subcommand", None)
     logging.basicConfig(level=getattr(cfg, "log_level", "error").upper())
-    _apply_legacy_name_env(cfg, overrides)
+    _apply_legacy_name_env(cfg, env_overrides)
 
     match subcommand:
         case "auth":
@@ -284,16 +264,23 @@ def main(args=None):
 
     if subcommand in RAG_COMMANDS:
         cmd_config = cfg.get(subcommand, None)
-        ursa_config = resolve_config(
-            cfg, overrides, cli_overrides, group=cmd_config.group
+        merged = merge_ursa_config(
+            cfg, env_overrides=env_overrides, cli_overrides=cli_overrides
         )
+        ursa_config = merged.model_copy(
+            update={"group": cmd_config.group}
+        ).resolve()
         if handle_rag_command(cfg, ursa_config):
             return
 
-    if print_config(cfg, overrides, cli_overrides):
+    if print_config(cfg, env_overrides, cli_overrides):
         exit(0)
 
-    ursa_config = resolve_config(cfg, overrides, cli_overrides)
+    ursa_config = merge_ursa_config(
+        cfg,
+        env_overrides=env_overrides,
+        cli_overrides=cli_overrides,
+    ).resolve()
     cmd_config = cfg.get(subcommand, None) if subcommand is not None else None
 
     legacy_checkpoint = ursa_config.workspace / "db" / "checkpointer.db"

--- a/src/ursa/cli/__init__.py
+++ b/src/ursa/cli/__init__.py
@@ -52,7 +52,9 @@ def _xdg_config_search_paths() -> list[Path]:
     for config_dir in config_dirs.split(":"):
         if not config_dir:
             continue
-        candidates.append(Path(config_dir).expanduser() / "ursa" / "config.yaml")
+        candidates.append(
+            Path(config_dir).expanduser() / "ursa" / "config.yaml"
+        )
 
     config_home = os.getenv("XDG_CONFIG_HOME")
     if config_home:

--- a/src/ursa/cli/__init__.py
+++ b/src/ursa/cli/__init__.py
@@ -1,7 +1,8 @@
 import logging
 import sys
+from os import getenv
 from pathlib import Path
-from warnings import filterwarnings
+from warnings import filterwarnings, warn
 
 from jsonargparse import ArgumentParser, set_parsing_settings
 
@@ -31,9 +32,10 @@ from ursa.cli.groups import (
     show_group,
     update_group,
 )
-from ursa.cli.print_config import print_config
+from ursa.cli.print_config import add_print_config_argument, print_config
 from ursa.cli.rag_management import (
     RAG_COMMANDS,
+    RAG_METADATA_COMMANDS,
     add_rag_subcommands,
     handle_rag_command,
 )
@@ -66,20 +68,7 @@ def build_parser() -> ArgumentParser:
         ),
     )
     parser.add_argument("--log-level", default="error", type=LoggingLevel)
-    parser.add_argument(
-        "--print-config",
-        nargs="?",
-        const="resolved",
-        default=None,
-        type=str,
-        help=(
-            "Print configuration and exit. Defaults to resolved output. "
-            "Accepted forms: --print-config, --print-config=resolved, "
-            "--print-config=merged, or --print-config=LEVEL,STAGE where "
-            "LEVEL is one of final, file, project, user (optionally suffixed "
-            "with + for cumulative input) and STAGE is merged or resolved."
-        ),
-    )
+    add_print_config_argument(parser)
     parser.add_class_arguments(
         UrsaConfig,
         help="URSA configuration",
@@ -147,15 +136,19 @@ def build_parser() -> ArgumentParser:
     return parser
 
 
-def resolve_config(cfg, overrides) -> UrsaConfig:
+def resolve_config(cfg, overrides, *, group: str | None = None) -> UrsaConfig:
     """Produce the fully resolved UrsaConfig from the parsed arguments.
 
     This function merges configuration layers in precedence order and then
     applies derived resolution semantics such as temporary workspace
-    materialization, top-level ``use_web`` promotion into ``agent_config``,
-    and group-based model endpoint policy enforcement.
+    materialization, top-level ``use_web`` promotion into ``agent_config``, and
+    group-based endpoint policy enforcement. Consumers with a more specific
+    effective group supply it before resolution.
     """
-    return resolve_ursa_config(merge_ursa_config(cfg, overrides=overrides))
+    merged = merge_ursa_config(cfg, overrides=overrides)
+    if group is not None:
+        merged = merged.model_copy(update={"group": group})
+    return resolve_ursa_config(merged)
 
 
 def _initialize_hitl(config: UrsaConfig):
@@ -174,6 +167,22 @@ def _initialize_hitl(config: UrsaConfig):
         raise SystemExit(2) from None
 
 
+def _apply_legacy_name_env(cfg, overrides) -> None:
+    """Apply deprecated ``URSA_NAME`` when no modern name override is set."""
+    legacy_name = getenv("URSA_NAME")
+    if legacy_name is None:
+        return
+
+    warn(
+        "URSA_NAME is deprecated; use URSA_AGENT_NAME or --name instead.",
+        FutureWarning,
+        stacklevel=2,
+    )
+    if overrides.get("agent_name", None) is None:
+        cfg["agent_name"] = legacy_name
+        overrides["agent_name"] = legacy_name
+
+
 def main(args=None):
     inject_truststore_into_ssl()
     parser = build_parser()
@@ -182,6 +191,7 @@ def main(args=None):
 
     subcommand = cfg.get("subcommand", None)
     logging.basicConfig(level=getattr(cfg, "log_level", "error").upper())
+    _apply_legacy_name_env(cfg, overrides)
 
     match subcommand:
         case "list-groups":
@@ -241,8 +251,13 @@ def main(args=None):
             )
             return
 
+    if subcommand in RAG_METADATA_COMMANDS:
+        if handle_rag_command(cfg):
+            return
+
     if subcommand in RAG_COMMANDS:
-        ursa_config = resolve_config(cfg, overrides)
+        cmd_config = cfg.get(subcommand, None)
+        ursa_config = resolve_config(cfg, overrides, group=cmd_config.group)
         if handle_rag_command(cfg, ursa_config):
             return
 
@@ -272,9 +287,7 @@ def main(args=None):
             UrsaRepl(hitl).run()
 
         case "mcp-server":
-            from ursa.cli.hitl import HITL
-
-            hitl = HITL(ursa_config)
+            hitl = _initialize_hitl(ursa_config)
             mcp = hitl.as_mcp_server()
 
             run_kwargs = {
@@ -286,10 +299,10 @@ def main(args=None):
                 run_kwargs["port"] = cmd_config.port
             mcp.run(**run_kwargs)
         case "exec":
-            from ursa.cli.hitl import UrsaExec
+            from ursa.cli.hitl import UrsaRepl
 
             hitl = _initialize_hitl(ursa_config)
-            UrsaExec(hitl).run([cmd_config.prompt])
+            UrsaRepl(hitl).run_prompt(cmd_config.prompt)
         case _:
             logging.error(f"Unknown subcommand {subcommand}")
             raise NotImplementedError

--- a/src/ursa/cli/__init__.py
+++ b/src/ursa/cli/__init__.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import sys
 from pathlib import Path
 from warnings import filterwarnings
@@ -21,6 +20,7 @@ from ursa.cli.config import (
     LoggingLevel,
     MCPServerConfig,
     UrsaConfig,
+    merge_ursa_config,
     resolve_ursa_config,
 )
 from ursa.cli.groups import (
@@ -43,29 +43,6 @@ set_parsing_settings(docstring_parse_attribute_docstrings=True)
 # NOTE [alui | 26 June, 2026]:
 # Pydantic warnings occured around v0.16.0. Suppress for now.
 filterwarnings("ignore", message="Pydantic serializer warnings:*")
-
-
-def _xdg_config_search_paths() -> list[Path]:
-    """Return candidate XDG config paths in increasing precedence order."""
-    candidates: list[Path] = []
-
-    config_dirs = os.getenv("XDG_CONFIG_DIRS", "/etc/xdg")
-    for config_dir in config_dirs.split(":"):
-        if not config_dir:
-            continue
-        candidates.append(
-            Path(config_dir).expanduser() / "ursa" / "config.yaml"
-        )
-
-    config_home = os.getenv("XDG_CONFIG_HOME")
-    if config_home:
-        candidates.append(
-            Path(config_home).expanduser() / "ursa" / "config.yaml"
-        )
-    else:
-        candidates.append(Path.home() / ".config" / "ursa" / "config.yaml")
-
-    return candidates
 
 
 def build_parser() -> ArgumentParser:
@@ -99,7 +76,8 @@ def build_parser() -> ArgumentParser:
             "Print configuration and exit. Defaults to resolved output. "
             "Accepted forms: --print-config, --print-config=resolved, "
             "--print-config=merged, or --print-config=LEVEL,STAGE where "
-            "LEVEL is one of final, file, project, user and STAGE is merged or resolved."
+            "LEVEL is one of final, file, project, user (optionally suffixed "
+            "with + for cumulative input) and STAGE is merged or resolved."
         ),
     )
     parser.add_class_arguments(
@@ -122,6 +100,7 @@ def build_parser() -> ArgumentParser:
     )
     parser.add_argument(
         "--name",
+        dest="agent_name",
         type=str,
         default=None,
         help="Name of the agent for persistence",
@@ -168,32 +147,7 @@ def build_parser() -> ArgumentParser:
     return parser
 
 
-def _config_search_paths(cfg) -> list[Path]:
-    """Return config files in increasing precedence order."""
-    paths: list[Path] = []
-    from ursa.cli.print_config import config_path_from_namespace
-
-    explicit_config = config_path_from_namespace(cfg)
-    implicit_paths = [
-        *_xdg_config_search_paths(),
-        Path.cwd() / ".ursa" / "config.yaml",
-    ]
-    seen: set[Path] = set()
-    for candidate in implicit_paths:
-        candidate = candidate.expanduser()
-        if candidate == explicit_config:
-            continue
-        if candidate in seen:
-            continue
-        seen.add(candidate)
-        if candidate.is_file():
-            paths.append(candidate)
-    if explicit_config:
-        paths.append(explicit_config)
-    return paths
-
-
-def resolve_config(cfg) -> UrsaConfig:
+def resolve_config(cfg, overrides) -> UrsaConfig:
     """Produce the fully resolved UrsaConfig from the parsed arguments.
 
     This function merges configuration layers in precedence order and then
@@ -201,31 +155,7 @@ def resolve_config(cfg) -> UrsaConfig:
     materialization, top-level ``use_web`` promotion into ``agent_config``,
     and group-based model endpoint policy enforcement.
     """
-    cfg_dict = cfg.as_dict()
-    # Change `name` to `agent_name` for consistency with agent
-    #    arguments.
-    # TODO: Longer term, we should make our agents use `name`
-    #    as the argument for the class, but this is a problem
-    #    with the current class property `name` that is used by
-    #    the CLI
-    if cfg_dict.get("name") is not None:
-        cfg_dict["agent_name"] = cfg_dict.pop("name")
-    else:
-        cfg_dict.pop("name", None)
-
-    config = UrsaConfig()
-    for config_path in _config_search_paths(cfg):
-        config.update(UrsaConfig.from_file(config_path))
-
-    cli_updates = cfg_dict.copy()
-    cli_updates.pop("subcommand", None)
-    cli_updates.pop("config", None)
-    cli_updates.pop("print_config", None)
-    if cli_updates.get("rag_tools") is None:
-        cli_updates.pop("rag_tools", None)
-
-    config.update(UrsaConfig.model_validate(cli_updates, extra="ignore"))
-    return resolve_ursa_config(config)
+    return resolve_ursa_config(merge_ursa_config(cfg, overrides=overrides))
 
 
 def _initialize_hitl(config: UrsaConfig):
@@ -248,6 +178,7 @@ def main(args=None):
     inject_truststore_into_ssl()
     parser = build_parser()
     cfg = parser.parse_args(args=args)
+    overrides = parser.parse_args(args=args, defaults=False)
 
     subcommand = cfg.get("subcommand", None)
     logging.basicConfig(level=getattr(cfg, "log_level", "error").upper())
@@ -311,14 +242,14 @@ def main(args=None):
             return
 
     if subcommand in RAG_COMMANDS:
-        ursa_config = resolve_config(cfg)
+        ursa_config = resolve_config(cfg, overrides)
         if handle_rag_command(cfg, ursa_config):
             return
 
-    if print_config(cfg, _config_search_paths(cfg)):
+    if print_config(cfg, overrides):
         exit(0)
 
-    ursa_config = resolve_config(cfg)
+    ursa_config = resolve_config(cfg, overrides)
     cmd_config = cfg.get(subcommand, None) if subcommand is not None else None
 
     legacy_checkpoint = ursa_config.workspace / "db" / "checkpointer.db"

--- a/src/ursa/cli/auth.py
+++ b/src/ursa/cli/auth.py
@@ -1,0 +1,239 @@
+"""Manage URSA credentials in the operating-system keyring."""
+
+from __future__ import annotations
+
+import getpass
+from argparse import SUPPRESS
+from collections import Counter
+from collections.abc import Iterator, Mapping, Sequence
+from os import environ
+from pathlib import Path
+from typing import Any
+
+import keyring
+from jsonargparse import ArgumentParser, Namespace
+
+from ursa.cli.config import (
+    config_search_paths,
+    deep_merge_dicts,
+    load_config_file,
+)
+from ursa.util.secrets import SecretReference, SecretTemplate
+
+KEYRING_SERVICE = "ursa"
+
+
+def add_auth_subcommands(subparsers) -> None:
+    """Add ``ursa auth`` credential-management commands."""
+    auth_parser = ArgumentParser()
+    subparsers.add_subcommand(
+        "auth",
+        auth_parser,
+        help="Manage credentials in the system keyring",
+        dest="subcommand",
+    )
+    auth_subparsers = auth_parser.add_subcommands(required=True)
+
+    login_parser = ArgumentParser()
+    source = login_parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
+        "username",
+        nargs="?",
+        help="Inference-provider name or keyring username",
+    )
+    source.add_argument(
+        "--config",
+        type=Path,
+        help="Store every keyring-backed secret referenced by this config",
+    )
+    login_parser.add_argument(
+        "--from-env",
+        metavar="VAR",
+        help="Read the secret from this environment variable instead of prompting",
+    )
+    login_parser.add_argument("--handler", default=None, help=SUPPRESS)
+    auth_subparsers.add_subcommand(
+        "login", login_parser, help="Store credentials in the system keyring"
+    )
+    login_parser.set_defaults(handler=login)
+
+    list_parser = ArgumentParser()
+    list_parser.add_argument(
+        "--config",
+        type=Path,
+        help="Additional config file to merge after system and user configs",
+    )
+    list_parser.add_argument(
+        "--show-secrets",
+        action="store_true",
+        default=False,
+        help="Print resolved secret values",
+    )
+    list_parser.add_argument("--handler", default=None, help=SUPPRESS)
+    auth_subparsers.add_subcommand(
+        "list",
+        list_parser,
+        help="Check configured environment and keyring secrets",
+    )
+    list_parser.set_defaults(handler=list_credentials)
+
+    # Authentication configuration must be explicit. In particular, do not
+    # let jsonargparse synthesize URSA_AUTH__... settings for these parsers.
+    auth_parser.default_env = False
+
+
+def config_keyring_usernames(path: Path) -> list[str]:
+    """Return keyring usernames referenced anywhere in an URSA config."""
+    secrets = _iter_secrets(load_config_file(path))
+    return sorted({
+        reference.keyring
+        if isinstance(reference.keyring, str)
+        else default_username
+        for _, reference, default_username in secrets
+        if reference.keyring not in (None, False)
+    })
+
+
+def _iter_secrets(
+    value: Any,
+    path: tuple[str, ...] = (),
+    default_username: str | None = None,
+) -> Iterator[tuple[tuple[str, ...], SecretReference, str | None]]:
+    """Yield secrets found in a loaded config mapping."""
+    value = SecretTemplate.maybe_validate(value)
+    if isinstance(value, SecretReference):
+        yield path, value, default_username
+        return
+    if isinstance(value, Mapping):
+        if isinstance(value.get("inference_provider"), str):
+            default_username = value["inference_provider"]
+        elif isinstance(value.get("model"), str) and ":" in value["model"]:
+            default_username = value["model"].split(":", 1)[0]
+        for name, item in value.items():
+            if name == "api_key_env" and isinstance(item, str):
+                yield (
+                    (*path, "api_key"),
+                    SecretReference(env=item),
+                    default_username,
+                )
+                continue
+            child_default = default_username
+            if path in {("inference_providers",), ("mcp_servers",)}:
+                child_default = str(name)
+            elif child_default is None:
+                child_default = str(name)
+            yield from _iter_secrets(item, (*path, str(name)), child_default)
+        return
+    if isinstance(value, Sequence) and not isinstance(
+        value, (str, bytes, bytearray)
+    ):
+        for index, item in enumerate(value):
+            yield from _iter_secrets(
+                item, (*path, str(index)), default_username
+            )
+
+
+def _secret_lines(
+    config: dict, show_secrets: bool = False
+) -> dict[str, list[str]]:
+    secrets = list(_iter_secrets(config))
+    mcp_counts = Counter(
+        path[1] for path, _, _ in secrets if path[:1] == ("mcp_servers",)
+    )
+    sections: dict[str, list[str]] = {
+        "Inference Providers": [],
+        "MCP Servers:": [],
+        "Other": [],
+    }
+    for path, reference, default_username in secrets:
+        if path[:1] == ("inference_providers",):
+            section, name = "Inference Providers", path[1]
+        elif path[:1] == ("mcp_servers",):
+            section, server_name = "MCP Servers:", path[1]
+            suffix = ".".join(part for part in path[2:] if part != "headers")
+            name = (
+                f"{server_name}.{suffix}"
+                if mcp_counts[server_name] > 1
+                else server_name
+            )
+        else:
+            section = "Other"
+            display_path = path[:-1] if path[-1:] == ("api_key",) else path
+            name = ".".join(display_path)
+
+        source = "env" if reference.env is not None else "keyring"
+        if source == "keyring" and isinstance(reference.keyring, str):
+            name += f" ({reference.keyring})"
+        try:
+            resolved = reference.resolve(default_username)
+        except (ValueError, keyring.errors.KeyringError):
+            resolved = None
+        line = (
+            f"  {name}: {source} {'ok' if resolved is not None else 'missing'}"
+        )
+        if show_secrets and resolved is not None:
+            line += f" = {resolved.get_secret_value()}"
+        sections[section].append(line)
+
+    return {heading: sorted(lines) for heading, lines in sections.items()}
+
+
+def configured_secret_lines(
+    config: Path | None = None, show_secrets: bool = False
+) -> dict[str, list[str]]:
+    """Build the categorized report for the active config stack."""
+    merged = {}
+    config_namespace = Namespace(config=config, subcommand=None)
+    for path in config_search_paths(config_namespace):
+        merged = deep_merge_dicts(merged, load_config_file(path))
+    return _secret_lines(merged, show_secrets)
+
+
+def list_credentials(
+    config: Path | None = None, show_secrets: bool = False
+) -> None:
+    """Report whether each configured external secret is present."""
+    sections = configured_secret_lines(config, show_secrets)
+    populated_sections = [
+        (heading, references)
+        for heading, references in sections.items()
+        if references
+    ]
+    for index, (heading, references) in enumerate(populated_sections):
+        if index:
+            print()  # noqa: T201
+        print(heading)  # noqa: T201
+        for line in references:
+            print(line)  # noqa: T201
+
+
+def login(
+    username: str | None = None,
+    config: Path | None = None,
+    from_env: str | None = None,
+) -> None:
+    """Prompt for and store one or more URSA credentials."""
+    usernames = config_keyring_usernames(config) if config else [username]
+    usernames = [name for name in usernames if name]
+    if not usernames:
+        print("No keyring-backed secrets found in the config.")  # noqa: T201
+        return
+
+    env_password: str | None = None
+    if from_env is not None:
+        if len(usernames) != 1:
+            raise ValueError(
+                "--from-env requires exactly one keyring-backed secret"
+            )
+        env_password = environ.get(from_env)
+        if not env_password:
+            raise ValueError(
+                f"Environment variable '{from_env}' is not set or is empty"
+            )
+
+    for name in usernames:
+        password = env_password or getpass.getpass(f"Secret for {name}: ")
+        if not password:
+            raise ValueError(f"Secret for '{name}' cannot be empty")
+        keyring.set_password(KEYRING_SERVICE, name, password)
+        print(f"Stored credential: {name}")  # noqa: T201

--- a/src/ursa/cli/auth.py
+++ b/src/ursa/cli/auth.py
@@ -14,7 +14,7 @@ import keyring
 from jsonargparse import ArgumentParser, Namespace
 
 from ursa.cli.config import (
-    config_search_paths,
+    config_layers,
     deep_merge_dicts,
     load_config_file,
 )
@@ -184,8 +184,8 @@ def configured_secret_lines(
     """Build the categorized report for the active config stack."""
     merged = {}
     config_namespace = Namespace(config=config, subcommand=None)
-    for path in config_search_paths(config_namespace):
-        merged = deep_merge_dicts(merged, load_config_file(path))
+    for layer in config_layers(config_namespace, "file+"):
+        merged = deep_merge_dicts(merged, layer)
     return _secret_lines(merged, show_secrets)
 
 

--- a/src/ursa/cli/config.py
+++ b/src/ursa/cli/config.py
@@ -294,27 +294,8 @@ class UrsaConfig(BaseModel):
             )
         return mc
 
-    @field_validator("llm_model", "emb_model", mode="after")
-    @classmethod
-    def _check_group_policy(
-        cls, value: ModelConfig | None, info: ValidationInfo
-    ) -> ModelConfig | None:
-        """Validate that configured model base URLs comply with the selected group policy.
-
-        This runs for both chat and embedding model configs after field parsing,
-        using the already-validated ``group`` value from ``info.data``.
-        """
-        if value is None:
-            return value
-        enforce_group_base_url_policy(value.base_url, info.data["group"])
-        return value
-
     def model_post_init(self, __context):
         """Handle temporary workspace creation post validation."""
-        if str(self.workspace) == "tmp" and not self.workspace.exists():
-            temp_workspace = TemporaryDirectory(prefix="ursa")
-            self.workspace = Path(temp_workspace.name)
-            self._temp_workspace = temp_workspace
 
     def update(self, other: "UrsaConfig") -> "UrsaConfig":
         """Merge non-default values from another config into this config."""
@@ -342,15 +323,11 @@ class UrsaConfig(BaseModel):
 
     @classmethod
     def from_file(cls, path: Path):
-        loader = (
-            yaml.safe_load if path.suffix in [".yaml", ".yml"] else json.load
-        )
-        with open(path, "r") as fid:
-            data = loader(fid)
+        return cls.model_validate(load_config_file(path))
 
-        data = deep_interp_env(data)
-
-        return cls.model_validate(data)
+    @classmethod
+    def resolve_config(cls, config: "UrsaConfig") -> "UrsaConfig":
+        return resolve_ursa_config(config)
 
     @field_serializer("workspace")
     def serialize_workspace(self, workspace: Path, _info):
@@ -364,6 +341,15 @@ class UrsaConfig(BaseModel):
             server: _serialize_server_config(config)
             for server, config in mcp_servers.items()
         }
+
+
+def load_config_file(path: Path) -> dict[str, Any]:
+    """Load and validate raw config-file data before config merging."""
+    loader = yaml.safe_load if path.suffix in [".yaml", ".yml"] else json.load
+    with open(path, "r") as fid:
+        data = loader(fid)
+
+    return deep_interp_env(data)
 
 
 @dataclass
@@ -425,6 +411,31 @@ def deep_interp_env(x: dict[str, Any] | str | Any):
         return interpolate_env(x)
     else:
         return x
+
+
+def resolve_ursa_config(config: UrsaConfig) -> UrsaConfig:
+    """Resolve derived config state after validation and merge steps."""
+    resolved = config.model_copy(deep=True)
+
+    if resolved.llm_model is not None:
+        enforce_group_base_url_policy(
+            resolved.llm_model.base_url, resolved.group
+        )
+    if resolved.emb_model is not None:
+        enforce_group_base_url_policy(
+            resolved.emb_model.base_url, resolved.group
+        )
+
+    if str(resolved.workspace) == "tmp" and not resolved.workspace.exists():
+        temp_workspace = TemporaryDirectory(prefix="ursa")
+        resolved.workspace = Path(temp_workspace.name)
+        resolved._temp_workspace = temp_workspace
+
+    if resolved.use_web:
+        for agent_name in ["chat", "execute", "deep_review", "prompt"]:
+            resolved.agent_config.setdefault(agent_name, {})["use_web"] = True
+
+    return resolved
 
 
 def interpolate_env(value: str) -> str:

--- a/src/ursa/cli/config.py
+++ b/src/ursa/cli/config.py
@@ -121,6 +121,20 @@ class ModelConfig(BaseModel):
     ssl_verify: bool = True
     """Flag for verifying SSL certs. during API access."""
 
+    def model_merge(self, other: Self | dict[str, Any]) -> Self:
+        """Merge explicit values from a higher-priority model config."""
+        updates = (
+            other.model_dump(mode="python", exclude_unset=True)
+            if isinstance(other, ModelConfig)
+            else deepcopy(other)
+        )
+        if updates.get("base_url") is not None:
+            updates.setdefault("inference_provider", None)
+        return type(self).model_validate({
+            **self.model_dump(mode="python"),
+            **updates,
+        })
+
     @model_validator(mode="before")
     @classmethod
     def _accept_legacy_api_key_env(cls, data):
@@ -381,6 +395,29 @@ class UrsaConfig(BaseModel):
         """Return this config after applying canonical resolution."""
         return resolve_ursa_config(self)
 
+    def model_merge(self, *others: Self | dict[str, Any]) -> Self:
+        """Merge higher-priority config layers and validate the result once."""
+        merged = {
+            name: deepcopy(getattr(self, name))
+            for name in type(self).model_fields
+        }
+        for other in others:
+            updates = (
+                other.model_dump(mode="python", exclude_unset=True)
+                if isinstance(other, UrsaConfig)
+                else deepcopy(other)
+            )
+            for key, value in updates.items():
+                current = merged.get(key)
+                model_merge = getattr(current, "model_merge", None)
+                if callable(model_merge):
+                    merged[key] = model_merge(value)
+                elif isinstance(current, dict) and isinstance(value, dict):
+                    merged[key] = deep_merge_dicts(current, value)
+                else:
+                    merged[key] = value
+        return type(self).model_validate(merged)
+
     @field_serializer("workspace")
     def serialize_workspace(self, workspace: Path, _info):
         return workspace.as_posix()
@@ -481,7 +518,7 @@ def merge_ursa_config(
     cli_overrides: Namespace | dict[str, Any] | None = None,
 ) -> UrsaConfig:
     """Merge sparse configuration sources, then validate the result once."""
-    merged: dict[str, Any] = {}
+    layers: list[dict[str, Any]] = []
     paths = config_search_paths(cfg, level)
     explicit_path = (
         config_path_from_namespace(cli_overrides)
@@ -493,7 +530,7 @@ def merge_ursa_config(
     else:
         lower_paths = paths
     for config_path in lower_paths:
-        merged = deep_merge_dicts(merged, load_config_file(config_path))
+        layers.append(load_config_file(config_path))
 
     if level.removesuffix("+") == "final":
         if overrides is None:
@@ -503,32 +540,26 @@ def merge_ursa_config(
             if isinstance(overrides, Namespace)
             else overrides
         )
-        merged = deep_merge_dicts(
-            merged,
-            {
-                key: value
-                for key, value in override_values.items()
-                if key in UrsaConfig.model_fields
-            },
-        )
+        layers.append({
+            key: value
+            for key, value in override_values.items()
+            if key in UrsaConfig.model_fields
+        })
         if explicit_path is not None and explicit_path in paths:
-            merged = deep_merge_dicts(merged, load_config_file(explicit_path))
+            layers.append(load_config_file(explicit_path))
         if cli_overrides is not None:
             cli_values = (
                 cli_overrides.as_dict()
                 if isinstance(cli_overrides, Namespace)
                 else cli_overrides
             )
-            merged = deep_merge_dicts(
-                merged,
-                {
-                    key: value
-                    for key, value in cli_values.items()
-                    if key in UrsaConfig.model_fields
-                },
-            )
+            layers.append({
+                key: value
+                for key, value in cli_values.items()
+                if key in UrsaConfig.model_fields
+            })
 
-    return UrsaConfig.model_validate(merged)
+    return UrsaConfig().model_merge(*layers)
 
 
 @dataclass

--- a/src/ursa/cli/config.py
+++ b/src/ursa/cli/config.py
@@ -53,7 +53,6 @@ def _strip_blank_optional_strings(value: Any) -> str | Any | None:
     return value or None
 
 
-APIKeyConfig = SecretReference
 APIKey = SecretReference | SecretStr
 
 
@@ -127,13 +126,19 @@ class ModelConfig(BaseModel):
 
     def model_merge(self, other: Self | dict[str, Any]) -> Self:
         """Merge explicit values from a higher-priority model config."""
-        updates = (
-            other.model_dump(mode="python", exclude_unset=True)
+        candidate = (
+            other
             if isinstance(other, ModelConfig)
-            else deepcopy(other)
+            else type(self).model_validate({
+                "model": self.model,
+                **deepcopy(other),
+            })
         )
+        updates = candidate.model_dump(mode="python", exclude_unset=True)
         if updates.get("base_url") is not None:
             updates.setdefault("inference_provider", None)
+        elif updates.get("inference_provider") is not None:
+            updates.setdefault("base_url", None)
         return type(self).model_validate({
             **self.model_dump(mode="python"),
             **updates,
@@ -157,6 +162,13 @@ class ModelConfig(BaseModel):
                 )
             data["model"] = model_name
             data["model_provider"] = provider
+        if (
+            data.get("base_url") is not None
+            and data.get("inference_provider") is not None
+        ):
+            raise ValueError(
+                "base_url and inference_provider cannot both be configured"
+            )
         return data
 
     @property
@@ -179,15 +191,32 @@ class ModelConfig(BaseModel):
             raise ValueError(f"Unknown inference_provider '{provider_name}'")
         assert isinstance(provider_config, InferenceProviderConfig)
 
-        provider_values = provider_config.model_dump(
-            mode="python", exclude_unset=True
-        )
-        model_values = self.model_dump(mode="python", exclude_unset=True)
+        provider_values = {
+            name: deepcopy(getattr(provider_config, name))
+            for name in provider_config.model_fields_set
+        }
+        provider_values.update(deepcopy(provider_config.model_extra or {}))
+        model_values = {
+            name: deepcopy(getattr(self, name))
+            for name in self.model_fields_set
+            if name in type(self).model_fields
+        }
+        model_values.update(deepcopy(self.model_extra or {}))
 
-        resolved = type(self).model_validate({
+        values = {
             **provider_values,
             **model_values,
-        })
+        }
+        api_key = values.get("api_key")
+        if isinstance(api_key, SecretReference) and api_key.keyring is True:
+            values["api_key"] = api_key.model_copy(
+                update={"keyring": provider_name}
+            )
+
+        # This is a trusted transition from configured input to a concrete
+        # runtime model. A resolved model intentionally retains the provider
+        # name while also containing the provider-derived base URL.
+        resolved = self.model_copy(update=values)
         resolved._inference_provider_resolved = True
         return resolved
 
@@ -230,26 +259,15 @@ class ModelConfig(BaseModel):
                 "client_kwargs",
                 {"verify": httpx_verify_value(verify=ssl_verify)},
             )
-        if isinstance(api_key := kwargs.get("api_key"), SecretStr):
-            kwargs["api_key"] = api_key.get_secret_value()
-        elif isinstance(api_key, dict):
-            resolved = self.resolve_api_key()
-            if isinstance(resolved.api_key, SecretStr):
-                kwargs["api_key"] = resolved.api_key.get_secret_value()
-            else:
+        if isinstance(api_key := self.api_key, SecretReference):
+            value = api_key.get_secret_value()
+            if value is None:
                 kwargs.pop("api_key", None)
+            else:
+                kwargs["api_key"] = value
+        elif isinstance(api_key, SecretStr):
+            kwargs["api_key"] = api_key.get_secret_value()
         return kwargs
-
-    def resolve_api_key(self, provider_name: str | None = None) -> Self:
-        """Resolve environment/keyring references to an in-memory SecretStr."""
-        value = self.api_key
-        if value is None or isinstance(value, SecretStr):
-            return self
-
-        secret = value.resolve(provider_name)
-        if secret is None:
-            return self
-        return self.model_copy(update={"api_key": secret})
 
     @staticmethod
     def _get_model_base_url(model) -> str | None:
@@ -336,7 +354,7 @@ class UrsaConfig(BaseModel):
         default_factory=lambda: {
             "openai": InferenceProviderConfig(
                 base_url="https://api.openai.com/v1",
-                api_key=APIKeyConfig(env="OPENAI_API_KEY"),
+                api_key=SecretReference(env="OPENAI_API_KEY"),
             )
         }
     )
@@ -656,20 +674,16 @@ def resolve_ursa_config(config: UrsaConfig) -> UrsaConfig:
     resolved._temp_workspace = config._temp_workspace
 
     if resolved.llm_model is not None:
-        provider_name = resolved.llm_model.inference_provider
         resolved.llm_model = resolved.llm_model.resolve_inference_provider(
             resolved.inference_providers
         )
-        resolved.llm_model = resolved.llm_model.resolve_api_key(provider_name)
         enforce_group_base_url_policy(
             resolved.llm_model.base_url, resolved.group
         )
     if resolved.emb_model is not None:
-        provider_name = resolved.emb_model.inference_provider
         resolved.emb_model = resolved.emb_model.resolve_inference_provider(
             resolved.inference_providers
         )
-        resolved.emb_model = resolved.emb_model.resolve_api_key(provider_name)
         enforce_group_base_url_policy(
             resolved.emb_model.base_url, resolved.group
         )

--- a/src/ursa/cli/config.py
+++ b/src/ursa/cli/config.py
@@ -139,10 +139,17 @@ class ModelConfig(BaseModel):
             updates.setdefault("inference_provider", None)
         elif updates.get("inference_provider") is not None:
             updates.setdefault("base_url", None)
-        return type(self).model_validate({
+        merged = type(self).model_validate({
             **self.model_dump(mode="python"),
             **updates,
         })
+        # Validating the complete merged mapping marks every default as explicit.
+        # Preserve only fields supplied by either layer so provider defaults can
+        # still fill values that merely appeared in the model dump.
+        merged.__pydantic_fields_set__ = (
+            self.model_fields_set | candidate.model_fields_set
+        )
+        return merged
 
     @model_validator(mode="before")
     @classmethod
@@ -430,6 +437,7 @@ class UrsaConfig(BaseModel):
 
     def model_merge(self, *others: Self | dict[str, Any]) -> Self:
         """Merge higher-priority config layers and validate the result once."""
+        fields_set = set(self.model_fields_set)
         merged = {
             name: deepcopy(getattr(self, name))
             for name in type(self).model_fields
@@ -440,6 +448,7 @@ class UrsaConfig(BaseModel):
                 if isinstance(other, UrsaConfig)
                 else deepcopy(other)
             )
+            fields_set.update(updates)
             for key, value in updates.items():
                 current = merged.get(key)
                 model_merge = getattr(current, "model_merge", None)
@@ -449,7 +458,9 @@ class UrsaConfig(BaseModel):
                     merged[key] = deep_merge_dicts(current, value)
                 else:
                     merged[key] = value
-        return type(self).model_validate(merged)
+        result = type(self).model_validate(merged)
+        result.__pydantic_fields_set__ = fields_set
+        return result
 
     @field_serializer("workspace")
     def serialize_workspace(self, workspace: Path, _info):

--- a/src/ursa/cli/config.py
+++ b/src/ursa/cli/config.py
@@ -58,7 +58,7 @@ APIKey = SecretReference | SecretStr
 
 
 def _migrate_api_key_env(data: Any) -> Any:
-    """Translate the removed ``api_key_env`` field for legacy configs."""
+    """Translate deprecated config-file ``api_key_env`` values."""
     if not isinstance(data, dict) or "api_key_env" not in data:
         return data
     from warnings import warn
@@ -67,7 +67,8 @@ def _migrate_api_key_env(data: Any) -> Any:
     env_name = _strip_blank_optional_strings(migrated.pop("api_key_env"))
     if env_name is not None:
         warn(
-            "api_key_env is deprecated; use api_key: {env: VAR_NAME} instead.",
+            "api_key_env is deprecated in config files; "
+            "use api_key: {env: VAR_NAME} instead.",
             DeprecationWarning,
             stacklevel=3,
         )
@@ -298,7 +299,7 @@ class UrsaConfig(BaseModel):
         default_factory=lambda: {
             "openai": InferenceProviderConfig(
                 base_url="https://api.openai.com/v1",
-                api_key=APIKeyConfig(env="OPENAI_API_KEY")
+                api_key=APIKeyConfig(env="OPENAI_API_KEY"),
             )
         }
     )

--- a/src/ursa/cli/config.py
+++ b/src/ursa/cli/config.py
@@ -367,7 +367,10 @@ def xdg_config_search_paths() -> list[Path]:
     candidates: list[Path] = []
     # XDG_CONFIG_DIRS lists its most-preferred directory first, whereas config
     # merging consumes sources from lowest to highest precedence.
-    config_dirs = getenv("XDG_CONFIG_DIRS", "/etc/xdg").split(":")
+    path_list_separator = ";" if Path.cwd().drive else ":"
+    config_dirs = getenv("XDG_CONFIG_DIRS", "/etc/xdg").split(
+        path_list_separator
+    )
     for config_dir in reversed(config_dirs):
         if config_dir:
             candidates.append(

--- a/src/ursa/cli/config.py
+++ b/src/ursa/cli/config.py
@@ -1,4 +1,3 @@
-from ursa.security import enforce_group_base_url_policy
 import json
 import logging
 import re
@@ -25,6 +24,7 @@ from pydantic import (
     field_validator,
 )
 
+from ursa.security import enforce_group_base_url_policy
 from ursa.util.http import (
     build_httpx_async_client,
     build_httpx_client,

--- a/src/ursa/cli/config.py
+++ b/src/ursa/cli/config.py
@@ -275,6 +275,16 @@ class UrsaConfig(BaseModel):
 
         return normalize_rag_tool_names(value)
 
+    @field_validator("agent_config", mode="before")
+    @classmethod
+    def _normalize_agent_config(cls, value):
+        if value is None:
+            logger.warning(
+                "Setting agent_config to null is deprecated; treating it as an empty mapping"
+            )
+            return {}
+        return value
+
     @field_validator("llm_model", "emb_model", mode="after")
     @classmethod
     def _check_inference_provider(
@@ -288,7 +298,12 @@ class UrsaConfig(BaseModel):
         """
         if mc is None or mc.inference_provider is None:
             return mc
-        if mc.inference_provider not in info.data["inference_providers"]:
+        providers = info.data.get("inference_providers")
+        if providers is None:
+            # Let the provider catalog's validation error remain the primary
+            # error when that earlier field could not be resolved.
+            return mc
+        if mc.inference_provider not in providers:
             raise ValueError(
                 f"Unknown inference_provider '{mc.inference_provider}'"
             )
@@ -304,10 +319,17 @@ class UrsaConfig(BaseModel):
 
     @field_serializer("mcp_servers")
     def serialize_mcp_servers(
-        self, mcp_servers: dict[str, ServerParameters], _info
+        self, mcp_servers: dict[str, ServerParameters], info
     ):
+        include_defaults = bool(
+            info.context and info.context.get("include_defaults")
+        )
         return {
-            server: _serialize_server_config(config)
+            server: _serialize_server_config(
+                config,
+                exclude_defaults=not include_defaults,
+                exclude_none=not include_defaults,
+            )
             for server, config in mcp_servers.items()
         }
 
@@ -318,6 +340,12 @@ def load_config_file(path: Path) -> dict[str, Any]:
     with open(path, "r") as fid:
         data = loader(fid)
 
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Configuration file '{path}' must contain a mapping at its root"
+        )
     return deep_interp_env(data)
 
 
@@ -337,7 +365,10 @@ def config_path_from_namespace(cfg: Namespace) -> Path | None:
 def xdg_config_search_paths() -> list[Path]:
     """Return candidate XDG config paths in increasing precedence order."""
     candidates: list[Path] = []
-    for config_dir in getenv("XDG_CONFIG_DIRS", "/etc/xdg").split(":"):
+    # XDG_CONFIG_DIRS lists its most-preferred directory first, whereas config
+    # merging consumes sources from lowest to highest precedence.
+    config_dirs = getenv("XDG_CONFIG_DIRS", "/etc/xdg").split(":")
+    for config_dir in reversed(config_dirs):
         if config_dir:
             candidates.append(
                 Path(config_dir).expanduser() / "ursa" / "config.yaml"
@@ -356,35 +387,27 @@ def config_search_paths(cfg: Namespace, level: str = "final") -> list[Path]:
     """Return isolated or cumulative config paths for a precedence level."""
     cumulative = level.endswith("+")
     level = level.removesuffix("+")
+    if level not in {"user", "file", "final"}:
+        raise ValueError(f"Unknown config level '{level}'")
     explicit_path = config_path_from_namespace(cfg)
-    project_path = Path.cwd() / ".ursa" / "config.yaml"
 
     seen: set[Path] = set()
     user_paths: list[Path] = []
     for candidate in xdg_config_search_paths():
         candidate = candidate.expanduser()
-        if candidate in {explicit_path, project_path} or candidate in seen:
+        if candidate == explicit_path or candidate in seen:
             continue
         seen.add(candidate)
         if candidate.is_file():
             user_paths.append(candidate)
 
-    project_paths = (
-        [project_path]
-        if project_path != explicit_path and project_path.is_file()
-        else []
-    )
     file_paths = [explicit_path] if explicit_path is not None else []
 
     if level == "user":
         return user_paths
-    if level == "project" and not cumulative:
-        return project_paths
-    if level == "project":
-        return [*user_paths, *project_paths]
     if level == "file" and not cumulative:
         return file_paths
-    return [*user_paths, *project_paths, *file_paths]
+    return [*user_paths, *file_paths]
 
 
 def merge_ursa_config(
@@ -479,8 +502,18 @@ def deep_interp_env(x: dict[str, Any] | str | Any):
 
 
 def resolve_ursa_config(config: UrsaConfig) -> UrsaConfig:
-    """Resolve derived config state after validation and merge steps."""
-    resolved = config.model_copy(deep=True)
+    """Resolve and group-policy-check config after validation and merging."""
+    # Copy public fields independently while retaining the same private
+    # TemporaryDirectory owner. Deep-copying the owner duplicates its cleanup
+    # finalizer and can remove the workspace while a resolved config still uses
+    # it. Copying the nested model objects also preserves their fields-set state,
+    # which provider resolution uses to distinguish defaults from overrides.
+    resolved = config.model_copy(
+        update={
+            name: deepcopy(getattr(config, name))
+            for name in type(config).model_fields
+        }
+    )
 
     if resolved.llm_model is not None:
         resolved.llm_model = resolved.llm_model.resolve_inference_provider(
@@ -497,10 +530,12 @@ def resolve_ursa_config(config: UrsaConfig) -> UrsaConfig:
             resolved.emb_model.base_url, resolved.group
         )
 
-    if str(resolved.workspace) == "tmp" and not resolved.workspace.exists():
-        temp_workspace = TemporaryDirectory(prefix="ursa")
-        resolved.workspace = Path(temp_workspace.name)
-        resolved._temp_workspace = temp_workspace
+    if str(resolved.workspace) == "tmp":
+        if resolved._temp_workspace is not None:
+            resolved.workspace = Path(resolved._temp_workspace.name)
+        elif not resolved.workspace.exists():
+            resolved._temp_workspace = TemporaryDirectory(prefix="ursa")
+            resolved.workspace = Path(resolved._temp_workspace.name)
 
     if resolved.use_web:
         for agent_name in ["chat", "execute", "deep_review", "prompt"]:

--- a/src/ursa/cli/config.py
+++ b/src/ursa/cli/config.py
@@ -100,6 +100,7 @@ class ModelConfig(BaseModel):
     """Configuration manager for LangChain's `init_*` factories."""
 
     model_config = ConfigDict(extra="allow")
+    _inference_provider_resolved: bool = PrivateAttr(default=False)
 
     model: str
     """Model provider and model name.
@@ -153,11 +154,12 @@ class ModelConfig(BaseModel):
         )
         model_values = self.model_dump(mode="python", exclude_unset=True)
 
-        return type(self).model_validate({
+        resolved = type(self).model_validate({
             **provider_values,
             **model_values,
-            "inference_provider": None,
         })
+        resolved._inference_provider_resolved = True
+        return resolved
 
     @staticmethod
     def _merge_provider_kwargs(
@@ -175,12 +177,16 @@ class ModelConfig(BaseModel):
         """Return a dict suitable for init_chat_model/init_embedding_model
         Removes parameters set to `None`
         """
-        if self.inference_provider is not None:
+        if (
+            self.inference_provider is not None
+            and not self._inference_provider_resolved
+        ):
             raise ValueError(
                 f"Model config references unresolved inference provider "
                 f"'{self.inference_provider}'"
             )
         kwargs = {k: v for k, v in self.model_dump().items() if v is not None}
+        kwargs.pop("inference_provider", None)
         ssl_verify = kwargs.pop("ssl_verify", True)
         model_provider = self._model_provider()
         if model_provider in {"openai", "azure_openai"}:
@@ -370,6 +376,10 @@ class UrsaConfig(BaseModel):
     @classmethod
     def from_file(cls, path: Path):
         return cls.model_validate(load_config_file(path))
+
+    def resolve(self) -> Self:
+        """Return this config after applying canonical resolution."""
+        return resolve_ursa_config(self)
 
     @field_serializer("workspace")
     def serialize_workspace(self, workspace: Path, _info):

--- a/src/ursa/cli/config.py
+++ b/src/ursa/cli/config.py
@@ -103,9 +103,13 @@ class ModelConfig(BaseModel):
     _inference_provider_resolved: bool = PrivateAttr(default=False)
 
     model: str
-    """Model provider and model name.
-    Use the format <provider>:<model-name>
-    """
+    """Model name."""
+
+    model_provider: Annotated[
+        str | None, AfterValidator(_strip_blank_optional_strings)
+    ] = None
+    """LangChain model provider."""
+
     base_url: Annotated[
         str | None, AfterValidator(_strip_blank_optional_strings)
     ] = None
@@ -137,11 +141,23 @@ class ModelConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def _accept_legacy_api_key_env(cls, data):
-        return _migrate_api_key_env(data)
+    def _normalize_input(cls, data):
+        data = _migrate_api_key_env(data)
+        if not isinstance(data, dict):
+            return data
 
-    def _model_provider(self) -> str:
-        return self.model.split(":", 1)[0]
+        data = dict(data)
+        model = data.get("model")
+        if isinstance(model, str) and ":" in model:
+            provider, model_name = model.split(":", 1)
+            explicit_provider = data.get("model_provider")
+            if explicit_provider is not None and explicit_provider != provider:
+                raise ValueError(
+                    f"model provider prefix ({provider}) conflicts with model_provider ({explicit_provider})"
+                )
+            data["model"] = model_name
+            data["model_provider"] = provider
+        return data
 
     @property
     def api_key_env(self) -> str | None:
@@ -202,7 +218,7 @@ class ModelConfig(BaseModel):
         kwargs = {k: v for k, v in self.model_dump().items() if v is not None}
         kwargs.pop("inference_provider", None)
         ssl_verify = kwargs.pop("ssl_verify", True)
-        model_provider = self._model_provider()
+        model_provider = self.model_provider
         if model_provider in {"openai", "azure_openai"}:
             kwargs["http_client"] = build_httpx_client(verify=ssl_verify)
             kwargs["http_async_client"] = build_httpx_async_client(
@@ -259,7 +275,8 @@ class ModelConfig(BaseModel):
 class ChatModelConfig(ModelConfig):
     """Configuration for instantiating a chat model"""
 
-    model: str = "openai:gpt-5.4"
+    model: str = "gpt-5.4"
+    model_provider: str | None = "openai"
 
     max_completion_tokens: int | None = None
     """Maximum tokens for LLM to output"""
@@ -269,7 +286,7 @@ class ChatModelConfig(ModelConfig):
         kwargs = super().kwargs
         if self.max_completion_tokens is not None:
             kwargs["max_completion_tokens"] = self.max_completion_tokens
-        match self._model_provider():
+        match self.model_provider:
             case "openai" | "azure_openai":
                 kwargs.setdefault("use_responses_api", True)
         return kwargs

--- a/src/ursa/cli/config.py
+++ b/src/ursa/cli/config.py
@@ -94,6 +94,19 @@ class InferenceProviderConfig(BaseModel):
     def _accept_legacy_api_key_env(cls, data):
         return _migrate_api_key_env(data)
 
+    def resolve(self, name: str) -> Self:
+        """Resolve settings whose defaults depend on the provider name."""
+        if (
+            isinstance(self.api_key, SecretReference)
+            and self.api_key.keyring is True
+        ):
+            return self.model_copy(
+                update={
+                    "api_key": self.api_key.model_copy(update={"keyring": name})
+                }
+            )
+        return self.model_copy()
+
 
 class ModelConfig(BaseModel):
     """Configuration manager for LangChain's `init_*` factories."""
@@ -197,6 +210,7 @@ class ModelConfig(BaseModel):
         if provider_config is None:
             raise ValueError(f"Unknown inference_provider '{provider_name}'")
         assert isinstance(provider_config, InferenceProviderConfig)
+        provider_config = provider_config.resolve(provider_name)
 
         provider_values = {
             name: deepcopy(getattr(provider_config, name))
@@ -214,16 +228,11 @@ class ModelConfig(BaseModel):
             **provider_values,
             **model_values,
         }
-        api_key = values.get("api_key")
-        if isinstance(api_key, SecretReference) and api_key.keyring is True:
-            values["api_key"] = api_key.model_copy(
-                update={"keyring": provider_name}
-            )
-
         # This is a trusted transition from configured input to a concrete
         # runtime model. A resolved model intentionally retains the provider
         # name while also containing the provider-derived base URL.
         resolved = self.model_copy(update=values)
+        resolved.__pydantic_fields_set__ = self.model_fields_set.copy()
         resolved._inference_provider_resolved = True
         return resolved
 
@@ -322,6 +331,13 @@ class ChatModelConfig(ModelConfig):
 
 class EmbModelConfig(ModelConfig):
     """Configuration for instantiating an embeddings model"""
+
+    @property
+    def kwargs(self) -> dict:
+        """Return keyword arguments accepted by ``init_embeddings``."""
+        kwargs = super().kwargs
+        kwargs["provider"] = kwargs.pop("model_provider", None)
+        return kwargs
 
     def init_embedding(self) -> Embeddings:
         emb = init_embeddings(**self.kwargs)
@@ -700,6 +716,11 @@ def resolve_ursa_config(config: UrsaConfig) -> UrsaConfig:
         }
     )
     resolved._temp_workspace = config._temp_workspace
+
+    resolved.inference_providers = {
+        name: provider.resolve(name)
+        for name, provider in resolved.inference_providers.items()
+    }
 
     for field_name in ("llm_model", "emb_model"):
         model = getattr(resolved, field_name)

--- a/src/ursa/cli/config.py
+++ b/src/ursa/cli/config.py
@@ -93,8 +93,12 @@ class ModelConfig(BaseModel):
     ] = None
     """Optional named inference provider to inherit shared settings from."""
 
-    ssl_verify: bool = True
-    """Flag for verifying SSL certs. during API access"""
+    ssl_verify: bool | None = None
+    """Flag for verifying SSL certs. during API access.
+
+    ``None`` inherits the inference-provider value, or enables verification
+    when no provider value is configured.
+    """
 
     def _model_provider(self) -> str:
         return self.model.split(":", 1)[0]
@@ -104,6 +108,8 @@ class ModelConfig(BaseModel):
     ) -> Self:
         """Return a copy with provider defaults merged under model-specific overrides."""
         if self.inference_provider is None:
+            if self.ssl_verify is None:
+                return self.model_copy(update={"ssl_verify": True})
             return self
 
         provider_name = self.inference_provider
@@ -112,23 +118,13 @@ class ModelConfig(BaseModel):
             raise ValueError(f"Unknown inference_provider '{provider_name}'")
         assert isinstance(provider_config, InferenceProviderConfig)
 
-        provider_values = provider_config.model_dump(
-            mode="python", exclude_unset=True
-        )
-        self_values = self.model_dump(mode="python", exclude_unset=True)
-        if provider_config.model_extra:
-            provider_values.update(provider_config.model_extra)
-        if self.model_extra:
-            self_values.update(self.model_extra)
-
-        for field_name in ["base_url", "api_key_env", "ssl_verify"]:
-            if getattr(self, field_name) is None and field_name in provider_values:
-                self_values.pop(field_name, None)
-
-        return type(self).model_validate({
-            **provider_values,
-            **self_values,
-        })
+        values = {
+            **provider_config.model_dump(mode="python", exclude_unset=True),
+            **self.model_dump(mode="python", exclude_none=True),
+            "inference_provider": None,
+        }
+        values.setdefault("ssl_verify", True)
+        return type(self).model_validate(values)
 
     @staticmethod
     def _merge_provider_kwargs(
@@ -212,11 +208,7 @@ class ChatModelConfig(ModelConfig):
         self,
         inference_providers: dict[str, InferenceProviderConfig] | None = None,
     ) -> BaseChatModel:
-        resolved = (
-            self.resolve_inference_provider(inference_providers)
-            if inference_providers is not None
-            else self
-        )
+        resolved = self.resolve_inference_provider(inference_providers or {})
         llm = init_chat_model(**resolved.kwargs)
         resolved.check_instantiated_model(llm)
         return llm
@@ -229,11 +221,7 @@ class EmbModelConfig(ModelConfig):
         self,
         inference_providers: dict[str, InferenceProviderConfig] | None = None,
     ) -> Embeddings:
-        resolved = (
-            self.resolve_inference_provider(inference_providers)
-            if inference_providers is not None
-            else self
-        )
+        resolved = self.resolve_inference_provider(inference_providers or {})
         emb = init_embeddings(**resolved.kwargs)
         resolved.check_instantiated_model(emb)
         return emb

--- a/src/ursa/cli/config.py
+++ b/src/ursa/cli/config.py
@@ -1,10 +1,9 @@
 import json
 import logging
 import re
-import sys
 from copy import deepcopy
 from dataclasses import dataclass
-from os import environ, getenv
+from os import environ
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Annotated, Any, Literal, Self
@@ -19,18 +18,21 @@ from pydantic import (
     ConfigDict,
     Field,
     PrivateAttr,
-    ValidationInfo,
+    SecretStr,
     field_serializer,
     field_validator,
+    model_validator,
 )
 
 from ursa.security import enforce_group_base_url_policy
+from ursa.util.crossplatform import system_config_path, user_config_paths
 from ursa.util.http import (
     build_httpx_async_client,
     build_httpx_client,
     httpx_verify_value,
 )
 from ursa.util.mcp import ServerParameters, _serialize_server_config
+from ursa.util.secrets import SecretReference
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +53,28 @@ def _strip_blank_optional_strings(value: Any) -> str | Any | None:
     return value or None
 
 
+APIKeyConfig = SecretReference
+APIKey = SecretReference | SecretStr
+
+
+def _migrate_api_key_env(data: Any) -> Any:
+    """Translate the removed ``api_key_env`` field for legacy configs."""
+    if not isinstance(data, dict) or "api_key_env" not in data:
+        return data
+    from warnings import warn
+
+    migrated = dict(data)
+    env_name = _strip_blank_optional_strings(migrated.pop("api_key_env"))
+    if env_name is not None:
+        warn(
+            "api_key_env is deprecated; use api_key: {env: VAR_NAME} instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        migrated.setdefault("api_key", {"env": env_name})
+    return migrated
+
+
 class InferenceProviderConfig(BaseModel):
     """Reusable provider-level inference settings for model configs."""
 
@@ -61,12 +85,14 @@ class InferenceProviderConfig(BaseModel):
     ] = None
     """Base URL for model API access"""
 
-    api_key_env: Annotated[
-        str | None, AfterValidator(_strip_blank_optional_strings)
-    ] = None
-    """Environmental variable containing the API key for this session"""
+    api_key: APIKey | None = None
 
     ssl_verify: bool = True
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_legacy_api_key_env(cls, data):
+        return _migrate_api_key_env(data)
 
 
 class ModelConfig(BaseModel):
@@ -83,10 +109,7 @@ class ModelConfig(BaseModel):
     ] = None
     """Base URL for model API access"""
 
-    api_key_env: Annotated[
-        str | None, AfterValidator(_strip_blank_optional_strings)
-    ] = None
-    """Environmental variable containing the API key for this session"""
+    api_key: APIKey | None = None
 
     inference_provider: Annotated[
         str | None, AfterValidator(_strip_blank_optional_strings)
@@ -96,8 +119,20 @@ class ModelConfig(BaseModel):
     ssl_verify: bool = True
     """Flag for verifying SSL certs. during API access."""
 
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_legacy_api_key_env(cls, data):
+        return _migrate_api_key_env(data)
+
     def _model_provider(self) -> str:
         return self.model.split(":", 1)[0]
+
+    @property
+    def api_key_env(self) -> str | None:
+        """Compatibility view of an environment-backed API key reference."""
+        if isinstance(self.api_key, SecretReference):
+            return self.api_key.env
+        return None
 
     def resolve_inference_provider(
         self, providers: dict[str, InferenceProviderConfig]
@@ -158,15 +193,26 @@ class ModelConfig(BaseModel):
                 "client_kwargs",
                 {"verify": httpx_verify_value(verify=ssl_verify)},
             )
-        if api_key_env := kwargs.pop("api_key_env", None):
-            try:
-                kwargs["api_key"] = environ[api_key_env]
-            except KeyError:
-                logger.error(
-                    f"Env variable '{api_key_env}' for {self.model}'s API key was not set"
-                )
-                sys.exit(1)
+        if isinstance(api_key := kwargs.get("api_key"), SecretStr):
+            kwargs["api_key"] = api_key.get_secret_value()
+        elif isinstance(api_key, dict):
+            resolved = self.resolve_api_key()
+            if isinstance(resolved.api_key, SecretStr):
+                kwargs["api_key"] = resolved.api_key.get_secret_value()
+            else:
+                kwargs.pop("api_key", None)
         return kwargs
+
+    def resolve_api_key(self, provider_name: str | None = None) -> Self:
+        """Resolve environment/keyring references to an in-memory SecretStr."""
+        value = self.api_key
+        if value is None or isinstance(value, SecretStr):
+            return self
+
+        secret = value.resolve(provider_name)
+        if secret is None:
+            return self
+        return self.model_copy(update={"api_key": secret})
 
     @staticmethod
     def _get_model_base_url(model) -> str | None:
@@ -249,11 +295,17 @@ class UrsaConfig(BaseModel):
     """Enable web-search tools for ChatAgent and ExecutionAgent."""
 
     inference_providers: dict[str, InferenceProviderConfig] = Field(
-        default_factory=dict
+        default_factory=lambda: {
+            "openai": InferenceProviderConfig(
+                api_key=APIKeyConfig(env="OPENAI_API_KEY")
+            )
+        }
     )
     """Named reusable inference provider configurations."""
 
-    llm_model: ChatModelConfig = Field(default_factory=ChatModelConfig)
+    llm_model: ChatModelConfig = Field(
+        default_factory=lambda: ChatModelConfig(inference_provider="openai")
+    )
     """Default LLM"""
 
     emb_model: EmbModelConfig | None = None
@@ -267,6 +319,14 @@ class UrsaConfig(BaseModel):
 
     mcp_servers: dict[str, ServerParameters] = Field(default_factory=dict)
     """MCP Servers to connect to Ursa."""
+
+    @field_validator("inference_providers", mode="before")
+    @classmethod
+    def _include_default_inference_provider(cls, value):
+        """Keep the provider used by the default LLM in every catalog."""
+        providers = dict(value or {})
+        providers.setdefault("openai", {"api_key": {"env": "OPENAI_API_KEY"}})
+        return providers
 
     @field_validator("rag_tools", mode="before")
     @classmethod
@@ -285,29 +345,19 @@ class UrsaConfig(BaseModel):
             return {}
         return value
 
-    @field_validator("llm_model", "emb_model", mode="after")
-    @classmethod
-    def _check_inference_provider(
-        cls, mc: ModelConfig | None, info: ValidationInfo
-    ) -> ModelConfig | None:
-        """Validate that any referenced inference provider exists.
-
-        This field validator relies on ``inference_providers`` being declared
-        earlier on ``UrsaConfig``, making it available via ``info.data`` when
-        validating ``llm_model`` and ``emb_model``.
-        """
-        if mc is None or mc.inference_provider is None:
-            return mc
-        providers = info.data.get("inference_providers")
-        if providers is None:
-            # Let the provider catalog's validation error remain the primary
-            # error when that earlier field could not be resolved.
-            return mc
-        if mc.inference_provider not in providers:
-            raise ValueError(
-                f"Unknown inference_provider '{mc.inference_provider}'"
-            )
-        return mc
+    @model_validator(mode="after")
+    def _check_inference_providers(self):
+        """Ensure every model references a defined, validated provider."""
+        for field_name in ("llm_model", "emb_model"):
+            model = getattr(self, field_name)
+            if model is None or model.inference_provider is None:
+                continue
+            if model.inference_provider not in self.inference_providers:
+                raise ValueError(
+                    f"{field_name} references unknown inference_provider "
+                    f"'{model.inference_provider}'"
+                )
+        return self
 
     @classmethod
     def from_file(cls, path: Path):
@@ -351,7 +401,11 @@ def load_config_file(path: Path) -> dict[str, Any]:
 
 def config_path_from_namespace(cfg: Namespace) -> Path | None:
     """Return a root or subcommand-local explicit config path."""
-    config_path = getattr(cfg, "config", None)
+    config_path = (
+        cfg.get("config")
+        if isinstance(cfg, dict)
+        else getattr(cfg, "config", None)
+    )
     subcommand = cfg.get("subcommand", None)
     if subcommand is not None:
         cmd_cfg = cfg.get(subcommand, None)
@@ -362,65 +416,65 @@ def config_path_from_namespace(cfg: Namespace) -> Path | None:
     return config_path
 
 
-def xdg_config_search_paths() -> list[Path]:
-    """Return candidate XDG config paths in increasing precedence order."""
-    candidates: list[Path] = []
-    # XDG_CONFIG_DIRS lists its most-preferred directory first, whereas config
-    # merging consumes sources from lowest to highest precedence.
-    path_list_separator = ";" if Path.cwd().drive else ":"
-    config_dirs = getenv("XDG_CONFIG_DIRS", "/etc/xdg").split(
-        path_list_separator
-    )
-    for config_dir in reversed(config_dirs):
-        if config_dir:
-            candidates.append(
-                Path(config_dir).expanduser() / "ursa" / "config.yaml"
-            )
+def system_config_paths() -> list[Path]:
+    """Return system config paths from lowest to highest precedence."""
+    return [system_config_path()]
 
-    config_home = getenv("XDG_CONFIG_HOME")
-    candidates.append(
-        Path(config_home).expanduser() / "ursa" / "config.yaml"
-        if config_home
-        else Path.home() / ".config" / "ursa" / "config.yaml"
-    )
-    return candidates
+
+def xdg_config_search_paths() -> list[Path]:
+    """Return all implicit config locations in merge order."""
+    return [*system_config_paths(), *user_config_paths()]
 
 
 def config_search_paths(cfg: Namespace, level: str = "final") -> list[Path]:
     """Return isolated or cumulative config paths for a precedence level."""
     cumulative = level.endswith("+")
     level = level.removesuffix("+")
-    if level not in {"user", "file", "final"}:
+    if level not in {"system", "user", "file", "final"}:
         raise ValueError(f"Unknown config level '{level}'")
     explicit_path = config_path_from_namespace(cfg)
 
-    seen: set[Path] = set()
-    user_paths: list[Path] = []
-    for candidate in xdg_config_search_paths():
-        candidate = candidate.expanduser()
-        if candidate == explicit_path or candidate in seen:
-            continue
-        seen.add(candidate)
-        if candidate.is_file():
-            user_paths.append(candidate)
+    def existing(paths: list[Path]) -> list[Path]:
+        return [
+            path.expanduser()
+            for path in paths
+            if path.expanduser() != explicit_path
+            and path.expanduser().is_file()
+        ]
+
+    system_paths = existing(system_config_paths())
+    user_paths = existing(user_config_paths())
 
     file_paths = [explicit_path] if explicit_path is not None else []
 
+    if level == "system":
+        return system_paths
     if level == "user":
         return user_paths
     if level == "file" and not cumulative:
         return file_paths
-    return [*user_paths, *file_paths]
+    return [*system_paths, *user_paths, *file_paths]
 
 
 def merge_ursa_config(
     cfg: Namespace,
     level: str = "final",
     overrides: Namespace | dict[str, Any] | None = None,
+    cli_overrides: Namespace | dict[str, Any] | None = None,
 ) -> UrsaConfig:
     """Merge sparse configuration sources, then validate the result once."""
     merged: dict[str, Any] = {}
-    for config_path in config_search_paths(cfg, level):
+    paths = config_search_paths(cfg, level)
+    explicit_path = (
+        config_path_from_namespace(cli_overrides)
+        if cli_overrides is not None
+        else None
+    )
+    if level.removesuffix("+") == "final" and explicit_path is not None:
+        lower_paths = [path for path in paths if path != explicit_path]
+    else:
+        lower_paths = paths
+    for config_path in lower_paths:
         merged = deep_merge_dicts(merged, load_config_file(config_path))
 
     if level.removesuffix("+") == "final":
@@ -439,6 +493,22 @@ def merge_ursa_config(
                 if key in UrsaConfig.model_fields
             },
         )
+        if explicit_path is not None and explicit_path in paths:
+            merged = deep_merge_dicts(merged, load_config_file(explicit_path))
+        if cli_overrides is not None:
+            cli_values = (
+                cli_overrides.as_dict()
+                if isinstance(cli_overrides, Namespace)
+                else cli_overrides
+            )
+            merged = deep_merge_dicts(
+                merged,
+                {
+                    key: value
+                    for key, value in cli_values.items()
+                    if key in UrsaConfig.model_fields
+                },
+            )
 
     return UrsaConfig.model_validate(merged)
 
@@ -519,16 +589,20 @@ def resolve_ursa_config(config: UrsaConfig) -> UrsaConfig:
     )
 
     if resolved.llm_model is not None:
+        provider_name = resolved.llm_model.inference_provider
         resolved.llm_model = resolved.llm_model.resolve_inference_provider(
             resolved.inference_providers
         )
+        resolved.llm_model = resolved.llm_model.resolve_api_key(provider_name)
         enforce_group_base_url_policy(
             resolved.llm_model.base_url, resolved.group
         )
     if resolved.emb_model is not None:
+        provider_name = resolved.emb_model.inference_provider
         resolved.emb_model = resolved.emb_model.resolve_inference_provider(
             resolved.inference_providers
         )
+        resolved.emb_model = resolved.emb_model.resolve_api_key(provider_name)
         enforce_group_base_url_policy(
             resolved.emb_model.base_url, resolved.group
         )

--- a/src/ursa/cli/config.py
+++ b/src/ursa/cli/config.py
@@ -297,6 +297,7 @@ class UrsaConfig(BaseModel):
     inference_providers: dict[str, InferenceProviderConfig] = Field(
         default_factory=lambda: {
             "openai": InferenceProviderConfig(
+                base_url="https://api.openai.com/v1",
                 api_key=APIKeyConfig(env="OPENAI_API_KEY")
             )
         }
@@ -325,7 +326,13 @@ class UrsaConfig(BaseModel):
     def _include_default_inference_provider(cls, value):
         """Keep the provider used by the default LLM in every catalog."""
         providers = dict(value or {})
-        providers.setdefault("openai", {"api_key": {"env": "OPENAI_API_KEY"}})
+        providers.setdefault(
+            "openai",
+            {
+                "base_url": "https://api.openai.com/v1",
+                "api_key": {"env": "OPENAI_API_KEY"},
+            },
+        )
         return providers
 
     @field_validator("rag_tools", mode="before")

--- a/src/ursa/cli/config.py
+++ b/src/ursa/cli/config.py
@@ -4,7 +4,7 @@ import re
 import sys
 from copy import deepcopy
 from dataclasses import dataclass
-from os import environ
+from os import environ, getenv
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Annotated, Any, Literal, Self
@@ -93,12 +93,8 @@ class ModelConfig(BaseModel):
     ] = None
     """Optional named inference provider to inherit shared settings from."""
 
-    ssl_verify: bool | None = None
-    """Flag for verifying SSL certs. during API access.
-
-    ``None`` inherits the inference-provider value, or enables verification
-    when no provider value is configured.
-    """
+    ssl_verify: bool = True
+    """Flag for verifying SSL certs. during API access."""
 
     def _model_provider(self) -> str:
         return self.model.split(":", 1)[0]
@@ -108,8 +104,6 @@ class ModelConfig(BaseModel):
     ) -> Self:
         """Return a copy with provider defaults merged under model-specific overrides."""
         if self.inference_provider is None:
-            if self.ssl_verify is None:
-                return self.model_copy(update={"ssl_verify": True})
             return self
 
         provider_name = self.inference_provider
@@ -118,13 +112,16 @@ class ModelConfig(BaseModel):
             raise ValueError(f"Unknown inference_provider '{provider_name}'")
         assert isinstance(provider_config, InferenceProviderConfig)
 
-        values = {
-            **provider_config.model_dump(mode="python", exclude_unset=True),
-            **self.model_dump(mode="python", exclude_none=True),
+        provider_values = provider_config.model_dump(
+            mode="python", exclude_unset=True
+        )
+        model_values = self.model_dump(mode="python", exclude_unset=True)
+
+        return type(self).model_validate({
+            **provider_values,
+            **model_values,
             "inference_provider": None,
-        }
-        values.setdefault("ssl_verify", True)
-        return type(self).model_validate(values)
+        })
 
     @staticmethod
     def _merge_provider_kwargs(
@@ -142,9 +139,13 @@ class ModelConfig(BaseModel):
         """Return a dict suitable for init_chat_model/init_embedding_model
         Removes parameters set to `None`
         """
+        if self.inference_provider is not None:
+            raise ValueError(
+                f"Model config references unresolved inference provider "
+                f"'{self.inference_provider}'"
+            )
         kwargs = {k: v for k, v in self.model_dump().items() if v is not None}
         ssl_verify = kwargs.pop("ssl_verify", True)
-        kwargs.pop("inference_provider", None)
         model_provider = self._model_provider()
         if model_provider in {"openai", "azure_openai"}:
             kwargs["http_client"] = build_httpx_client(verify=ssl_verify)
@@ -191,6 +192,8 @@ class ModelConfig(BaseModel):
 class ChatModelConfig(ModelConfig):
     """Configuration for instantiating a chat model"""
 
+    model: str = "openai:gpt-5.4"
+
     max_completion_tokens: int | None = None
     """Maximum tokens for LLM to output"""
 
@@ -204,26 +207,18 @@ class ChatModelConfig(ModelConfig):
                 kwargs.setdefault("use_responses_api", True)
         return kwargs
 
-    def init_chat_model(
-        self,
-        inference_providers: dict[str, InferenceProviderConfig] | None = None,
-    ) -> BaseChatModel:
-        resolved = self.resolve_inference_provider(inference_providers or {})
-        llm = init_chat_model(**resolved.kwargs)
-        resolved.check_instantiated_model(llm)
+    def init_chat_model(self) -> BaseChatModel:
+        llm = init_chat_model(**self.kwargs)
+        self.check_instantiated_model(llm)
         return llm
 
 
 class EmbModelConfig(ModelConfig):
     """Configuration for instantiating an embeddings model"""
 
-    def init_embedding(
-        self,
-        inference_providers: dict[str, InferenceProviderConfig] | None = None,
-    ) -> Embeddings:
-        resolved = self.resolve_inference_provider(inference_providers or {})
-        emb = init_embeddings(**resolved.kwargs)
-        resolved.check_instantiated_model(emb)
+    def init_embedding(self) -> Embeddings:
+        emb = init_embeddings(**self.kwargs)
+        self.check_instantiated_model(emb)
         return emb
 
 
@@ -258,11 +253,7 @@ class UrsaConfig(BaseModel):
     )
     """Named reusable inference provider configurations."""
 
-    llm_model: ChatModelConfig = Field(
-        default_factory=lambda: ChatModelConfig(
-            model="openai:gpt-5.4",
-        )
-    )
+    llm_model: ChatModelConfig = Field(default_factory=ChatModelConfig)
     """Default LLM"""
 
     emb_model: EmbModelConfig | None = None
@@ -303,40 +294,9 @@ class UrsaConfig(BaseModel):
             )
         return mc
 
-    def model_post_init(self, __context):
-        """Handle temporary workspace creation post validation."""
-
-    def update(self, other: "UrsaConfig") -> "UrsaConfig":
-        """Merge non-default values from another config into this config."""
-        defaults = type(self)().model_dump(mode="python")
-        updates = dict_diff(defaults, other.model_dump(mode="python"))
-        merged = deep_merge_dicts(self.model_dump(mode="python"), updates)
-        updated = type(self).model_validate(merged)
-
-        for field_name in type(self).model_fields:
-            setattr(self, field_name, getattr(updated, field_name))
-
-        if other._temp_workspace and other.workspace == self.workspace:
-            self._temp_workspace = other._temp_workspace
-        elif (
-            self._temp_workspace
-            and Path(self._temp_workspace.name) != self.workspace
-        ):
-            self._temp_workspace = None
-        return self
-
-    @classmethod
-    def from_namespace(cls, cfg: Namespace):
-        """Instantiate from a jsonargparse namespace."""
-        return cls.model_validate(cfg.as_dict(), extra="ignore")
-
     @classmethod
     def from_file(cls, path: Path):
         return cls.model_validate(load_config_file(path))
-
-    @classmethod
-    def resolve_config(cls, config: "UrsaConfig") -> "UrsaConfig":
-        return resolve_ursa_config(config)
 
     @field_serializer("workspace")
     def serialize_workspace(self, workspace: Path, _info):
@@ -353,12 +313,108 @@ class UrsaConfig(BaseModel):
 
 
 def load_config_file(path: Path) -> dict[str, Any]:
-    """Load and validate raw config-file data before config merging."""
+    """Load raw config-file data for merging before validation."""
     loader = yaml.safe_load if path.suffix in [".yaml", ".yml"] else json.load
     with open(path, "r") as fid:
         data = loader(fid)
 
     return deep_interp_env(data)
+
+
+def config_path_from_namespace(cfg: Namespace) -> Path | None:
+    """Return a root or subcommand-local explicit config path."""
+    config_path = getattr(cfg, "config", None)
+    subcommand = cfg.get("subcommand", None)
+    if subcommand is not None:
+        cmd_cfg = cfg.get(subcommand, None)
+        cmd_config_path = (
+            getattr(cmd_cfg, "config", None) if cmd_cfg is not None else None
+        )
+        config_path = cmd_config_path or config_path
+    return config_path
+
+
+def xdg_config_search_paths() -> list[Path]:
+    """Return candidate XDG config paths in increasing precedence order."""
+    candidates: list[Path] = []
+    for config_dir in getenv("XDG_CONFIG_DIRS", "/etc/xdg").split(":"):
+        if config_dir:
+            candidates.append(
+                Path(config_dir).expanduser() / "ursa" / "config.yaml"
+            )
+
+    config_home = getenv("XDG_CONFIG_HOME")
+    candidates.append(
+        Path(config_home).expanduser() / "ursa" / "config.yaml"
+        if config_home
+        else Path.home() / ".config" / "ursa" / "config.yaml"
+    )
+    return candidates
+
+
+def config_search_paths(cfg: Namespace, level: str = "final") -> list[Path]:
+    """Return isolated or cumulative config paths for a precedence level."""
+    cumulative = level.endswith("+")
+    level = level.removesuffix("+")
+    explicit_path = config_path_from_namespace(cfg)
+    project_path = Path.cwd() / ".ursa" / "config.yaml"
+
+    seen: set[Path] = set()
+    user_paths: list[Path] = []
+    for candidate in xdg_config_search_paths():
+        candidate = candidate.expanduser()
+        if candidate in {explicit_path, project_path} or candidate in seen:
+            continue
+        seen.add(candidate)
+        if candidate.is_file():
+            user_paths.append(candidate)
+
+    project_paths = (
+        [project_path]
+        if project_path != explicit_path and project_path.is_file()
+        else []
+    )
+    file_paths = [explicit_path] if explicit_path is not None else []
+
+    if level == "user":
+        return user_paths
+    if level == "project" and not cumulative:
+        return project_paths
+    if level == "project":
+        return [*user_paths, *project_paths]
+    if level == "file" and not cumulative:
+        return file_paths
+    return [*user_paths, *project_paths, *file_paths]
+
+
+def merge_ursa_config(
+    cfg: Namespace,
+    level: str = "final",
+    overrides: Namespace | dict[str, Any] | None = None,
+) -> UrsaConfig:
+    """Merge sparse configuration sources, then validate the result once."""
+    merged: dict[str, Any] = {}
+    for config_path in config_search_paths(cfg, level):
+        merged = deep_merge_dicts(merged, load_config_file(config_path))
+
+    if level.removesuffix("+") == "final":
+        if overrides is None:
+            raise ValueError("Final config merging requires sparse overrides")
+        override_values = (
+            overrides.as_dict()
+            if isinstance(overrides, Namespace)
+            else overrides
+        )
+        merged = deep_merge_dicts(
+            merged,
+            {
+                key: value
+                for key, value in override_values.items()
+                if key in UrsaConfig.model_fields
+            },
+        )
+
+    return UrsaConfig.model_validate(merged)
 
 
 @dataclass

--- a/src/ursa/cli/config.py
+++ b/src/ursa/cli/config.py
@@ -1,23 +1,26 @@
-import sys
+from ursa.security import enforce_group_base_url_policy
 import json
 import logging
 import re
+import sys
 from copy import deepcopy
 from dataclasses import dataclass
 from os import environ
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Literal
+from typing import Annotated, Any, Literal, Self
 
 import yaml
 from jsonargparse import Namespace
 from langchain.chat_models import BaseChatModel, init_chat_model
 from langchain.embeddings import Embeddings, init_embeddings
 from pydantic import (
+    AfterValidator,
     BaseModel,
     ConfigDict,
     Field,
     PrivateAttr,
+    ValidationInfo,
     field_serializer,
     field_validator,
 )
@@ -36,6 +39,36 @@ LoggingLevel = Literal[
 ]
 
 
+def _strip_blank_optional_strings(value: Any) -> str | Any | None:
+    """Normalize blank strings to ``None`` after stripping whitespace.
+    Non-string values are returned unchanged.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return value
+    value = value.strip()
+    return value or None
+
+
+class InferenceProviderConfig(BaseModel):
+    """Reusable provider-level inference settings for model configs."""
+
+    model_config = ConfigDict(extra="allow")
+
+    base_url: Annotated[
+        str | None, AfterValidator(_strip_blank_optional_strings)
+    ] = None
+    """Base URL for model API access"""
+
+    api_key_env: Annotated[
+        str | None, AfterValidator(_strip_blank_optional_strings)
+    ] = None
+    """Environmental variable containing the API key for this session"""
+
+    ssl_verify: bool = True
+
+
 class ModelConfig(BaseModel):
     """Configuration manager for LangChain's `init_*` factories."""
 
@@ -45,25 +78,44 @@ class ModelConfig(BaseModel):
     """Model provider and model name.
     Use the format <provider>:<model-name>
     """
-    base_url: str | None = None
+    base_url: Annotated[
+        str | None, AfterValidator(_strip_blank_optional_strings)
+    ] = None
     """Base URL for model API access"""
 
-    api_key_env: str | None = None
+    api_key_env: Annotated[
+        str | None, AfterValidator(_strip_blank_optional_strings)
+    ] = None
     """Environmental variable containing the API key for this session"""
 
-    @field_validator("base_url", "api_key_env", mode="before")
-    @classmethod
-    def _strip_blank_optional_strings(cls, value: Any) -> str | None:
-        if value is None:
-            return None
-        value = str(value).strip()
-        return value or None
+    inference_provider: Annotated[
+        str | None, AfterValidator(_strip_blank_optional_strings)
+    ] = None
+    """Optional named inference provider to inherit shared settings from."""
 
     ssl_verify: bool = True
     """Flag for verifying SSL certs. during API access"""
 
-    def _provider(self) -> str:
+    def _model_provider(self) -> str:
         return self.model.split(":", 1)[0]
+
+    def resolve_inference_provider(
+        self, providers: dict[str, InferenceProviderConfig]
+    ) -> Self:
+        """Return a copy with provider defaults merged under model-specific overrides."""
+        if self.inference_provider is None:
+            return self
+
+        provider_name = self.inference_provider
+        provider_config = providers.get(provider_name)
+        if provider_config is None:
+            raise ValueError(f"Unknown inference_provider '{provider_name}'")
+        assert isinstance(provider_config, InferenceProviderConfig)
+
+        return type(self).model_validate({
+            **(provider_config.model_dump(mode="python", exclude_unset=True)),
+            **(self.model_dump(mode="python", exclude_unset=True)),
+        })
 
     @staticmethod
     def _merge_provider_kwargs(
@@ -83,13 +135,14 @@ class ModelConfig(BaseModel):
         """
         kwargs = {k: v for k, v in self.model_dump().items() if v is not None}
         ssl_verify = kwargs.pop("ssl_verify", True)
-        provider = self._provider()
-        if provider in {"openai", "azure_openai"}:
+        kwargs.pop("inference_provider", None)
+        model_provider = self._model_provider()
+        if model_provider in {"openai", "azure_openai"}:
             kwargs["http_client"] = build_httpx_client(verify=ssl_verify)
             kwargs["http_async_client"] = build_httpx_async_client(
                 verify=ssl_verify
             )
-        elif provider == "ollama":
+        elif model_provider == "ollama":
             self._merge_provider_kwargs(
                 kwargs,
                 "client_kwargs",
@@ -105,6 +158,26 @@ class ModelConfig(BaseModel):
                 sys.exit(1)
         return kwargs
 
+    @staticmethod
+    def _get_model_base_url(model) -> str | None:
+        for attr in ["base_url", "api_base", "openai_api_base"]:
+            if base_url := getattr(model, attr, None):
+                return base_url
+        logger.warning(
+            f"Missing base_url for {model} ({model.__class__.__name__})"
+        )
+
+    def check_instantiated_model(self, model):
+        """Validates that `model` matches the configuration of `self`"""
+        if (
+            self.base_url is not None
+            and (model_url := self._get_model_base_url(model)) is not None
+            and self.base_url != model_url
+        ):
+            logger.error(
+                f"Model base url ({model_url}) and config ({self.base_url}) do not match"
+            )
+
 
 class ChatModelConfig(ModelConfig):
     """Configuration for instantiating a chat model"""
@@ -117,20 +190,32 @@ class ChatModelConfig(ModelConfig):
         kwargs = super().kwargs
         if self.max_completion_tokens is not None:
             kwargs["max_completion_tokens"] = self.max_completion_tokens
-        match self._provider():
+        match self._model_provider():
             case "openai" | "azure_openai":
                 kwargs.setdefault("use_responses_api", True)
         return kwargs
 
-    def init_chat_model(self) -> BaseChatModel:
-        return init_chat_model(**self.kwargs)
+    def init_chat_model(
+        self,
+        inference_providers: dict[str, InferenceProviderConfig] | None = None,
+    ) -> BaseChatModel:
+        resolved = self.resolve_inference_provider(inference_providers or {})
+        llm = init_chat_model(**resolved.kwargs)
+        resolved.check_instantiated_model(llm)
+        return llm
 
 
 class EmbModelConfig(ModelConfig):
     """Configuration for instantiating an embeddings model"""
 
-    def init_embedding(self) -> Embeddings:
-        return init_embeddings(**self.kwargs)
+    def init_embedding(
+        self,
+        inference_providers: dict[str, InferenceProviderConfig] | None = None,
+    ) -> Embeddings:
+        resolved = self.resolve_inference_provider(inference_providers or {})
+        emb = init_embeddings(**resolved.kwargs)
+        resolved.check_instantiated_model(emb)
+        return emb
 
 
 class UrsaConfig(BaseModel):
@@ -159,6 +244,11 @@ class UrsaConfig(BaseModel):
     use_web: bool = False
     """Enable web-search tools for ChatAgent and ExecutionAgent."""
 
+    inference_providers: dict[str, InferenceProviderConfig] = Field(
+        default_factory=dict
+    )
+    """Named reusable inference provider configurations."""
+
     llm_model: ChatModelConfig = Field(
         default_factory=lambda: ChatModelConfig(
             model="openai:gpt-5.4",
@@ -172,7 +262,7 @@ class UrsaConfig(BaseModel):
     rag_tools: list[str] = Field(default_factory=list)
     """Persisted RAG agent names to bind as tools."""
 
-    agent_config: dict[str, dict[str, Any]] | None = None
+    agent_config: dict[str, dict[str, Any]] = Field(default_factory=dict)
     """ Configuration options for URSA Agents """
 
     mcp_servers: dict[str, ServerParameters] = Field(default_factory=dict)
@@ -184,6 +274,40 @@ class UrsaConfig(BaseModel):
         from ursa.rag.persistence import normalize_rag_tool_names
 
         return normalize_rag_tool_names(value)
+
+    @field_validator("llm_model", "emb_model", mode="after")
+    @classmethod
+    def _check_inference_provider(
+        cls, mc: ModelConfig | None, info: ValidationInfo
+    ) -> ModelConfig | None:
+        """Validate that any referenced inference provider exists.
+
+        This field validator relies on ``inference_providers`` being declared
+        earlier on ``UrsaConfig``, making it available via ``info.data`` when
+        validating ``llm_model`` and ``emb_model``.
+        """
+        if mc is None or mc.inference_provider is None:
+            return mc
+        if mc.inference_provider not in info.data["inference_providers"]:
+            raise ValueError(
+                f"Unknown inference_provider '{mc.inference_provider}'"
+            )
+        return mc
+
+    @field_validator("llm_model", "emb_model", mode="after")
+    @classmethod
+    def _check_group_policy(
+        cls, value: ModelConfig | None, info: ValidationInfo
+    ) -> ModelConfig | None:
+        """Validate that configured model base URLs comply with the selected group policy.
+
+        This runs for both chat and embedding model configs after field parsing,
+        using the already-validated ``group`` value from ``info.data``.
+        """
+        if value is None:
+            return value
+        enforce_group_base_url_policy(value.base_url, info.data["group"])
+        return value
 
     def model_post_init(self, __context):
         """Handle temporary workspace creation post validation."""

--- a/src/ursa/cli/config.py
+++ b/src/ursa/cli/config.py
@@ -112,9 +112,22 @@ class ModelConfig(BaseModel):
             raise ValueError(f"Unknown inference_provider '{provider_name}'")
         assert isinstance(provider_config, InferenceProviderConfig)
 
+        provider_values = provider_config.model_dump(
+            mode="python", exclude_unset=True
+        )
+        self_values = self.model_dump(mode="python", exclude_unset=True)
+        if provider_config.model_extra:
+            provider_values.update(provider_config.model_extra)
+        if self.model_extra:
+            self_values.update(self.model_extra)
+
+        for field_name in ["base_url", "api_key_env", "ssl_verify"]:
+            if getattr(self, field_name) is None and field_name in provider_values:
+                self_values.pop(field_name, None)
+
         return type(self).model_validate({
-            **(provider_config.model_dump(mode="python", exclude_unset=True)),
-            **(self.model_dump(mode="python", exclude_unset=True)),
+            **provider_values,
+            **self_values,
         })
 
     @staticmethod
@@ -199,7 +212,11 @@ class ChatModelConfig(ModelConfig):
         self,
         inference_providers: dict[str, InferenceProviderConfig] | None = None,
     ) -> BaseChatModel:
-        resolved = self.resolve_inference_provider(inference_providers or {})
+        resolved = (
+            self.resolve_inference_provider(inference_providers)
+            if inference_providers is not None
+            else self
+        )
         llm = init_chat_model(**resolved.kwargs)
         resolved.check_instantiated_model(llm)
         return llm
@@ -212,7 +229,11 @@ class EmbModelConfig(ModelConfig):
         self,
         inference_providers: dict[str, InferenceProviderConfig] | None = None,
     ) -> Embeddings:
-        resolved = self.resolve_inference_provider(inference_providers or {})
+        resolved = (
+            self.resolve_inference_provider(inference_providers)
+            if inference_providers is not None
+            else self
+        )
         emb = init_embeddings(**resolved.kwargs)
         resolved.check_instantiated_model(emb)
         return emb
@@ -418,10 +439,16 @@ def resolve_ursa_config(config: UrsaConfig) -> UrsaConfig:
     resolved = config.model_copy(deep=True)
 
     if resolved.llm_model is not None:
+        resolved.llm_model = resolved.llm_model.resolve_inference_provider(
+            resolved.inference_providers
+        )
         enforce_group_base_url_policy(
             resolved.llm_model.base_url, resolved.group
         )
     if resolved.emb_model is not None:
+        resolved.emb_model = resolved.emb_model.resolve_inference_provider(
+            resolved.inference_providers
+        )
         enforce_group_base_url_policy(
             resolved.emb_model.base_url, resolved.group
         )
@@ -433,7 +460,9 @@ def resolve_ursa_config(config: UrsaConfig) -> UrsaConfig:
 
     if resolved.use_web:
         for agent_name in ["chat", "execute", "deep_review", "prompt"]:
-            resolved.agent_config.setdefault(agent_name, {})["use_web"] = True
+            resolved.agent_config.setdefault(agent_name, {}).setdefault(
+                "use_web", True
+            )
 
     return resolved
 

--- a/src/ursa/cli/config.py
+++ b/src/ursa/cli/config.py
@@ -595,6 +595,7 @@ def resolve_ursa_config(config: UrsaConfig) -> UrsaConfig:
             for name in type(config).model_fields
         }
     )
+    resolved._temp_workspace = config._temp_workspace
 
     if resolved.llm_model is not None:
         provider_name = resolved.llm_model.inference_provider

--- a/src/ursa/cli/config.py
+++ b/src/ursa/cli/config.py
@@ -259,14 +259,12 @@ class ModelConfig(BaseModel):
                 "client_kwargs",
                 {"verify": httpx_verify_value(verify=ssl_verify)},
             )
-        if isinstance(api_key := self.api_key, SecretReference):
+        if (api_key := self.api_key) is not None:
             value = api_key.get_secret_value()
             if value is None:
                 kwargs.pop("api_key", None)
             else:
                 kwargs["api_key"] = value
-        elif isinstance(api_key, SecretStr):
-            kwargs["api_key"] = api_key.get_secret_value()
         return kwargs
 
     @staticmethod
@@ -537,64 +535,83 @@ def config_search_paths(cfg: Namespace, level: str = "final") -> list[Path]:
 
     file_paths = [explicit_path] if explicit_path is not None else []
 
-    if level == "system":
-        return system_paths
-    if level == "user":
-        return user_paths
-    if level == "file" and not cumulative:
-        return file_paths
-    return [*system_paths, *user_paths, *file_paths]
+    paths_by_level = {
+        "system": system_paths,
+        "user": user_paths,
+        "file": file_paths,
+    }
+    if level == "final":
+        return [*system_paths, *user_paths, *file_paths]
+    if not cumulative:
+        return paths_by_level[level]
+
+    ordered_levels = ("system", "user", "file")
+    level_index = ordered_levels.index(level)
+    return [
+        path
+        for name in ordered_levels[: level_index + 1]
+        for path in paths_by_level[name]
+    ]
+
+
+def _namespace_values(value: Namespace | dict[str, Any]) -> dict[str, Any]:
+    return value.as_dict() if isinstance(value, Namespace) else value
+
+
+def _ursa_config_values(
+    value: Namespace | dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        key: item
+        for key, item in _namespace_values(value).items()
+        if key in UrsaConfig.model_fields
+    }
+
+
+def config_layers(
+    cfg: Namespace,
+    level: str = "final",
+    env_overrides: Namespace | dict[str, Any] | None = None,
+    cli_overrides: Namespace | dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Return raw configuration layers in increasing precedence order."""
+    paths = config_search_paths(cfg, level)
+    cli_config_path = (
+        config_path_from_namespace(cli_overrides)
+        if cli_overrides is not None
+        else None
+    )
+    final = level.removesuffix("+") == "final"
+
+    if final and cli_config_path is not None:
+        file_paths = [path for path in paths if path != cli_config_path]
+    else:
+        file_paths = paths
+    layers = [load_config_file(path) for path in file_paths]
+
+    if not final:
+        return layers
+    if env_overrides is None:
+        raise ValueError("Final config layering requires sparse env overrides")
+
+    layers.append(_ursa_config_values(env_overrides))
+    if cli_config_path is not None and cli_config_path in paths:
+        layers.append(load_config_file(cli_config_path))
+    if cli_overrides is not None:
+        layers.append(_ursa_config_values(cli_overrides))
+    return layers
 
 
 def merge_ursa_config(
     cfg: Namespace,
     level: str = "final",
-    overrides: Namespace | dict[str, Any] | None = None,
+    env_overrides: Namespace | dict[str, Any] | None = None,
     cli_overrides: Namespace | dict[str, Any] | None = None,
 ) -> UrsaConfig:
     """Merge sparse configuration sources, then validate the result once."""
-    layers: list[dict[str, Any]] = []
-    paths = config_search_paths(cfg, level)
-    explicit_path = (
-        config_path_from_namespace(cli_overrides)
-        if cli_overrides is not None
-        else None
+    return UrsaConfig().model_merge(
+        *config_layers(cfg, level, env_overrides, cli_overrides)
     )
-    if level.removesuffix("+") == "final" and explicit_path is not None:
-        lower_paths = [path for path in paths if path != explicit_path]
-    else:
-        lower_paths = paths
-    for config_path in lower_paths:
-        layers.append(load_config_file(config_path))
-
-    if level.removesuffix("+") == "final":
-        if overrides is None:
-            raise ValueError("Final config merging requires sparse overrides")
-        override_values = (
-            overrides.as_dict()
-            if isinstance(overrides, Namespace)
-            else overrides
-        )
-        layers.append({
-            key: value
-            for key, value in override_values.items()
-            if key in UrsaConfig.model_fields
-        })
-        if explicit_path is not None and explicit_path in paths:
-            layers.append(load_config_file(explicit_path))
-        if cli_overrides is not None:
-            cli_values = (
-                cli_overrides.as_dict()
-                if isinstance(cli_overrides, Namespace)
-                else cli_overrides
-            )
-            layers.append({
-                key: value
-                for key, value in cli_values.items()
-                if key in UrsaConfig.model_fields
-            })
-
-    return UrsaConfig().model_merge(*layers)
 
 
 @dataclass
@@ -673,20 +690,13 @@ def resolve_ursa_config(config: UrsaConfig) -> UrsaConfig:
     )
     resolved._temp_workspace = config._temp_workspace
 
-    if resolved.llm_model is not None:
-        resolved.llm_model = resolved.llm_model.resolve_inference_provider(
-            resolved.inference_providers
-        )
-        enforce_group_base_url_policy(
-            resolved.llm_model.base_url, resolved.group
-        )
-    if resolved.emb_model is not None:
-        resolved.emb_model = resolved.emb_model.resolve_inference_provider(
-            resolved.inference_providers
-        )
-        enforce_group_base_url_policy(
-            resolved.emb_model.base_url, resolved.group
-        )
+    for field_name in ("llm_model", "emb_model"):
+        model = getattr(resolved, field_name)
+        if model is None:
+            continue
+        model = model.resolve_inference_provider(resolved.inference_providers)
+        enforce_group_base_url_policy(model.base_url, resolved.group)
+        setattr(resolved, field_name, model)
 
     if str(resolved.workspace) == "tmp":
         if resolved._temp_workspace is not None:

--- a/src/ursa/cli/hitl.py
+++ b/src/ursa/cli/hitl.py
@@ -28,7 +28,6 @@ from ursa.agents.base import URSA_VERSION, AgentWithTools
 from ursa.cli.callbacks import HITLLogEventHandler
 from ursa.cli.config import UrsaConfig
 from ursa.security import (
-    enforce_group_base_url_policy,
     enforce_model_group_policy,
 )
 from ursa.util.has_optional_dep_group import has_optional_dep_group

--- a/src/ursa/cli/hitl.py
+++ b/src/ursa/cli/hitl.py
@@ -124,42 +124,24 @@ class HITL:
         self.workspace = self.config.workspace
         self.config.workspace.mkdir(parents=True, exist_ok=True)
 
-        agent_overrides = dict(config.agent_config or {})
-
         self.agent_name = self.config.agent_name
         self.group = self.config.group
 
-        enforce_group_base_url_policy(
-            self.config.llm_model.base_url, self.group
+        self.model: BaseChatModel = self.config.llm_model.init_chat_model(
+            self.config.inference_providers
         )
-        self.model: BaseChatModel = self.config.llm_model.init_chat_model()
         enforce_model_group_policy(self.model, self.group)
-        if self.config.emb_model:
-            enforce_group_base_url_policy(
-                self.config.emb_model.base_url, self.group
-            )
+
         self.embedding = (
-            self.config.emb_model.init_embedding()
-            if self.config.emb_model
+            self.config.emb_model.init_embedding(
+                self.config.inference_providers
+            )
+            if self.config.emb_model is not None
             else None
         )
         enforce_model_group_policy(self.embedding, self.group)
 
         self.mcp_client = start_mcp_client(self.config.mcp_servers)
-        if base_url := getattr(self.config.llm_model, "base_url"):
-            if model_base_url := get_base_url(self.model):
-                if base_url != model_base_url:
-                    logging.error(
-                        f"Model base url ({model_base_url}) and config ({base_url}) do not match"
-                    )
-
-        if self.embedding:
-            if base_url := getattr(self.config.emb_model, "base_url"):
-                if model_base_url := get_base_url(self.model):
-                    if base_url != model_base_url:
-                        logging.error(
-                            f"Model base url ({model_base_url}) and config ({base_url}) do not match"
-                        )
 
         rag_tool_config = {
             "rag_tools": self.config.rag_tools,
@@ -202,7 +184,7 @@ class HITL:
             self.agents["lammps"] = AgentHITL(agent_class=agents.LammpsAgent)
 
         # Apply agent-specific configuration overrides
-        for agent, agent_config in agent_overrides.items():
+        for agent, agent_config in self.config.agent_config.items():
             assert agent in self.agents, (
                 f"Unknown agent {agent}, Know agents: {','.join(self.agents.keys())}"
             )

--- a/src/ursa/cli/hitl.py
+++ b/src/ursa/cli/hitl.py
@@ -117,7 +117,7 @@ def get_base_url(model: BaseChatModel) -> str | None:
 
 class HITL:
     def __init__(self, config: UrsaConfig):
-        self.config = config
+        self.config = UrsaConfig.resolve_config(config)
         self.thread_id = config.thread_id or "ursa"
         # expose workspace and init common attributes
         self.workspace = self.config.workspace
@@ -126,15 +126,11 @@ class HITL:
         self.agent_name = self.config.agent_name
         self.group = self.config.group
 
-        self.model: BaseChatModel = self.config.llm_model.init_chat_model(
-            self.config.inference_providers
-        )
+        self.model: BaseChatModel = self.config.llm_model.init_chat_model()
         enforce_model_group_policy(self.model, self.group)
 
         self.embedding = (
-            self.config.emb_model.init_embedding(
-                self.config.inference_providers
-            )
+            self.config.emb_model.init_embedding()
             if self.config.emb_model is not None
             else None
         )
@@ -148,39 +144,28 @@ class HITL:
         }
 
         self.agents: dict[str, AgentHITL] = {}
-        self.agents["chat"] = AgentHITL(
-            agent_class=agents.ChatAgent,
-            config={"use_web": self.config.use_web, **rag_tool_config},
-        )
-        self.agents["arxiv"] = AgentHITL(agent_class=agents.ArxivAgent)
-        if has_optional_dep_group("dsi"):
-            self.agents["dsi"] = AgentHITL(
-                agent_class=agents.DSIAgent,
-                config=dict(rag_tool_config),
-            )
-        self.agents["execute"] = AgentHITL(
-            agent_class=agents.ExecutionAgent,
-            config={
-                "use_web": self.config.use_web,
-                **rag_tool_config,
-            },
-        )
-        self.agents["deep_review"] = AgentHITL(
-            agent_class=agents.DeepReviewAgent,
-            config={"use_web": self.config.use_web, **rag_tool_config},
-        )
-        self.agents["hypothesize"] = AgentHITL(
-            agent_class=agents.HypothesizerAgent
-        )
-        self.agents["plan"] = AgentHITL(agent_class=agents.PlanningAgent)
-        self.agents["prompt"] = AgentHITL(
-            agent_class=agents.PromptingAgent,
-            config={"use_web": self.config.use_web},
-        )
-        self.agents["web"] = AgentHITL(agent_class=agents.WebSearchAgent)
+        for agent_name, agent_class_name, deps in [
+            ("chat", "ChatAgent", None),
+            ("arxiv", "ArxivAgent", None),
+            ("dsi", "DSIAgent", "dsi"),
+            ("execute", "ExecutionAgent", None),
+            ("deep_review", "DeepReviewAgent", None),
+            ("hypothesize", "HypothesizerAgent", None),
+            ("plan", "PlanningAgent", None),
+            ("prompt", "PromptingAgent", None),
+            ("web", "WebSearchAgent", None),
+            ("lammps", "LammpsAgent", "lammps"),
+        ]:
+            if deps is not None and not has_optional_dep_group(deps):
+                continue
 
-        if has_optional_dep_group("lammps"):
-            self.agents["lammps"] = AgentHITL(agent_class=agents.LammpsAgent)
+            config = {}
+            if agent_name in {"chat", "execute", "deep_review", "dsi"}:
+                config.update(rag_tool_config)
+            self.agents[agent_name] = AgentHITL(
+                agent_class=getattr(agents, agent_class_name),
+                config=config,
+            )
 
         # Apply agent-specific configuration overrides
         for agent, agent_config in self.config.agent_config.items():

--- a/src/ursa/cli/hitl.py
+++ b/src/ursa/cli/hitl.py
@@ -118,7 +118,7 @@ def get_base_url(model: BaseChatModel) -> str | None:
 class HITL:
     def __init__(self, config: UrsaConfig):
         self.config = UrsaConfig.resolve_config(config)
-        self.thread_id = config.thread_id or "ursa"
+        self.thread_id = self.config.thread_id or "ursa"
         # expose workspace and init common attributes
         self.workspace = self.config.workspace
         self.config.workspace.mkdir(parents=True, exist_ok=True)

--- a/src/ursa/cli/hitl.py
+++ b/src/ursa/cli/hitl.py
@@ -26,7 +26,7 @@ from ursa import agents
 from ursa.agents import BaseAgent
 from ursa.agents.base import URSA_VERSION, AgentWithTools
 from ursa.cli.callbacks import HITLLogEventHandler
-from ursa.cli.config import UrsaConfig
+from ursa.cli.config import UrsaConfig, resolve_ursa_config
 from ursa.security import (
     enforce_model_group_policy,
 )
@@ -117,7 +117,7 @@ def get_base_url(model: BaseChatModel) -> str | None:
 
 class HITL:
     def __init__(self, config: UrsaConfig):
-        self.config = UrsaConfig.resolve_config(config)
+        self.config = resolve_ursa_config(config)
         self.thread_id = self.config.thread_id or "ursa"
         # expose workspace and init common attributes
         self.workspace = self.config.workspace

--- a/src/ursa/cli/print_config.py
+++ b/src/ursa/cli/print_config.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from ursa.cli.config import UrsaConfig, resolve_ursa_config
+
+
+VALID_PRINT_CONFIG_LEVELS = {"final", "file", "project", "user"}
+VALID_PRINT_CONFIG_STAGES = {"merged", "resolved"}
+
+
+def config_path_from_namespace(cfg) -> Path | None:
+    """Return a root or subcommand-local config path from parsed CLI args."""
+    config_path = getattr(cfg, "config", None)
+    subcommand = cfg.get("subcommand", None)
+    if subcommand is not None:
+        cmd_cfg = cfg.get(subcommand, None)
+        cmd_config_path = (
+            getattr(cmd_cfg, "config", None) if cmd_cfg is not None else None
+        )
+        config_path = cmd_config_path or config_path
+    return config_path
+
+
+def config_for_level(cfg, search_paths: list[Path], level: str) -> UrsaConfig:
+    """Return the merged config at a specific precedence level."""
+    cfg_dict = cfg.as_dict()
+    if cfg_dict.get("name") is not None:
+        cfg_dict["agent_name"] = cfg_dict.pop("name")
+    else:
+        cfg_dict.pop("name", None)
+
+    config = UrsaConfig()
+
+    if level == "user":
+        for config_path in search_paths:
+            if config_path.parent.parent == Path.home() / ".config":
+                config.update(UrsaConfig.from_file(config_path))
+        return config
+
+    if level == "project":
+        for config_path in search_paths:
+            if config_path == Path.cwd() / ".ursa" / "config.yaml":
+                config.update(UrsaConfig.from_file(config_path))
+        return config
+
+    if level == "file":
+        config_path = config_path_from_namespace(cfg)
+        if config_path is not None:
+            config.update(UrsaConfig.from_file(config_path))
+        return config
+
+    for config_path in search_paths:
+        config.update(UrsaConfig.from_file(config_path))
+
+    cli_updates = cfg_dict.copy()
+    cli_updates.pop("subcommand", None)
+    cli_updates.pop("config", None)
+    cli_updates.pop("print_config", None)
+    if cli_updates.get("rag_tools") is None:
+        cli_updates.pop("rag_tools", None)
+
+    config.update(UrsaConfig.model_validate(cli_updates, extra="ignore"))
+    return config
+
+
+def parse_print_config_spec(spec: str | None) -> tuple[str, str] | None:
+    if spec is None:
+        return None
+    if spec in {True, False}:
+        return ("final", "resolved") if spec else None
+    if spec in VALID_PRINT_CONFIG_STAGES:
+        return ("final", spec)
+    if "," not in spec:
+        raise ValueError(
+            "--print-config must be one of merged, resolved, or LEVEL,STAGE"
+        )
+    level, stage = [part.strip() for part in spec.split(",", maxsplit=1)]
+    if not level:
+        level = "final"
+    if level not in VALID_PRINT_CONFIG_LEVELS:
+        raise ValueError(f"Unknown print-config level '{level}'")
+    if stage not in VALID_PRINT_CONFIG_STAGES:
+        raise ValueError(f"Unknown print-config stage '{stage}'")
+    return level, stage
+
+
+def print_config(cfg, search_paths: list[Path]) -> bool:
+    """Print config according to --print-config and return whether it handled output."""
+    print_config_spec = parse_print_config_spec(cfg["print_config"])
+    if print_config_spec is None:
+        return False
+    level, stage = print_config_spec
+    config = config_for_level(cfg, search_paths, level)
+    if stage == "resolved":
+        config = resolve_ursa_config(config)
+    print(yaml.safe_dump(config.model_dump(), sort_keys=False))  # noqa: T201
+    return True

--- a/src/ursa/cli/print_config.py
+++ b/src/ursa/cli/print_config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from argparse import Action
+
 import yaml
 from jsonargparse import ArgumentParser
 
@@ -8,7 +10,7 @@ from ursa.cli.config import (
     resolve_ursa_config,
 )
 
-VALID_PRINT_CONFIG_LEVELS = {"final", "file", "user"}
+VALID_PRINT_CONFIG_LEVELS = {"final", "file", "user", "system"}
 VALID_PRINT_CONFIG_STAGES = {"merged", "resolved"}
 
 
@@ -20,9 +22,10 @@ def parse_print_config_spec(spec: str | None) -> tuple[str, str] | None:
     if spec in VALID_PRINT_CONFIG_STAGES:
         return ("final", spec)
     if "," not in spec:
-        raise ValueError(
-            "--print-config must be one of merged, resolved, or LEVEL[+],STAGE"
-        )
+        base_level = spec.removesuffix("+")
+        if base_level in VALID_PRINT_CONFIG_LEVELS:
+            return spec, "resolved"
+        raise ValueError(f"Unknown print-config level or stage '{spec}'")
     level, stage = [part.strip() for part in spec.split(",", maxsplit=1)]
     if not level:
         level = "final"
@@ -34,10 +37,15 @@ def parse_print_config_spec(spec: str | None) -> tuple[str, str] | None:
     return level, stage
 
 
-def _validate_print_config_spec(spec: str) -> str:
-    """Validate a print-config value while preserving its CLI representation."""
-    parse_print_config_spec(spec)
-    return spec
+class PrintConfigAction(Action):
+    """Validate without exposing a validator function in parser errors."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        try:
+            parse_print_config_spec(values)
+        except ValueError as exc:
+            parser.error(str(exc))
+        setattr(namespace, self.dest, values)
 
 
 def add_print_config_argument(parser: ArgumentParser) -> None:
@@ -47,24 +55,28 @@ def add_print_config_argument(parser: ArgumentParser) -> None:
         nargs="?",
         const="resolved",
         default=None,
-        type=_validate_print_config_spec,
+        action=PrintConfigAction,
+        metavar="LEVEL[,STAGE]",
         help=(
             "Print configuration and exit. Defaults to resolved output. "
             "Accepted forms: --print-config, --print-config=resolved, "
             "--print-config=merged, or --print-config=LEVEL,STAGE where "
-            "LEVEL is one of final, file, user (optionally suffixed with + "
+            "LEVEL is one of final, file, user, system (optionally suffixed with + "
             "for cumulative input) and STAGE is merged or resolved."
         ),
     )
 
 
-def print_config(cfg, overrides) -> bool:
+def print_config(cfg, overrides, cli_overrides=None) -> bool:
     """Print config according to --print-config and return whether it handled output."""
     print_config_spec = parse_print_config_spec(cfg["print_config"])
     if print_config_spec is None:
         return False
     level, stage = print_config_spec
-    config = merge_ursa_config(cfg, level, overrides)
+    if cli_overrides is None:
+        config = merge_ursa_config(cfg, level, overrides)
+    else:
+        config = merge_ursa_config(cfg, level, overrides, cli_overrides)
     if stage == "resolved":
         config = resolve_ursa_config(config)
     print(  # noqa: T201

--- a/src/ursa/cli/print_config.py
+++ b/src/ursa/cli/print_config.py
@@ -1,69 +1,29 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 import yaml
 
-from ursa.cli.config import UrsaConfig, resolve_ursa_config
-
+from ursa.cli.config import (
+    UrsaConfig,
+    dict_diff,
+    merge_ursa_config,
+    resolve_ursa_config,
+)
 
 VALID_PRINT_CONFIG_LEVELS = {"final", "file", "project", "user"}
 VALID_PRINT_CONFIG_STAGES = {"merged", "resolved"}
 
 
-def config_path_from_namespace(cfg) -> Path | None:
-    """Return a root or subcommand-local config path from parsed CLI args."""
-    config_path = getattr(cfg, "config", None)
-    subcommand = cfg.get("subcommand", None)
-    if subcommand is not None:
-        cmd_cfg = cfg.get(subcommand, None)
-        cmd_config_path = (
-            getattr(cmd_cfg, "config", None) if cmd_cfg is not None else None
-        )
-        config_path = cmd_config_path or config_path
-    return config_path
-
-
-def config_for_level(cfg, search_paths: list[Path], level: str) -> UrsaConfig:
-    """Return the merged config at a specific precedence level."""
-    cfg_dict = cfg.as_dict()
-    if cfg_dict.get("name") is not None:
-        cfg_dict["agent_name"] = cfg_dict.pop("name")
-    else:
-        cfg_dict.pop("name", None)
-
-    config = UrsaConfig()
-
-    if level == "user":
-        for config_path in search_paths:
-            if config_path.parent.parent == Path.home() / ".config":
-                config.update(UrsaConfig.from_file(config_path))
-        return config
-
-    if level == "project":
-        for config_path in search_paths:
-            if config_path == Path.cwd() / ".ursa" / "config.yaml":
-                config.update(UrsaConfig.from_file(config_path))
-        return config
-
-    if level == "file":
-        config_path = config_path_from_namespace(cfg)
-        if config_path is not None:
-            config.update(UrsaConfig.from_file(config_path))
-        return config
-
-    for config_path in search_paths:
-        config.update(UrsaConfig.from_file(config_path))
-
-    cli_updates = cfg_dict.copy()
-    cli_updates.pop("subcommand", None)
-    cli_updates.pop("config", None)
-    cli_updates.pop("print_config", None)
-    if cli_updates.get("rag_tools") is None:
-        cli_updates.pop("rag_tools", None)
-
-    config.update(UrsaConfig.model_validate(cli_updates, extra="ignore"))
-    return config
+def _drop_none(value):
+    """Recursively omit null values from serialized configuration."""
+    if isinstance(value, dict):
+        return {
+            key: _drop_none(item)
+            for key, item in value.items()
+            if item is not None
+        }
+    if isinstance(value, list):
+        return [_drop_none(item) for item in value if item is not None]
+    return value
 
 
 def parse_print_config_spec(spec: str | None) -> tuple[str, str] | None:
@@ -75,26 +35,37 @@ def parse_print_config_spec(spec: str | None) -> tuple[str, str] | None:
         return ("final", spec)
     if "," not in spec:
         raise ValueError(
-            "--print-config must be one of merged, resolved, or LEVEL,STAGE"
+            "--print-config must be one of merged, resolved, or LEVEL[+],STAGE"
         )
     level, stage = [part.strip() for part in spec.split(",", maxsplit=1)]
     if not level:
         level = "final"
-    if level not in VALID_PRINT_CONFIG_LEVELS:
+    base_level = level.removesuffix("+")
+    if base_level not in VALID_PRINT_CONFIG_LEVELS:
         raise ValueError(f"Unknown print-config level '{level}'")
     if stage not in VALID_PRINT_CONFIG_STAGES:
         raise ValueError(f"Unknown print-config stage '{stage}'")
     return level, stage
 
 
-def print_config(cfg, search_paths: list[Path]) -> bool:
+def print_config(cfg, overrides) -> bool:
     """Print config according to --print-config and return whether it handled output."""
     print_config_spec = parse_print_config_spec(cfg["print_config"])
     if print_config_spec is None:
         return False
     level, stage = print_config_spec
-    config = config_for_level(cfg, search_paths, level)
+    config = merge_ursa_config(cfg, level, overrides)
+    reference = UrsaConfig()
     if stage == "resolved":
         config = resolve_ursa_config(config)
-    print(yaml.safe_dump(config.model_dump(), sort_keys=False))  # noqa: T201
+        reference = resolve_ursa_config(reference)
+    output = _drop_none(
+        dict_diff(
+            reference.model_dump(exclude_none=True),
+            config.model_dump(exclude_none=True),
+        )
+    )
+    print(  # noqa: T201
+        yaml.safe_dump(output, sort_keys=False)
+    )
     return True

--- a/src/ursa/cli/print_config.py
+++ b/src/ursa/cli/print_config.py
@@ -1,29 +1,15 @@
 from __future__ import annotations
 
 import yaml
+from jsonargparse import ArgumentParser
 
 from ursa.cli.config import (
-    UrsaConfig,
-    dict_diff,
     merge_ursa_config,
     resolve_ursa_config,
 )
 
-VALID_PRINT_CONFIG_LEVELS = {"final", "file", "project", "user"}
+VALID_PRINT_CONFIG_LEVELS = {"final", "file", "user"}
 VALID_PRINT_CONFIG_STAGES = {"merged", "resolved"}
-
-
-def _drop_none(value):
-    """Recursively omit null values from serialized configuration."""
-    if isinstance(value, dict):
-        return {
-            key: _drop_none(item)
-            for key, item in value.items()
-            if item is not None
-        }
-    if isinstance(value, list):
-        return [_drop_none(item) for item in value if item is not None]
-    return value
 
 
 def parse_print_config_spec(spec: str | None) -> tuple[str, str] | None:
@@ -48,6 +34,30 @@ def parse_print_config_spec(spec: str | None) -> tuple[str, str] | None:
     return level, stage
 
 
+def _validate_print_config_spec(spec: str) -> str:
+    """Validate a print-config value while preserving its CLI representation."""
+    parse_print_config_spec(spec)
+    return spec
+
+
+def add_print_config_argument(parser: ArgumentParser) -> None:
+    """Register the validated ``--print-config`` CLI option."""
+    parser.add_argument(
+        "--print-config",
+        nargs="?",
+        const="resolved",
+        default=None,
+        type=_validate_print_config_spec,
+        help=(
+            "Print configuration and exit. Defaults to resolved output. "
+            "Accepted forms: --print-config, --print-config=resolved, "
+            "--print-config=merged, or --print-config=LEVEL,STAGE where "
+            "LEVEL is one of final, file, user (optionally suffixed with + "
+            "for cumulative input) and STAGE is merged or resolved."
+        ),
+    )
+
+
 def print_config(cfg, overrides) -> bool:
     """Print config according to --print-config and return whether it handled output."""
     print_config_spec = parse_print_config_spec(cfg["print_config"])
@@ -55,17 +65,12 @@ def print_config(cfg, overrides) -> bool:
         return False
     level, stage = print_config_spec
     config = merge_ursa_config(cfg, level, overrides)
-    reference = UrsaConfig()
     if stage == "resolved":
         config = resolve_ursa_config(config)
-        reference = resolve_ursa_config(reference)
-    output = _drop_none(
-        dict_diff(
-            reference.model_dump(exclude_none=True),
-            config.model_dump(exclude_none=True),
-        )
-    )
     print(  # noqa: T201
-        yaml.safe_dump(output, sort_keys=False)
+        yaml.safe_dump(
+            config.model_dump(mode="json", context={"include_defaults": True}),
+            sort_keys=False,
+        )
     )
     return True

--- a/src/ursa/cli/print_config.py
+++ b/src/ursa/cli/print_config.py
@@ -67,16 +67,13 @@ def add_print_config_argument(parser: ArgumentParser) -> None:
     )
 
 
-def print_config(cfg, overrides, cli_overrides=None) -> bool:
+def print_config(cfg, env_overrides, cli_overrides=None) -> bool:
     """Print config according to --print-config and return whether it handled output."""
     print_config_spec = parse_print_config_spec(cfg["print_config"])
     if print_config_spec is None:
         return False
     level, stage = print_config_spec
-    if cli_overrides is None:
-        config = merge_ursa_config(cfg, level, overrides)
-    else:
-        config = merge_ursa_config(cfg, level, overrides, cli_overrides)
+    config = merge_ursa_config(cfg, level, env_overrides, cli_overrides)
     if stage == "resolved":
         config = resolve_ursa_config(config)
     print(  # noqa: T201

--- a/src/ursa/cli/rag_management.py
+++ b/src/ursa/cli/rag_management.py
@@ -18,17 +18,17 @@ from ursa.rag.persistence import (
     validate_rag_agent_name,
 )
 from ursa.security import (
+    enforce_group_base_url_policy,
     enforce_model_group_policy,
 )
 
-RAG_COMMANDS = {
-    "rag-ingest",
-    "rag-query",
+RAG_METADATA_COMMANDS = {
     "list-rag-agents",
     "show-rag-agent",
     "delete-rag-agent",
     "save-rag-agent",
 }
+RAG_COMMANDS = {"rag-ingest", "rag-query", *RAG_METADATA_COMMANDS}
 
 
 def add_rag_subcommands(subparsers) -> None:
@@ -137,10 +137,12 @@ def _init_models(
         else _model_config_from_namespace(root_args)
     )
     group = getattr(cmd_args, "group", "default") or "default"
+    enforce_group_base_url_policy(llm_model.base_url, group)
     llm = llm_model.init_chat_model()
     enforce_model_group_policy(llm, group)
     embedding = None
     if emb_model is not None:
+        enforce_group_base_url_policy(emb_model.base_url, group)
         embedding = emb_model.init_embedding()
         enforce_model_group_policy(embedding, group)
     return llm, embedding

--- a/src/ursa/cli/rag_management.py
+++ b/src/ursa/cli/rag_management.py
@@ -141,13 +141,15 @@ def _init_models(
         else _model_config_from_namespace(root_args)
     )
     group = getattr(cmd_args, "group", "default") or "default"
-    enforce_group_base_url_policy(llm_model.base_url, group)
-    llm = init_chat_model(**llm_model.kwargs)
+    llm = llm_model.init_chat_model(
+        config.inference_providers if config is not None else {}
+    )
     enforce_model_group_policy(llm, group)
     embedding = None
-    if emb_model:
-        enforce_group_base_url_policy(emb_model.base_url, group)
-        embedding = init_embeddings(**emb_model.kwargs)
+    if emb_model is not None:
+        embedding = emb_model.init_embedding(
+            config.inference_providers if config is not None else {}
+        )
         enforce_model_group_policy(embedding, group)
     return llm, embedding
 

--- a/src/ursa/cli/rag_management.py
+++ b/src/ursa/cli/rag_management.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 from argparse import Namespace
 from pathlib import Path
 
-from langchain.chat_models import init_chat_model
-from langchain.embeddings import init_embeddings
-
 from ursa.cli.config import ModelConfig, UrsaConfig
 from ursa.rag.persistence import (
     build_persistent_rag_agent,
@@ -21,7 +18,6 @@ from ursa.rag.persistence import (
     validate_rag_agent_name,
 )
 from ursa.security import (
-    enforce_group_base_url_policy,
     enforce_model_group_policy,
 )
 

--- a/src/ursa/cli/rag_management.py
+++ b/src/ursa/cli/rag_management.py
@@ -137,15 +137,11 @@ def _init_models(
         else _model_config_from_namespace(root_args)
     )
     group = getattr(cmd_args, "group", "default") or "default"
-    llm = llm_model.init_chat_model(
-        config.inference_providers if config is not None else {}
-    )
+    llm = llm_model.init_chat_model()
     enforce_model_group_policy(llm, group)
     embedding = None
     if emb_model is not None:
-        embedding = emb_model.init_embedding(
-            config.inference_providers if config is not None else {}
-        )
+        embedding = emb_model.init_embedding()
         enforce_model_group_policy(embedding, group)
     return llm, embedding
 

--- a/src/ursa/environments/config.py
+++ b/src/ursa/environments/config.py
@@ -8,8 +8,13 @@ from typing import Any, Mapping
 import yaml
 from langchain.chat_models import BaseChatModel, init_chat_model
 
-from ursa.cli.config import ModelConfig, deep_interp_env
-from ursa.security import group_environments_dir
+from ursa.cli.config import (
+    InferenceProviderConfig,
+    ModelConfig,
+    deep_interp_env,
+)
+from ursa.security import enforce_group_base_url_policy, group_environments_dir
+from ursa.util.secrets import SecretReference
 
 
 @dataclass(frozen=True)
@@ -35,12 +40,44 @@ class EnvironmentMemberConfig:
     reviewer: bool = True
 
     @classmethod
-    def from_mapping(cls, data: Mapping[str, Any]) -> "EnvironmentMemberConfig":
+    def from_mapping(
+        cls,
+        data: Mapping[str, Any],
+        inference_providers: Mapping[str, InferenceProviderConfig]
+        | None = None,
+        group: str = "default",
+    ) -> "EnvironmentMemberConfig":
         raw = dict(data)
         model = raw.get("model")
         if isinstance(model, Mapping):
-            raw["model"] = ModelConfig.model_validate(model)
+            model_config = ModelConfig.model_validate(model)
+            provider_name = model_config.inference_provider
+            if provider_name is not None:
+                providers = dict(inference_providers or {})
+                model_config = model_config.resolve_inference_provider(
+                    providers
+                )
+                if (
+                    isinstance(model_config.api_key, SecretReference)
+                    and model_config.api_key.keyring is True
+                ):
+                    model_config = model_config.model_copy(
+                        update={
+                            "api_key": SecretReference(keyring=provider_name)
+                        }
+                    )
+            enforce_group_base_url_policy(model_config.base_url, group)
+            raw["model"] = model_config
         return cls(**raw)
+
+
+def _inference_providers(
+    data: Mapping[str, Any],
+) -> dict[str, InferenceProviderConfig]:
+    return {
+        name: InferenceProviderConfig.model_validate(config)
+        for name, config in data.items()
+    }
 
 
 @dataclass(frozen=True)
@@ -50,6 +87,9 @@ class AgentTeamConfig:
     name: str
     group: str = "default"
     description: str | None = None
+    inference_providers: dict[str, InferenceProviderConfig] = field(
+        default_factory=dict
+    )
     pi: EnvironmentMemberConfig = field(
         default_factory=lambda: EnvironmentMemberConfig(
             name="pi", role="Principal investigator", agent="ExecutionAgent"
@@ -62,11 +102,16 @@ class AgentTeamConfig:
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any]) -> "AgentTeamConfig":
         raw = dict(data)
+        providers = _inference_providers(raw.get("inference_providers") or {})
+        raw["inference_providers"] = providers
+        group = str(raw.get("group") or "default")
         if "pi" in raw and isinstance(raw["pi"], Mapping):
-            raw["pi"] = EnvironmentMemberConfig.from_mapping(raw["pi"])
+            raw["pi"] = EnvironmentMemberConfig.from_mapping(
+                raw["pi"], providers, group
+            )
         if "members" in raw:
             raw["members"] = [
-                EnvironmentMemberConfig.from_mapping(member)
+                EnvironmentMemberConfig.from_mapping(member, providers, group)
                 for member in raw["members"]
             ]
         return cls(**raw)
@@ -79,6 +124,9 @@ class AgentSymposiumConfig:
     name: str
     group: str = "default"
     description: str | None = None
+    inference_providers: dict[str, InferenceProviderConfig] = field(
+        default_factory=dict
+    )
     organizer: EnvironmentMemberConfig = field(
         default_factory=lambda: EnvironmentMemberConfig(
             name="organizer", role="Symposium organizer", agent="ChatAgent"
@@ -92,13 +140,16 @@ class AgentSymposiumConfig:
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any]) -> "AgentSymposiumConfig":
         raw = dict(data)
+        providers = _inference_providers(raw.get("inference_providers") or {})
+        raw["inference_providers"] = providers
+        group = str(raw.get("group") or "default")
         if "organizer" in raw and isinstance(raw["organizer"], Mapping):
             raw["organizer"] = EnvironmentMemberConfig.from_mapping(
-                raw["organizer"]
+                raw["organizer"], providers, group
             )
         if "members" in raw:
             raw["members"] = [
-                EnvironmentMemberConfig.from_mapping(member)
+                EnvironmentMemberConfig.from_mapping(member, providers, group)
                 for member in raw["members"]
             ]
         return cls(**raw)

--- a/src/ursa/environments/config.py
+++ b/src/ursa/environments/config.py
@@ -14,7 +14,6 @@ from ursa.cli.config import (
     deep_interp_env,
 )
 from ursa.security import enforce_group_base_url_policy, group_environments_dir
-from ursa.util.secrets import SecretReference
 
 
 @dataclass(frozen=True)
@@ -51,21 +50,9 @@ class EnvironmentMemberConfig:
         model = raw.get("model")
         if isinstance(model, Mapping):
             model_config = ModelConfig.model_validate(model)
-            provider_name = model_config.inference_provider
-            if provider_name is not None:
-                providers = dict(inference_providers or {})
-                model_config = model_config.resolve_inference_provider(
-                    providers
-                )
-                if (
-                    isinstance(model_config.api_key, SecretReference)
-                    and model_config.api_key.keyring is True
-                ):
-                    model_config = model_config.model_copy(
-                        update={
-                            "api_key": SecretReference(keyring=provider_name)
-                        }
-                    )
+            model_config = model_config.resolve_inference_provider(
+                dict(inference_providers or {})
+            )
             enforce_group_base_url_policy(model_config.base_url, group)
             raw["model"] = model_config
         return cls(**raw)

--- a/src/ursa/util/crossplatform.py
+++ b/src/ursa/util/crossplatform.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 def system_config_path() -> Path:
     """Return the platform-specific system-wide URSA configuration path."""
+    if sys_config := os.environ.get("URSA_SYSTEM_CONFIG"):
+        return Path(sys_config)
     if sys.platform == "win32":
         root = Path(os.environ.get("PROGRAMDATA", "C:/ProgramData"))
         return root / "ursa" / "config.yaml"

--- a/src/ursa/util/crossplatform.py
+++ b/src/ursa/util/crossplatform.py
@@ -1,0 +1,46 @@
+"""Cross-platform locations used by URSA."""
+
+import os
+import sys
+from pathlib import Path
+
+
+def system_config_path() -> Path:
+    """Return the platform-specific system-wide URSA configuration path."""
+    if sys.platform == "win32":
+        root = Path(os.environ.get("PROGRAMDATA", "C:/ProgramData"))
+        return root / "ursa" / "config.yaml"
+    if sys.platform == "darwin":
+        return Path("/Library/Application Support/ursa/config.yaml")
+    return Path("/etc/ursa/config.yaml")
+
+
+def platform_user_config_path() -> Path:
+    """Return the native platform-specific per-user configuration path."""
+    if sys.platform == "win32":
+        root = Path(os.environ.get("APPDATA", Path.home() / "AppData/Roaming"))
+        return root / "ursa" / "config.yaml"
+    if sys.platform == "darwin":
+        return Path.home() / "Library/Application Support/ursa/config.yaml"
+    return Path.home() / ".config/ursa/config.yaml"
+
+
+def user_config_paths() -> list[Path]:
+    """Return user config paths from lowest to highest precedence.
+
+    The native platform location is followed by the portable ``~/.config``
+    location and then an explicit ``XDG_CONFIG_HOME`` location. Duplicate
+    paths are omitted while preserving that precedence.
+    """
+    candidates = [
+        platform_user_config_path(),
+        Path.home() / ".config/ursa/config.yaml",
+    ]
+    if xdg_home := os.environ.get("XDG_CONFIG_HOME"):
+        candidates.append(Path(xdg_home).expanduser() / "ursa" / "config.yaml")
+
+    paths: list[Path] = []
+    for candidate in candidates:
+        if candidate not in paths:
+            paths.append(candidate)
+    return paths

--- a/src/ursa/util/mcp.py
+++ b/src/ursa/util/mcp.py
@@ -10,6 +10,7 @@ from mcp.client.session_group import (
 from pydantic import BaseModel, BeforeValidator, ValidationError
 
 from ursa.util.http import build_mcp_httpx_async_client
+from ursa.util.secrets import SecretTemplate
 
 
 def validate_server_parameters(config: dict):
@@ -73,10 +74,29 @@ def start_mcp_client(
             **config.model_dump(),
             "transport": transport(config),
         }
+        if headers := connection.get("headers"):
+            connection["headers"] = {
+                name: _resolve_header(value, server)
+                for name, value in headers.items()
+            }
         if isinstance(config, (SseServerParameters, StreamableHttpParameters)):
             connection["httpx_client_factory"] = build_mcp_httpx_async_client
         client_config[server] = connection
     return MultiServerMCPClient(client_config)
+
+
+def _resolve_header(value, server_name: str):
+    """Resolve a typed secret template in an MCP HTTP header."""
+    if isinstance(value, dict):
+        rendered = SecretTemplate.model_validate(value).get_secret_value(
+            server_name
+        )
+        if rendered is None:
+            raise ValueError(
+                f"Secret for MCP server '{server_name}' is not set"
+            )
+        return rendered
+    return value
 
 
 def _serialize_server_config(

--- a/src/ursa/util/mcp.py
+++ b/src/ursa/util/mcp.py
@@ -81,7 +81,10 @@ def start_mcp_client(
 
 def _serialize_server_config(config: ServerParameters):
     """Internal: serialize MCP ServerParameters in a yaml/json compatible way"""
-    config = {"transport": transport(config), **config.model_dump()}
+    config = {
+        "transport": transport(config),
+        **config.model_dump(exclude_defaults=True, exclude_none=True),
+    }
     for k, v in config.items():
         if isinstance(v, timedelta):
             config[k] = v.total_seconds()

--- a/src/ursa/util/mcp.py
+++ b/src/ursa/util/mcp.py
@@ -18,6 +18,11 @@ def validate_server_parameters(config: dict):
         return config
     transport_hint = config.get("transport")
     payload = {k: v for k, v in config.items() if k != "transport"}
+    if isinstance(headers := payload.get("headers"), dict):
+        payload["headers"] = {
+            name: SecretTemplate.maybe_validate(value)
+            for name, value in headers.items()
+        }
     if transport_hint == "stdio":
         return StdioServerParameters(**payload)
     elif transport_hint == "sse":
@@ -87,10 +92,13 @@ def start_mcp_client(
 
 def _resolve_header(value, server_name: str):
     """Resolve a typed secret template in an MCP HTTP header."""
-    if isinstance(value, dict):
-        rendered = SecretTemplate.model_validate(value).get_secret_value(
-            server_name
-        )
+    reference = (
+        SecretTemplate.model_validate(value)
+        if isinstance(value, dict)
+        else value
+    )
+    if isinstance(reference, SecretTemplate):
+        rendered = reference.get_secret_value(server_name)
         if rendered is None:
             raise ValueError(
                 f"Secret for MCP server '{server_name}' is not set"

--- a/src/ursa/util/mcp.py
+++ b/src/ursa/util/mcp.py
@@ -79,11 +79,19 @@ def start_mcp_client(
     return MultiServerMCPClient(client_config)
 
 
-def _serialize_server_config(config: ServerParameters):
+def _serialize_server_config(
+    config: ServerParameters,
+    *,
+    exclude_defaults: bool = True,
+    exclude_none: bool = True,
+):
     """Internal: serialize MCP ServerParameters in a yaml/json compatible way"""
     config = {
         "transport": transport(config),
-        **config.model_dump(exclude_defaults=True, exclude_none=True),
+        **config.model_dump(
+            exclude_defaults=exclude_defaults,
+            exclude_none=exclude_none,
+        ),
     }
     for k, v in config.items():
         if isinstance(v, timedelta):

--- a/src/ursa/util/secrets.py
+++ b/src/ursa/util/secrets.py
@@ -1,13 +1,14 @@
 """References to secrets stored outside configuration files."""
 
 from os import environ
-from typing import Annotated
+from typing import Annotated, Any
 
 from pydantic import (
     AfterValidator,
     BaseModel,
     ConfigDict,
     SecretStr,
+    ValidationError,
     model_validator,
 )
 
@@ -28,6 +29,14 @@ class SecretReference(BaseModel):
 
     env: Annotated[str | None, AfterValidator(_non_blank)] = None
     keyring: bool | Annotated[str, AfterValidator(_non_blank)] | None = None
+
+    @classmethod
+    def maybe_validate(cls, value: Any, **kwargs) -> Any:
+        """Type a secret mapping while leaving unrelated values unchanged."""
+        try:
+            return cls.model_validate(value, **kwargs)
+        except ValidationError:
+            return value
 
     @model_validator(mode="after")
     def _validate_source(self):

--- a/src/ursa/util/secrets.py
+++ b/src/ursa/util/secrets.py
@@ -1,0 +1,88 @@
+"""References to secrets stored outside configuration files."""
+
+from os import environ
+from typing import Annotated
+
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    SecretStr,
+    model_validator,
+)
+
+
+def _non_blank(value: str | None) -> str | None:
+    if value is None:
+        return None
+    value = value.strip()
+    if not value:
+        raise ValueError("secret reference values cannot be blank")
+    return value
+
+
+class SecretReference(BaseModel):
+    """A reference to a secret in the environment or system keyring."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    env: Annotated[str | None, AfterValidator(_non_blank)] = None
+    keyring: bool | Annotated[str, AfterValidator(_non_blank)] | None = None
+
+    @model_validator(mode="after")
+    def _validate_source(self):
+        sources = int(self.env is not None) + int(
+            self.keyring not in (None, False)
+        )
+        if sources != 1:
+            raise ValueError("a secret reference requires exactly one source")
+        return self
+
+    def resolve(
+        self, default_keyring_username: str | None = None
+    ) -> SecretStr | None:
+        """Resolve the reference, returning ``None`` for a missing env value."""
+        if self.env is not None:
+            value = environ.get(self.env)
+            return SecretStr(value) if value is not None else None
+
+        import keyring
+
+        username = (
+            default_keyring_username if self.keyring is True else self.keyring
+        )
+        if not username:
+            raise ValueError("keyring=true requires a default username")
+        value = keyring.get_password("ursa", username)
+        if value is None:
+            raise ValueError(
+                f"No secret found in the system keyring for '{username}'"
+            )
+        return SecretStr(value)
+
+    def get_secret_value(
+        self, default_keyring_username: str | None = None
+    ) -> str | None:
+        """Resolve and unwrap the referenced secret value."""
+        secret = self.resolve(default_keyring_username)
+        return secret.get_secret_value() if secret is not None else None
+
+
+class SecretTemplate(SecretReference):
+    """A secret reference rendered into a string at point of use."""
+
+    template: str = "%s"
+
+    @model_validator(mode="after")
+    def _validate_template(self):
+        if self.template.count("%s") != 1:
+            raise ValueError("secret template must contain exactly one '%s'")
+        return self
+
+    def get_secret_value(
+        self, default_keyring_username: str | None = None
+    ) -> str | None:
+        secret = super().get_secret_value(default_keyring_username)
+        if secret is None:
+            return None
+        return self.template % secret

--- a/src/ursa_dashboard/settings.py
+++ b/src/ursa_dashboard/settings.py
@@ -5,7 +5,7 @@ import re
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, SecretStr, field_validator
 
 from ursa.cli.config import UrsaConfig, resolve_ursa_config
 from ursa.security import enforce_group_base_url_policy
@@ -183,6 +183,11 @@ def dashboard_llm_patch_from_ursa_config(
 
     cfg = UrsaConfig.from_file(Path(path))
     llm_cfg = cfg.llm_model
+    if isinstance(llm_cfg.api_key, SecretStr):
+        raise ValueError(
+            "Dashboard config does not store raw llm_model.api_key; "
+            "use an environment or dashboard credential instead."
+        )
     if (
         current is not None
         and llm_cfg.inference_provider is None
@@ -190,6 +195,11 @@ def dashboard_llm_patch_from_ursa_config(
     ):
         llm_cfg = llm_cfg.model_copy(update={"base_url": current.llm.base_url})
     emb_cfg = cfg.emb_model
+    if emb_cfg is not None and isinstance(emb_cfg.api_key, SecretStr):
+        raise ValueError(
+            "Dashboard config does not store raw emb_model.api_key; "
+            "use an environment or dashboard credential instead."
+        )
     if (
         current is not None
         and emb_cfg is not None
@@ -202,14 +212,22 @@ def dashboard_llm_patch_from_ursa_config(
     cfg = cfg.model_copy(
         update={"group": group, "llm_model": llm_cfg, "emb_model": emb_cfg}
     )
+    llm_api_key_env = llm_cfg.resolve_inference_provider(
+        cfg.inference_providers
+    ).api_key_env
+    emb_api_key_env = (
+        emb_cfg.resolve_inference_provider(cfg.inference_providers).api_key_env
+        if emb_cfg is not None
+        else None
+    )
     cfg = resolve_ursa_config(cfg)
     llm_cfg = cfg.llm_model
 
     patch: dict[str, Any] = {"model": llm_cfg.model}
     if llm_cfg.base_url is not None:
         patch["base_url"] = llm_cfg.base_url
-    if llm_cfg.api_key_env is not None:
-        patch["api_key_env"] = llm_cfg.api_key_env
+    if llm_api_key_env is not None:
+        patch["api_key_env"] = llm_api_key_env
         patch["credential_source"] = "environment"
     if llm_cfg.max_completion_tokens is not None:
         patch["max_tokens"] = llm_cfg.max_completion_tokens
@@ -250,8 +268,8 @@ def dashboard_llm_patch_from_ursa_config(
         emb_patch: dict[str, Any] = {"model": emb_cfg.model}
         if emb_cfg.base_url is not None:
             emb_patch["base_url"] = emb_cfg.base_url
-        if emb_cfg.api_key_env is not None:
-            emb_patch["api_key_env"] = emb_cfg.api_key_env
+        if emb_api_key_env is not None:
+            emb_patch["api_key_env"] = emb_api_key_env
             emb_patch["credential_source"] = "environment"
 
         emb_model_kwargs: dict[str, Any] = {}

--- a/src/ursa_dashboard/settings.py
+++ b/src/ursa_dashboard/settings.py
@@ -7,7 +7,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
-from ursa.cli.config import UrsaConfig
+from ursa.cli.config import UrsaConfig, resolve_ursa_config
 from ursa.security import enforce_group_base_url_policy
 
 from .credentials import assert_no_raw_api_key
@@ -176,7 +176,7 @@ def dashboard_llm_patch_from_ursa_config(path: str | Path) -> dict[str, Any]:
     first-class dashboard setting.
     """
 
-    cfg = UrsaConfig.from_file(Path(path))
+    cfg = resolve_ursa_config(UrsaConfig.from_file(Path(path)))
     llm_cfg = cfg.llm_model
 
     patch: dict[str, Any] = {"model": llm_cfg.model}

--- a/src/ursa_dashboard/settings.py
+++ b/src/ursa_dashboard/settings.py
@@ -218,16 +218,9 @@ def dashboard_llm_patch_from_ursa_config(
     cfg = cfg.model_copy(
         update={"group": group, "llm_model": llm_cfg, "emb_model": emb_cfg}
     )
-    llm_api_key_env = llm_cfg.resolve_inference_provider(
-        cfg.inference_providers
-    ).api_key_env
-    emb_api_key_env = (
-        emb_cfg.resolve_inference_provider(cfg.inference_providers).api_key_env
-        if emb_cfg is not None
-        else None
-    )
     cfg = resolve_ursa_config(cfg)
     llm_cfg = cfg.llm_model
+    llm_api_key_env = llm_cfg.api_key_env
 
     patch: dict[str, Any] = {"model": _qualified_model_name(llm_cfg)}
     if llm_cfg.base_url is not None:
@@ -271,6 +264,7 @@ def dashboard_llm_patch_from_ursa_config(
 
     emb_cfg = cfg.emb_model
     if emb_cfg is not None:
+        emb_api_key_env = emb_cfg.api_key_env
         emb_patch: dict[str, Any] = {"model": _qualified_model_name(emb_cfg)}
         if emb_cfg.base_url is not None:
             emb_patch["base_url"] = emb_cfg.base_url

--- a/src/ursa_dashboard/settings.py
+++ b/src/ursa_dashboard/settings.py
@@ -166,7 +166,12 @@ class GlobalSettings(BaseModel):
     ui: UISettings = Field(default_factory=UISettings)
 
 
-def dashboard_llm_patch_from_ursa_config(path: str | Path) -> dict[str, Any]:
+def dashboard_llm_patch_from_ursa_config(
+    path: str | Path,
+    *,
+    group: str,
+    current: GlobalSettings | None = None,
+) -> dict[str, Any]:
     """Return a dashboard settings patch from a CLI-style URSA config.
 
     The dashboard intentionally stores only non-secret LLM settings.
@@ -176,7 +181,28 @@ def dashboard_llm_patch_from_ursa_config(path: str | Path) -> dict[str, Any]:
     first-class dashboard setting.
     """
 
-    cfg = resolve_ursa_config(UrsaConfig.from_file(Path(path)))
+    cfg = UrsaConfig.from_file(Path(path))
+    llm_cfg = cfg.llm_model
+    if (
+        current is not None
+        and llm_cfg.inference_provider is None
+        and "base_url" not in llm_cfg.model_fields_set
+    ):
+        llm_cfg = llm_cfg.model_copy(update={"base_url": current.llm.base_url})
+    emb_cfg = cfg.emb_model
+    if (
+        current is not None
+        and emb_cfg is not None
+        and emb_cfg.inference_provider is None
+        and "base_url" not in emb_cfg.model_fields_set
+    ):
+        emb_cfg = emb_cfg.model_copy(
+            update={"base_url": current.embedding.base_url}
+        )
+    cfg = cfg.model_copy(
+        update={"group": group, "llm_model": llm_cfg, "emb_model": emb_cfg}
+    )
+    cfg = resolve_ursa_config(cfg)
     llm_cfg = cfg.llm_model
 
     patch: dict[str, Any] = {"model": llm_cfg.model}
@@ -299,8 +325,11 @@ def apply_dashboard_config(
     dashboard app.
     """
 
-    patch = dashboard_llm_patch_from_ursa_config(path)
-    settings = merge_global_settings_patch(settings_store.load(), patch)
+    current = settings_store.load()
+    patch = dashboard_llm_patch_from_ursa_config(
+        path, group=group, current=current
+    )
+    settings = merge_global_settings_patch(current, patch)
     enforce_group_base_url_policy(settings.llm.base_url, group)
     if settings.embedding.model:
         enforce_group_base_url_policy(settings.embedding.base_url, group)

--- a/src/ursa_dashboard/settings.py
+++ b/src/ursa_dashboard/settings.py
@@ -14,6 +14,12 @@ from .credentials import assert_no_raw_api_key
 from .storage import read_json, utc_now, write_json
 
 
+def _qualified_model_name(model_config) -> str:
+    if model_config.model_provider is None:
+        return model_config.model
+    return f"{model_config.model_provider}:{model_config.model}"
+
+
 class LLMSettings(BaseModel):
     model: str = "openai:gpt-5.2"
     base_url: str | None = None
@@ -223,7 +229,7 @@ def dashboard_llm_patch_from_ursa_config(
     cfg = resolve_ursa_config(cfg)
     llm_cfg = cfg.llm_model
 
-    patch: dict[str, Any] = {"model": llm_cfg.model}
+    patch: dict[str, Any] = {"model": _qualified_model_name(llm_cfg)}
     if llm_cfg.base_url is not None:
         patch["base_url"] = llm_cfg.base_url
     if llm_api_key_env is not None:
@@ -265,7 +271,7 @@ def dashboard_llm_patch_from_ursa_config(
 
     emb_cfg = cfg.emb_model
     if emb_cfg is not None:
-        emb_patch: dict[str, Any] = {"model": emb_cfg.model}
+        emb_patch: dict[str, Any] = {"model": _qualified_model_name(emb_cfg)}
         if emb_cfg.base_url is not None:
             emb_patch["base_url"] = emb_cfg.base_url
         if emb_api_key_env is not None:

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -8,6 +8,7 @@ from ursa.cli.auth import (
     list_credentials,
     login,
 )
+from ursa.cli.config import load_config_file
 
 
 @pytest.fixture
@@ -238,8 +239,10 @@ llm_model:
 """
     )
     monkeypatch.setattr(
-        "ursa.cli.auth.config_search_paths",
-        lambda namespace: [system, user, explicit],
+        "ursa.cli.auth.config_layers",
+        lambda namespace, level: [
+            load_config_file(path) for path in (system, user, explicit)
+        ],
     )
     monkeypatch.setenv("ANTHROPIC_API_KEY", "present")
     fake_keyring[(KEYRING_SERVICE, "mcp-account")] = "present"
@@ -306,7 +309,8 @@ mcp_servers:
 """
     )
     monkeypatch.setattr(
-        "ursa.cli.auth.config_search_paths", lambda namespace: [config]
+        "ursa.cli.auth.config_layers",
+        lambda namespace, level: [load_config_file(config)],
     )
 
     lines = configured_secret_lines(config)["MCP Servers:"]
@@ -328,7 +332,8 @@ llm_model:
 """
     )
     monkeypatch.setattr(
-        "ursa.cli.auth.config_search_paths", lambda namespace: [config]
+        "ursa.cli.auth.config_layers",
+        lambda namespace, level: [load_config_file(config)],
     )
 
     list_credentials(config)
@@ -347,7 +352,8 @@ llm_model:
 """
     )
     monkeypatch.setattr(
-        "ursa.cli.auth.config_search_paths", lambda namespace: [config]
+        "ursa.cli.auth.config_layers",
+        lambda namespace, level: [load_config_file(config)],
     )
     calls = []
 
@@ -376,7 +382,8 @@ inference_providers:
 """
     )
     monkeypatch.setattr(
-        "ursa.cli.auth.config_search_paths", lambda namespace: [config]
+        "ursa.cli.auth.config_layers",
+        lambda namespace, level: [load_config_file(config)],
     )
     fake_keyring[(KEYRING_SERVICE, "hosted")] = "visible-token"
 
@@ -393,7 +400,8 @@ def test_auth_list_prints_nothing_when_no_secrets_exist(
     config = tmp_path / "config.yaml"
     config.write_text("workspace: .\n")
     monkeypatch.setattr(
-        "ursa.cli.auth.config_search_paths", lambda namespace: [config]
+        "ursa.cli.auth.config_layers",
+        lambda namespace, level: [load_config_file(config)],
     )
 
     list_credentials(config)

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -1,0 +1,418 @@
+import pytest
+
+from ursa.cli import build_parser, main
+from ursa.cli.auth import (
+    KEYRING_SERVICE,
+    config_keyring_usernames,
+    configured_secret_lines,
+    list_credentials,
+    login,
+)
+
+
+@pytest.fixture
+def fake_keyring(monkeypatch):
+    values = {}
+
+    def get_password(service, username):
+        return values.get((service, username))
+
+    def set_password(service, username, password):
+        values[(service, username)] = password
+
+    monkeypatch.setattr("ursa.cli.auth.keyring.get_password", get_password)
+    monkeypatch.setattr("ursa.cli.auth.keyring.set_password", set_password)
+    return values
+
+
+def test_login_stores_secret(monkeypatch, fake_keyring, capsys):
+    monkeypatch.setattr("ursa.cli.auth.getpass.getpass", lambda prompt: "token")
+
+    login("openai")
+
+    assert fake_keyring[(KEYRING_SERVICE, "openai")] == "token"
+    assert capsys.readouterr().out == "Stored credential: openai\n"
+
+
+def test_login_rejects_empty_secret(monkeypatch, fake_keyring):
+    monkeypatch.setattr("ursa.cli.auth.getpass.getpass", lambda prompt: "")
+
+    with pytest.raises(ValueError, match="cannot be empty"):
+        login("openai")
+
+
+def test_login_reads_secret_from_environment(monkeypatch, fake_keyring):
+    monkeypatch.setenv("PROVIDER_TOKEN", "from-environment")
+    monkeypatch.setattr(
+        "ursa.cli.auth.getpass.getpass",
+        lambda prompt: pytest.fail("password prompt should not be used"),
+    )
+
+    login("openai", from_env="PROVIDER_TOKEN")
+
+    assert fake_keyring[(KEYRING_SERVICE, "openai")] == "from-environment"
+
+
+def test_login_rejects_missing_environment_secret(monkeypatch, fake_keyring):
+    monkeypatch.delenv("MISSING_PROVIDER_TOKEN", raising=False)
+    with pytest.raises(ValueError, match="is not set or is empty"):
+        login("openai", from_env="MISSING_PROVIDER_TOKEN")
+
+
+def test_config_login_finds_provider_model_and_mcp_keyring_names(tmp_path):
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        """
+inference_providers:
+  hosted:
+    api_key:
+      keyring: true
+llm_model:
+  model: anthropic:model
+  api_key:
+    keyring: direct-model
+mcp_servers:
+  tools:
+    transport: streamable-http
+    url: https://example.test/mcp
+    headers:
+      Authorization:
+        keyring: true
+        template: "Bearer %s"
+      X-API-Key:
+        keyring: shared-mcp
+"""
+    )
+
+    assert config_keyring_usernames(path) == [
+        "direct-model",
+        "hosted",
+        "shared-mcp",
+        "tools",
+    ]
+
+
+def test_config_login_prompts_for_each_discovered_secret(
+    tmp_path, monkeypatch, fake_keyring
+):
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        """
+inference_providers:
+  hosted:
+    api_key:
+      keyring: true
+llm_model:
+  model: openai:model
+  inference_provider: hosted
+"""
+    )
+    prompts = []
+
+    def prompt(message):
+        prompts.append(message)
+        return "token"
+
+    monkeypatch.setattr("ursa.cli.auth.getpass.getpass", prompt)
+
+    login(config=path)
+
+    assert prompts == ["Secret for hosted: "]
+    assert fake_keyring[(KEYRING_SERVICE, "hosted")] == "token"
+
+
+def test_config_login_supports_environment_configs(tmp_path, fake_keyring):
+    path = tmp_path / "team.yaml"
+    path.write_text(
+        """
+name: reviewers
+inference_providers:
+  anthropic:
+    api_key:
+      keyring: true
+members:
+  - name: reviewer
+    model:
+      model: openai:gpt-test
+      api_key:
+        keyring: model-override
+"""
+    )
+
+    assert config_keyring_usernames(path) == [
+        "anthropic",
+        "model-override",
+    ]
+
+
+def test_from_env_rejects_config_with_multiple_secrets(
+    tmp_path, monkeypatch, fake_keyring
+):
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        """
+inference_providers:
+  first:
+    api_key:
+      keyring: true
+  second:
+    api_key:
+      keyring: true
+"""
+    )
+    monkeypatch.setenv("SHARED_TOKEN", "token")
+
+    with pytest.raises(ValueError, match="exactly one"):
+        login(config=path, from_env="SHARED_TOKEN")
+
+
+def test_auth_main_dispatches_login(monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        "ursa.cli.auth.login",
+        lambda username, config, from_env: called.append((
+            username,
+            config,
+            from_env,
+        )),
+    )
+
+    main(["auth", "login", "openai", "--from-env", "OPENAI_API_KEY"])
+
+    assert called == [("openai", None, "OPENAI_API_KEY")]
+
+
+def test_auth_main_dispatches_list(monkeypatch, tmp_path):
+    config = tmp_path / "config.yaml"
+    called = []
+    monkeypatch.setattr(
+        "ursa.cli.auth.list_credentials",
+        lambda config, show_secrets: called.append((config, show_secrets)),
+    )
+
+    main(["auth", "list", "--config", str(config)])
+
+    assert called == [(config, False)]
+
+
+def test_auth_list_reports_merged_configured_secrets(
+    tmp_path, monkeypatch, fake_keyring, capsys
+):
+    system = tmp_path / "system.yaml"
+    user = tmp_path / "user.yaml"
+    explicit = tmp_path / "explicit.yaml"
+    system.write_text(
+        """
+inference_providers:
+  openai:
+    api_key:
+      keyring: true
+mcp_servers:
+  tools:
+    transport: streamable-http
+    url: https://example.test/mcp
+    headers:
+      Authorization:
+        keyring: mcp-account
+        template: "Bearer %s"
+"""
+    )
+    user.write_text(
+        """
+inference_providers:
+  anthropic:
+    api_key:
+      env: ANTHROPIC_API_KEY
+"""
+    )
+    explicit.write_text(
+        """
+emb_model:
+  model: openai:embedding
+  api_key:
+    env: SIGNING_KEY
+llm_model:
+  model: openai:test
+  api_key:
+    keyring: model-account
+"""
+    )
+    monkeypatch.setattr(
+        "ursa.cli.auth.config_search_paths",
+        lambda namespace: [system, user, explicit],
+    )
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "present")
+    fake_keyring[(KEYRING_SERVICE, "mcp-account")] = "present"
+
+    list_credentials(explicit)
+
+    assert capsys.readouterr().out == (
+        "Inference Providers\n"
+        "  anthropic: env ok\n"
+        "  openai: keyring missing\n"
+        "\nMCP Servers:\n"
+        "  tools (mcp-account): keyring ok\n"
+        "\nOther\n"
+        "  emb_model: env missing\n"
+        "  llm_model (model-account): keyring missing\n"
+    )
+
+
+def test_auth_list_uses_shared_config_search_primitive(tmp_path, monkeypatch):
+    system = tmp_path / "system.yaml"
+    explicit = tmp_path / "explicit.yaml"
+    system.write_text(
+        """
+llm_model:
+  model: openai:test
+  api_key:
+    env: SYSTEM_TOKEN
+"""
+    )
+    explicit.write_text(
+        """
+emb_model:
+  model: openai:embedding
+  api_key:
+    env: FILE_TOKEN
+"""
+    )
+    monkeypatch.setattr("ursa.cli.config.system_config_paths", lambda: [system])
+    monkeypatch.setattr("ursa.cli.config.user_config_paths", lambda: [])
+
+    lines = configured_secret_lines(explicit)["Other"]
+
+    assert lines == [
+        "  emb_model: env missing",
+        "  llm_model: env missing",
+    ]
+
+
+def test_auth_list_discovers_multiple_mcp_secrets(
+    tmp_path, monkeypatch, fake_keyring
+):
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
+mcp_servers:
+  tools:
+    transport: streamable-http
+    url: https://example.test/mcp
+    headers:
+      Authorization:
+        env: TOOLS_BEARER
+      X-API-Key:
+        keyring: true
+"""
+    )
+    monkeypatch.setattr(
+        "ursa.cli.auth.config_search_paths", lambda namespace: [config]
+    )
+
+    lines = configured_secret_lines(config)["MCP Servers:"]
+
+    assert lines == [
+        "  tools.Authorization: env missing",
+        "  tools.X-API-Key: keyring missing",
+    ]
+
+
+def test_auth_list_skips_empty_sections(tmp_path, monkeypatch, capsys):
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
+llm_model:
+  model: openai:test
+  api_key:
+    env: SIGNING_KEY
+"""
+    )
+    monkeypatch.setattr(
+        "ursa.cli.auth.config_search_paths", lambda namespace: [config]
+    )
+
+    list_credentials(config)
+
+    assert capsys.readouterr().out == "Other\n  llm_model: env missing\n"
+
+
+def test_auth_list_uses_secret_resolution(tmp_path, monkeypatch, capsys):
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
+llm_model:
+  model: openai:test
+  api_key:
+    env: MODEL_TOKEN
+"""
+    )
+    monkeypatch.setattr(
+        "ursa.cli.auth.config_search_paths", lambda namespace: [config]
+    )
+    calls = []
+
+    def resolve(reference, default_username=None):
+        calls.append((reference.env, default_username))
+        return None
+
+    monkeypatch.setattr("ursa.cli.auth.SecretReference.resolve", resolve)
+
+    list_credentials(config)
+
+    assert calls == [("MODEL_TOKEN", "openai")]
+    assert "llm_model: env missing" in capsys.readouterr().out
+
+
+def test_auth_list_can_show_secret_values(
+    tmp_path, monkeypatch, fake_keyring, capsys
+):
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
+inference_providers:
+  hosted:
+    api_key:
+      keyring: true
+"""
+    )
+    monkeypatch.setattr(
+        "ursa.cli.auth.config_search_paths", lambda namespace: [config]
+    )
+    fake_keyring[(KEYRING_SERVICE, "hosted")] = "visible-token"
+
+    list_credentials(config, show_secrets=True)
+
+    assert capsys.readouterr().out == (
+        "Inference Providers\n  hosted: keyring ok = visible-token\n"
+    )
+
+
+def test_auth_list_prints_nothing_when_no_secrets_exist(
+    tmp_path, monkeypatch, capsys
+):
+    config = tmp_path / "config.yaml"
+    config.write_text("workspace: .\n")
+    monkeypatch.setattr(
+        "ursa.cli.auth.config_search_paths", lambda namespace: [config]
+    )
+
+    list_credentials(config)
+
+    assert capsys.readouterr().out == ""
+
+
+def test_auth_parser_ignores_configuration_environment_variables(monkeypatch):
+    monkeypatch.setenv("URSA_AUTH__LOGIN__USERNAME", "from-environment")
+    monkeypatch.setenv("URSA_AUTH__LOGIN__FROM_ENV", "SECRET_VARIABLE")
+    monkeypatch.setenv("URSA_AUTH__LIST__CONFIG", "/ignored/config.yaml")
+
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["auth", "login"])
+
+    parsed = build_parser().parse_args(["auth", "login", "explicit"])
+    assert parsed.auth.login.username == "explicit"
+    assert parsed.auth.login.from_env is None
+
+    parsed = build_parser().parse_args(["auth", "list"])
+    assert parsed.auth.list.config is None
+    assert parsed.auth.list.show_secrets is False

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -267,7 +267,8 @@ def test_mcp_server_config_flag_sets_hosted_llm(monkeypatch, tmp_path):
 
     # HITL should be constructed with the config loaded from --config.
     (ursa_config,), _ = hitl_class.call_args
-    assert ursa_config.llm_model.model == "ollama:llama3.1"
+    assert ursa_config.llm_model.model == "llama3.1"
+    assert ursa_config.llm_model.model_provider == "ollama"
     assert ursa_config.llm_model.base_url == "http://localhost:11434"
 
 
@@ -298,7 +299,8 @@ def test_mcp_server_config_flag_parses_alongside_transport(
     ])
 
     (ursa_config,), _ = hitl_class.call_args
-    assert ursa_config.llm_model.model == "ollama:llama3.1"
+    assert ursa_config.llm_model.model == "llama3.1"
+    assert ursa_config.llm_model.model_provider == "ollama"
     mcp.run.assert_called_once_with(
         transport="streamable-http",
         log_level="INFO",
@@ -482,7 +484,8 @@ def test_config_env_cli_precedence(tmp_path, monkeypatch):
     )
     assert config_cli.workspace == cli_workspace
     assert config_cli.llm_model.model == "cli-model"
-    assert config_cli.emb_model.model == "openai:text-embedding-3-large"
+    assert config_cli.emb_model.model == "text-embedding-3-large"
+    assert config_cli.emb_model.model_provider == "openai"
 
 
 def test_config_file_env_interpolation(tmp_path, monkeypatch):
@@ -507,8 +510,10 @@ def test_config_file_env_interpolation(tmp_path, monkeypatch):
     config = _resolve_args(parser, ["--config", str(cfg_path)])
 
     assert config.workspace == env_workspace
-    assert config.llm_model.model == "openai:gpt-env"
-    assert config.emb_model.model == "openai:gpt-5"
+    assert config.llm_model.model == "gpt-env"
+    assert config.llm_model.model_provider == "openai"
+    assert config.emb_model.model == "gpt-5"
+    assert config.emb_model.model_provider == "openai"
 
 
 def test_config_file_with_extra_keys(tmp_path):
@@ -528,7 +533,8 @@ def test_config_file_with_extra_keys(tmp_path):
     parser = build_parser()
     config = _resolve_args(parser, ["--config", str(cfg_path)])
 
-    assert config.llm_model.model == "openai:gpt-5-small"
+    assert config.llm_model.model == "gpt-5-small"
+    assert config.llm_model.model_provider == "openai"
     assert config.llm_model.model_extra["seed"] == 123
     assert config.emb_model.model_extra["cache_dir"] == "/tmp/cache"
 
@@ -564,9 +570,11 @@ def test_config_file_and_cli_are_merged(tmp_path):
     )
 
     assert config.workspace == cli_workspace
-    assert config.llm_model.model == "openai:gpt-5-nano"
+    assert config.llm_model.model == "gpt-5-nano"
+    assert config.llm_model.model_provider == "openai"
     assert config.llm_model.model_extra["temperature"] == 0.4
-    assert config.emb_model.model == "openai:text-embedding-3-large"
+    assert config.emb_model.model == "text-embedding-3-large"
+    assert config.emb_model.model_provider == "openai"
     assert config.emb_model.model_extra["cache_dir"] == "/tmp/cache"
 
 
@@ -631,7 +639,8 @@ def test_merge_ursa_config_applies_sparse_overrides(tmp_path, monkeypatch):
     )
 
     assert config.group == "default"
-    assert config.llm_model.model == "openai:gpt-5.4"
+    assert config.llm_model.model == "gpt-5.4"
+    assert config.llm_model.model_provider == "openai"
     assert config.llm_model.ssl_verify is True
 
 
@@ -760,7 +769,8 @@ def test_merge_ursa_config_validates_provider_after_merging_layers(
     config = merge_ursa_config(Namespace(), overrides={})
 
     assert "openai_project" in config.inference_providers
-    assert config.llm_model.model == "openai:gpt-5.4-mini"
+    assert config.llm_model.model == "gpt-5.4-mini"
+    assert config.llm_model.model_provider == "openai"
     assert config.llm_model.inference_provider == "openai_project"
 
 
@@ -772,7 +782,8 @@ def test_model_config_kwargs_includes_extra():
     cfg.model_extra["timeout"] = 30
 
     kwargs = cfg.kwargs
-    assert kwargs["model"] == "openai:gpt-5"
+    assert kwargs["model"] == "gpt-5"
+    assert kwargs["model_provider"] == "openai"
     assert "http_client" in kwargs  # ssl_verify False triggers custom client
     assert "http_async_client" in kwargs
     assert kwargs["timeout"] == 30
@@ -783,7 +794,8 @@ def test_chat_model_config_kwargs_includes_max_completion_tokens():
 
     kwargs = cfg.kwargs
 
-    assert kwargs["model"] == "openai:gpt-5"
+    assert kwargs["model"] == "gpt-5"
+    assert kwargs["model_provider"] == "openai"
     assert kwargs["max_completion_tokens"] == 1024
 
 
@@ -803,7 +815,8 @@ def test_chat_model_config_initializes_chat_model(monkeypatch):
     result = cfg.init_chat_model()
 
     assert result == "chat-model"
-    assert captured_kwargs["model"] == "openai:gpt-5"
+    assert captured_kwargs["model"] == "gpt-5"
+    assert captured_kwargs["model_provider"] == "openai"
     assert captured_kwargs["max_completion_tokens"] == 1024
     assert captured_kwargs["use_responses_api"] is True
 
@@ -824,7 +837,8 @@ def test_emb_model_config_initializes_embedding_model(monkeypatch):
     result = cfg.init_embedding()
 
     assert result == "embedding-model"
-    assert captured_kwargs["model"] == "openai:text-embedding-3-large"
+    assert captured_kwargs["model"] == "text-embedding-3-large"
+    assert captured_kwargs["model_provider"] == "openai"
     assert "use_responses_api" not in captured_kwargs
 
 
@@ -833,7 +847,8 @@ def test_model_config_openai_uses_truststore_client():
 
     kwargs = cfg.kwargs
 
-    assert kwargs["model"] == "openai:text-embedding-3-large"
+    assert kwargs["model"] == "text-embedding-3-large"
+    assert kwargs["model_provider"] == "openai"
     assert "http_client" in kwargs
     assert "http_async_client" in kwargs
 
@@ -843,7 +858,8 @@ def test_model_config_ollama_uses_client_kwargs():
 
     kwargs = cfg.kwargs
 
-    assert kwargs["model"] == "ollama:nomic-embed-text:latest"
+    assert kwargs["model"] == "nomic-embed-text:latest"
+    assert kwargs["model_provider"] == "ollama"
     assert "http_client" not in kwargs
     assert "http_async_client" not in kwargs
     assert kwargs["client_kwargs"]["verify"] is not False

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -1,10 +1,13 @@
+import gc
 import importlib
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 import yaml
 from jsonargparse import Namespace
 from openai import OpenAIError
+from pydantic import ValidationError
 
 from ursa.cli import (
     build_parser,
@@ -17,6 +20,7 @@ from ursa.cli.config import (
     ModelConfig,
     UrsaConfig,
     config_search_paths,
+    load_config_file,
     merge_ursa_config,
     resolve_ursa_config,
     xdg_config_search_paths,
@@ -44,9 +48,12 @@ def _stub_mcp_server(monkeypatch):
 
 
 def _stub_cli_repl(monkeypatch):
-    monkeypatch.setattr("ursa.cli.hitl.HITL", MagicMock())
-    monkeypatch.setattr("ursa.cli.hitl.UrsaRepl", MagicMock())
+    hitl_class = MagicMock()
+    repl_class = MagicMock()
+    monkeypatch.setattr("ursa.cli.hitl.HITL", hitl_class)
+    monkeypatch.setattr("ursa.cli.hitl.UrsaRepl", repl_class)
     monkeypatch.setattr("ursa.cli.inject_truststore_into_ssl", lambda: None)
+    return hitl_class, repl_class
 
 
 def _parse_config_args(parser, args):
@@ -105,8 +112,9 @@ def test_cli_does_not_warn_without_legacy_checkpoint(
     assert capsys.readouterr().err == ""
 
 
+@pytest.mark.parametrize("args", [[], ["mcp-server"]])
 def test_cli_reports_model_initialization_error_without_traceback(
-    monkeypatch, capsys
+    monkeypatch, capsys, args
 ):
     error = OpenAIError(
         "The api_key client option must be set by setting the "
@@ -116,12 +124,106 @@ def test_cli_reports_model_initialization_error_without_traceback(
     monkeypatch.setattr("ursa.cli.inject_truststore_into_ssl", lambda: None)
 
     with pytest.raises(SystemExit, match="2"):
-        main([])
+        main(args)
 
     stderr = capsys.readouterr().err
     assert stderr.startswith("Error: unable to initialize the language model.")
     assert "OPENAI_API_KEY" in stderr
     assert "Traceback" not in stderr
+
+
+def test_exec_runs_prompt_with_repl(monkeypatch):
+    hitl_class, repl_class = _stub_cli_repl(monkeypatch)
+
+    main(["exec", "summarize this"])
+
+    hitl = hitl_class.return_value
+    repl_class.assert_called_once_with(hitl)
+    repl_class.return_value.run_prompt.assert_called_once_with("summarize this")
+
+
+@pytest.mark.parametrize(
+    ("modern_env", "cli_args", "expected"),
+    [
+        (None, [], "legacy-agent"),
+        ("modern-agent", [], "modern-agent"),
+        (None, ["--name", "cli-agent"], "cli-agent"),
+    ],
+)
+def test_legacy_ursa_name_is_supported_with_deprecation_warning(
+    monkeypatch, modern_env, cli_args, expected
+):
+    hitl_class, _ = _stub_cli_repl(monkeypatch)
+    monkeypatch.setenv("URSA_NAME", "legacy-agent")
+    if modern_env is not None:
+        monkeypatch.setenv("URSA_AGENT_NAME", modern_env)
+
+    with pytest.warns(FutureWarning, match="URSA_NAME is deprecated"):
+        main(cli_args)
+
+    (config,), _ = hitl_class.call_args
+    assert config.agent_name == expected
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["list-rag-agents"],
+        ["show-rag-agent", "docs"],
+        ["delete-rag-agent", "docs"],
+        ["save-rag-agent", "docs"],
+    ],
+)
+def test_rag_metadata_commands_dispatch_before_config_resolution(
+    monkeypatch, args
+):
+    monkeypatch.setattr("ursa.cli.inject_truststore_into_ssl", lambda: None)
+    handle = MagicMock(return_value=True)
+    monkeypatch.setattr("ursa.cli.handle_rag_command", handle)
+    monkeypatch.setattr(
+        "ursa.cli.resolve_config",
+        MagicMock(side_effect=AssertionError("must not resolve config")),
+    )
+
+    main(args)
+
+    handle.assert_called_once()
+    assert len(handle.call_args.args) == 1
+
+
+def test_rag_model_commands_resolve_with_subcommand_group(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr("ursa.cli.inject_truststore_into_ssl", lambda: None)
+    config_file = tmp_path / "rag.yaml"
+    config_file.write_text(
+        yaml.safe_dump({
+            "group": "file-group",
+            "llm_model": {"base_url": "https://models.example/v1"},
+        }),
+        encoding="utf-8",
+    )
+    policy_calls = []
+    monkeypatch.setattr(
+        "ursa.cli.config.enforce_group_base_url_policy",
+        lambda base_url, group: policy_calls.append((base_url, group)),
+    )
+    monkeypatch.setattr(
+        "ursa.cli.handle_rag_command", MagicMock(return_value=True)
+    )
+
+    main([
+        "rag-query",
+        "--name",
+        "docs",
+        "--group",
+        "rag-group",
+        "--config",
+        str(config_file),
+        "question",
+    ])
+
+    assert policy_calls == [("https://models.example/v1", "rag-group")]
 
 
 def test_mcp_server_passes_only_stdio_run_options(monkeypatch):
@@ -255,8 +357,8 @@ def test_parse_print_config_spec_accepts_stage_only_and_level_stage():
         "file",
         "resolved",
     )
-    assert parse_print_config_spec("project+,resolved") == (
-        "project+",
+    assert parse_print_config_spec("file+,resolved") == (
+        "file+",
         "resolved",
     )
 
@@ -265,6 +367,12 @@ def test_parse_print_config_spec_accepts_stage_only_and_level_stage():
 def test_parse_print_config_spec_rejects_invalid_values(spec):
     with pytest.raises(ValueError):
         parse_print_config_spec(spec)
+
+
+@pytest.mark.parametrize("spec", ["bogus", "final,bogus", "project,resolved"])
+def test_print_config_parser_rejects_invalid_values(spec):
+    with pytest.raises(SystemExit, match="2"):
+        build_parser().parse_args([f"--print-config={spec}"])
 
 
 def test_resolve_config_preserves_cli_tmp_workspace_owner():
@@ -523,6 +631,37 @@ def test_merge_ursa_config_applies_sparse_overrides(tmp_path, monkeypatch):
     assert config.llm_model.ssl_verify is True
 
 
+def test_merge_ursa_config_normalizes_empty_yaml(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "empty.yaml"
+    cfg_path.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        "ursa.cli.config.config_search_paths",
+        lambda cfg, level="final": [cfg_path],
+    )
+
+    config = merge_ursa_config(Namespace(), overrides={})
+
+    assert config == UrsaConfig()
+    assert load_config_file(cfg_path) == {}
+
+
+def test_load_config_file_rejects_non_mapping_yaml(tmp_path):
+    cfg_path = tmp_path / "list.yaml"
+    cfg_path.write_text("- invalid\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must contain a mapping"):
+        load_config_file(cfg_path)
+
+
+def test_agent_config_null_is_normalized_with_deprecation_warning(caplog):
+    caplog.set_level("WARNING", logger="ursa.cli.config")
+
+    config = UrsaConfig(agent_config=None)
+
+    assert config.agent_config == {}
+    assert "agent_config to null is deprecated" in caplog.text
+
+
 def test_xdg_config_search_paths_honor_env_overrides(tmp_path, monkeypatch):
     xdg_home = tmp_path / "xdg-home"
     xdg_dir_1 = tmp_path / "xdg-dir-1"
@@ -532,15 +671,28 @@ def test_xdg_config_search_paths_honor_env_overrides(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_CONFIG_DIRS", f"{xdg_dir_1}:{xdg_dir_2}")
 
     assert xdg_config_search_paths() == [
-        xdg_dir_1 / "ursa" / "config.yaml",
         xdg_dir_2 / "ursa" / "config.yaml",
+        xdg_dir_1 / "ursa" / "config.yaml",
         xdg_home / "ursa" / "config.yaml",
     ]
 
 
-def test_config_search_paths_returns_existing_sources_in_precedence_order(
-    tmp_path, monkeypatch
-):
+def test_first_xdg_config_dir_has_higher_precedence(tmp_path, monkeypatch):
+    high = tmp_path / "high" / "ursa" / "config.yaml"
+    low = tmp_path / "low" / "ursa" / "config.yaml"
+    high.parent.mkdir(parents=True)
+    low.parent.mkdir(parents=True)
+    high.write_text("group: high\n", encoding="utf-8")
+    low.write_text("group: low\n", encoding="utf-8")
+    monkeypatch.setenv("XDG_CONFIG_DIRS", f"{high.parents[1]}:{low.parents[1]}")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "missing"))
+
+    config = merge_ursa_config(Namespace(), overrides={})
+
+    assert config.group == "high"
+
+
+def test_config_search_paths_ignores_project_config(tmp_path, monkeypatch):
     xdg_dir = tmp_path / "xdg"
     project_dir = tmp_path / "project"
     explicit_cfg = tmp_path / "explicit.yaml"
@@ -557,7 +709,6 @@ def test_config_search_paths_returns_existing_sources_in_precedence_order(
 
     assert config_search_paths(Namespace(config=explicit_cfg)) == [
         user_cfg,
-        project_cfg,
         explicit_cfg,
     ]
 
@@ -833,6 +984,20 @@ def test_unknown_inference_provider_is_validation_error():
         )
 
 
+def test_invalid_provider_catalog_preserves_validation_error():
+    with pytest.raises(ValidationError) as exc_info:
+        UrsaConfig.model_validate({
+            "inference_providers": {"shared": {"ssl_verify": "not-a-boolean"}},
+            "llm_model": {"inference_provider": "shared"},
+        })
+
+    assert exc_info.value.errors()[0]["loc"] == (
+        "inference_providers",
+        "shared",
+        "ssl_verify",
+    )
+
+
 def test_model_config_kwargs_rejects_unresolved_inference_provider():
     cfg = ChatModelConfig(
         model="openai:gpt-5",
@@ -897,7 +1062,7 @@ def test_resolve_ursa_config_applies_inference_provider():
         ),
     ],
 )
-def test_print_config_omits_defaults_and_nulls(
+def test_print_config_includes_defaults_and_nulls(
     monkeypatch, capsys, stage, expected_model
 ):
     merged = UrsaConfig(
@@ -938,11 +1103,16 @@ def test_print_config_omits_defaults_and_nulls(
     assert print_config(Namespace(print_config=stage), {}) is True
 
     output = yaml.safe_load(capsys.readouterr().out)
-    assert "workspace" not in output
-    assert output["llm_model"] == expected_model
+    assert output["workspace"] == "."
+    assert output["agent_name"] is None
+    assert output["emb_model"] is None
+    assert output["agent_config"] == {}
+    for key, value in expected_model.items():
+        assert output["llm_model"][key] == value
     assert output["inference_providers"] == {
         "shared": {
             "base_url": "https://provider.example/v1",
+            "api_key_env": None,
             "ssl_verify": False,
         }
     }
@@ -950,6 +1120,11 @@ def test_print_config_omits_defaults_and_nulls(
         "example": {
             "transport": "stdio",
             "command": "example-server",
+            "args": [],
+            "env": None,
+            "cwd": None,
+            "encoding": "utf-8",
+            "encoding_error_handler": "strict",
         }
     }
 
@@ -981,6 +1156,29 @@ def test_resolve_ursa_config_creates_tmp_workspace():
     assert resolved.workspace.exists()
     assert resolved._temp_workspace is not None
     assert resolved._temp_workspace.name == str(resolved.workspace)
+
+
+def test_resolve_ursa_config_uses_existing_literal_tmp_directory(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "tmp").mkdir()
+
+    resolved = resolve_ursa_config(UrsaConfig(workspace="tmp"))
+
+    assert resolved.workspace == Path("tmp")
+    assert resolved._temp_workspace is None
+
+
+def test_resolve_ursa_config_reuses_tmp_workspace_owner():
+    first = resolve_ursa_config(UrsaConfig(workspace="tmp"))
+    second = resolve_ursa_config(first)
+    workspace = second.workspace
+
+    assert second._temp_workspace is first._temp_workspace
+    del first
+    gc.collect()
+    assert workspace.exists()
 
 
 def test_resolve_ursa_config_checks_group_base_url_policy(monkeypatch):

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -6,7 +6,6 @@ import yaml
 from openai import OpenAIError
 
 from ursa.cli import (
-    _xdg_config_search_paths,
     build_parser,
     main,
     resolve_config,
@@ -16,9 +15,14 @@ from ursa.cli.config import (
     EmbModelConfig,
     ModelConfig,
     UrsaConfig,
+    merge_ursa_config,
     resolve_ursa_config,
+    xdg_config_search_paths,
 )
-from ursa.cli.print_config import parse_print_config_spec
+from ursa.cli.print_config import (
+    parse_print_config_spec,
+    print_config,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -41,6 +45,19 @@ def _stub_cli_repl(monkeypatch):
     monkeypatch.setattr("ursa.cli.hitl.HITL", MagicMock())
     monkeypatch.setattr("ursa.cli.hitl.UrsaRepl", MagicMock())
     monkeypatch.setattr("ursa.cli.inject_truststore_into_ssl", lambda: None)
+
+
+def _parse_config_args(parser, args):
+    """Parse the runtime namespace and its sparse config overrides."""
+    return (
+        parser.parse_args(args),
+        parser.parse_args(args, defaults=False),
+    )
+
+
+def _resolve_args(parser, args):
+    cfg, overrides = _parse_config_args(parser, args)
+    return resolve_config(cfg, overrides)
 
 
 def test_cli_warns_about_legacy_unnamed_checkpoint(
@@ -208,16 +225,18 @@ def test_mcp_server_passes_http_options_when_running(monkeypatch):
 
 def test_cli_parses_typed_flags(tmp_path):
     parser = build_parser()
-    args = parser.parse_args([
-        "--workspace",
-        str(tmp_path / "workspace"),
-        "--llm_model.model",
-        "openai:gpt-5-nano",
-        "--llm_model.max_completion_tokens",
-        "2048",
-    ])
+    config = _resolve_args(
+        parser,
+        [
+            "--workspace",
+            str(tmp_path / "workspace"),
+            "--llm_model.model",
+            "openai:gpt-5-nano",
+            "--llm_model.max_completion_tokens",
+            "2048",
+        ],
+    )
 
-    config = UrsaConfig.from_namespace(args)
     assert config.workspace == tmp_path / "workspace"
     assert config.llm_model.model == "openai:gpt-5-nano"
     assert config.llm_model.max_completion_tokens == 2048
@@ -228,11 +247,11 @@ def test_print_config_flag_defaults_to_resolved_string(monkeypatch, tmp_path):
     monkeypatch.setenv("XDG_CONFIG_DIRS", str(tmp_path / "xdg-dirs-missing"))
     monkeypatch.chdir(tmp_path)
     parser = build_parser()
-    args = parser.parse_args(["--print-config"])
+    args, overrides = _parse_config_args(parser, ["--print-config"])
 
     assert args["print_config"] == "resolved"
 
-    config = resolve_config(args)
+    config = resolve_config(args, overrides)
     assert config.model_dump() == resolve_ursa_config(UrsaConfig()).model_dump()
 
 
@@ -241,6 +260,10 @@ def test_parse_print_config_spec_accepts_stage_only_and_level_stage():
     assert parse_print_config_spec("merged") == ("final", "merged")
     assert parse_print_config_spec("file,resolved") == (
         "file",
+        "resolved",
+    )
+    assert parse_print_config_spec("project+,resolved") == (
+        "project+",
         "resolved",
     )
 
@@ -253,9 +276,7 @@ def test_parse_print_config_spec_rejects_invalid_values(spec):
 
 def test_resolve_config_preserves_cli_tmp_workspace_owner():
     parser = build_parser()
-    args = parser.parse_args(["--workspace", "tmp"])
-
-    config = resolve_config(args)
+    config = _resolve_args(parser, ["--workspace", "tmp"])
 
     assert config.workspace.exists()
     assert config._temp_workspace is not None
@@ -266,9 +287,7 @@ def test_resolve_config_preserves_file_tmp_workspace_owner(tmp_path):
     cfg_path = tmp_path / "ursa.yml"
     cfg_path.write_text("workspace: tmp\n")
     parser = build_parser()
-    args = parser.parse_args(["--config", str(cfg_path)])
-
-    config = resolve_config(args)
+    config = _resolve_args(parser, ["--config", str(cfg_path)])
 
     assert config.workspace.exists()
     assert config._temp_workspace is not None
@@ -277,9 +296,7 @@ def test_resolve_config_preserves_file_tmp_workspace_owner(tmp_path):
 
 def test_cli_applies_chat_only_openai_defaults_to_llm_model():
     parser = build_parser()
-    args = parser.parse_args([])
-
-    config = resolve_config(args)
+    config = _resolve_args(parser, [])
 
     assert isinstance(config.llm_model, ChatModelConfig)
     assert config.llm_model.kwargs["use_responses_api"] is True
@@ -287,12 +304,13 @@ def test_cli_applies_chat_only_openai_defaults_to_llm_model():
 
 def test_cli_does_not_apply_chat_only_openai_defaults_to_emb_model():
     parser = build_parser()
-    args = parser.parse_args([
-        "--emb_model.model",
-        "openai:text-embedding-3-large",
-    ])
-
-    config = resolve_config(args)
+    config = _resolve_args(
+        parser,
+        [
+            "--emb_model.model",
+            "openai:text-embedding-3-large",
+        ],
+    )
 
     assert isinstance(config.emb_model, EmbModelConfig)
     assert not isinstance(config.emb_model, ChatModelConfig)
@@ -301,22 +319,22 @@ def test_cli_does_not_apply_chat_only_openai_defaults_to_emb_model():
 
 def test_print_config_yaml_round_trip(tmp_path):
     parser = build_parser()
-    args = parser.parse_args([
-        "--workspace",
-        str(tmp_path / "original"),
-        "--llm_model.model",
-        "openai:gpt-5-nano",
-    ])
-
-    original_config = resolve_config(args)
+    original_config = _resolve_args(
+        parser,
+        [
+            "--workspace",
+            str(tmp_path / "original"),
+            "--llm_model.model",
+            "openai:gpt-5-nano",
+        ],
+    )
     yaml_text = yaml.safe_dump(original_config.model_dump())
 
     cfg_path = tmp_path / "round-trip.yml"
     cfg_path.write_text(yaml_text)
 
     parser = build_parser()
-    loaded_args = parser.parse_args(["--config", str(cfg_path)])
-    loaded_config = resolve_config(loaded_args)
+    loaded_config = _resolve_args(parser, ["--config", str(cfg_path)])
 
     assert loaded_config.model_dump() == original_config.model_dump()
 
@@ -338,24 +356,25 @@ def test_config_env_cli_precedence(tmp_path, monkeypatch):
 
     parser = build_parser()
 
-    args_env = parser.parse_args(["--config", str(cfg_path)])
-    config_env = resolve_config(args_env)
+    config_env = _resolve_args(parser, ["--config", str(cfg_path)])
     assert config_env.workspace == env_workspace
     assert config_env.llm_model.model == "env-model"
 
     cli_workspace = tmp_path / "cli-workspace"
     cli_workspace.mkdir()
-    args_cli = parser.parse_args([
-        "--config",
-        str(cfg_path),
-        "--emb_model.model",
-        "openai:text-embedding-3-large",
-        "--workspace",
-        str(cli_workspace),
-        "--llm_model.model",
-        "cli-model",
-    ])
-    config_cli = resolve_config(args_cli)
+    config_cli = _resolve_args(
+        parser,
+        [
+            "--config",
+            str(cfg_path),
+            "--emb_model.model",
+            "openai:text-embedding-3-large",
+            "--workspace",
+            str(cli_workspace),
+            "--llm_model.model",
+            "cli-model",
+        ],
+    )
     assert config_cli.workspace == cli_workspace
     assert config_cli.llm_model.model == "cli-model"
     assert config_cli.emb_model.model == "openai:text-embedding-3-large"
@@ -380,8 +399,7 @@ def test_config_file_env_interpolation(tmp_path, monkeypatch):
     )
 
     parser = build_parser()
-    args = parser.parse_args(["--config", str(cfg_path)])
-    config = resolve_config(args)
+    config = _resolve_args(parser, ["--config", str(cfg_path)])
 
     assert config.workspace == env_workspace
     assert config.llm_model.model == "openai:gpt-env"
@@ -403,8 +421,7 @@ def test_config_file_with_extra_keys(tmp_path):
     )
 
     parser = build_parser()
-    args = parser.parse_args(["--config", str(cfg_path)])
-    config = resolve_config(args)
+    config = _resolve_args(parser, ["--config", str(cfg_path)])
 
     assert config.llm_model.model == "openai:gpt-5-small"
     assert config.llm_model.model_extra["seed"] == 123
@@ -427,24 +444,104 @@ def test_config_file_and_cli_are_merged(tmp_path):
 
     cli_workspace = tmp_path / "cli-workspace"
     parser = build_parser()
-    args = parser.parse_args([
-        "--config",
-        str(cfg_path),
-        "--emb_model.model",
-        "openai:text-embedding-3-large",
-        "--workspace",
-        str(cli_workspace),
-        "--llm_model.model",
-        "openai:gpt-5-nano",
-    ])
-
-    config = resolve_config(args)
+    config = _resolve_args(
+        parser,
+        [
+            "--config",
+            str(cfg_path),
+            "--emb_model.model",
+            "openai:text-embedding-3-large",
+            "--workspace",
+            str(cli_workspace),
+            "--llm_model.model",
+            "openai:gpt-5-nano",
+        ],
+    )
 
     assert config.workspace == cli_workspace
     assert config.llm_model.model == "openai:gpt-5-nano"
     assert config.llm_model.model_extra["temperature"] == 0.4
     assert config.emb_model.model == "openai:text-embedding-3-large"
     assert config.emb_model.model_extra["cache_dir"] == "/tmp/cache"
+
+
+def test_sparse_parser_preserves_only_explicit_config_values():
+    parser = build_parser()
+
+    assert parser.parse_args([], defaults=False).as_dict() == {}
+    assert parser.parse_args(
+        ["--group", "default", "--llm_model.ssl_verify", "true"],
+        defaults=False,
+    ).as_dict() == {
+        "group": "default",
+        "llm_model": {"ssl_verify": True},
+    }
+
+
+@pytest.mark.parametrize(
+    ("subcommand_args", "expected_subcommand"),
+    [
+        ([], None),
+        (["exec", "hello"], "exec"),
+        (["mcp-server"], "mcp-server"),
+        (
+            ["rag-query", "--name", "docs", "What is indexed?"],
+            "rag-query",
+        ),
+    ],
+)
+def test_explicit_schema_defaults_override_file_for_all_runtime_commands(
+    tmp_path, subcommand_args, expected_subcommand
+):
+    cfg_path = tmp_path / "ursa.yml"
+    cfg_path.write_text(
+        yaml.safe_dump({
+            "group": "restricted",
+            "llm_model": {
+                "model": "openai:file-model",
+                "ssl_verify": False,
+            },
+        })
+    )
+    parser = build_parser()
+    args = [
+        "--config",
+        str(cfg_path),
+        "--group",
+        "default",
+        "--llm_model.model",
+        "openai:gpt-5.4",
+        "--llm_model.ssl_verify",
+        "true",
+        *subcommand_args,
+    ]
+    cfg, overrides = _parse_config_args(parser, args)
+
+    config = resolve_config(cfg, overrides)
+
+    assert cfg.get("subcommand") == expected_subcommand
+    assert config.group == "default"
+    assert config.llm_model.model == "openai:gpt-5.4"
+    assert config.llm_model.ssl_verify is True
+
+
+def test_explicit_environment_defaults_override_config_file(
+    tmp_path, monkeypatch
+):
+    cfg_path = tmp_path / "ursa.yml"
+    cfg_path.write_text(
+        yaml.safe_dump({
+            "group": "restricted",
+            "llm_model": {"ssl_verify": False},
+        })
+    )
+    monkeypatch.setenv("URSA_GROUP", "default")
+    monkeypatch.setenv("URSA_LLM_MODEL__SSL_VERIFY", "true")
+
+    config = _resolve_args(build_parser(), ["--config", str(cfg_path)])
+
+    assert config.group == "default"
+    assert config.llm_model.ssl_verify is True
 
 
 def test_xdg_config_search_paths_honor_env_overrides(tmp_path, monkeypatch):
@@ -455,7 +552,7 @@ def test_xdg_config_search_paths_honor_env_overrides(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_home))
     monkeypatch.setenv("XDG_CONFIG_DIRS", f"{xdg_dir_1}:{xdg_dir_2}")
 
-    assert _xdg_config_search_paths() == [
+    assert xdg_config_search_paths() == [
         xdg_dir_1 / "ursa" / "config.yaml",
         xdg_dir_2 / "ursa" / "config.yaml",
         xdg_home / "ursa" / "config.yaml",
@@ -532,18 +629,19 @@ def test_resolve_config_merges_xdg_local_file_and_cli_layers(
     monkeypatch.setenv("XDG_CONFIG_DIRS", str(xdg_dir_1))
 
     parser = build_parser()
-    args = parser.parse_args([
-        "--config",
-        str(explicit_cfg),
-        "--workspace",
-        str(cli_workspace),
-        "--group",
-        "cli-group",
-        "--llm_model.model",
-        "openai:gpt-5-nano",
-    ])
-
-    config = resolve_config(args)
+    config = _resolve_args(
+        parser,
+        [
+            "--config",
+            str(explicit_cfg),
+            "--workspace",
+            str(cli_workspace),
+            "--group",
+            "cli-group",
+            "--llm_model.model",
+            "openai:gpt-5-nano",
+        ],
+    )
 
     assert config.workspace == cli_workspace
     assert config.group == "cli-group"
@@ -606,13 +704,55 @@ def test_resolve_config_uses_local_and_xdg_defaults_without_explicit_config(
     local_path.write_text(local_config.read_text())
 
     parser = build_parser()
-    args = parser.parse_args([])
-    config = resolve_config(args)
+    config = _resolve_args(parser, [])
 
     assert config.workspace == Path("xdg-dir-workspace")
     assert config.group == "local-group"
     assert config.llm_model.model == "openai:gpt-5-mini"
     assert config.llm_model.base_url == "https://local.example/v1"
+
+
+def test_project_config_can_select_provider_from_user_config(
+    tmp_path, monkeypatch
+):
+    xdg_home = tmp_path / "xdg-home"
+    project_dir = tmp_path / "project"
+    user_config = xdg_home / "ursa" / "config.yaml"
+    project_config = project_dir / ".ursa" / "config.yaml"
+    user_config.parent.mkdir(parents=True)
+    project_config.parent.mkdir(parents=True)
+    user_config.write_text(
+        yaml.safe_dump({
+            "inference_providers": {
+                "openai_project": {
+                    "base_url": "https://project.example/v1",
+                    "ssl_verify": False,
+                }
+            }
+        })
+    )
+    project_config.write_text(
+        yaml.safe_dump({
+            "llm_model": {
+                "model": "openai:gpt-5.4-mini",
+                "inference_provider": "openai_project",
+            }
+        })
+    )
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_home))
+    monkeypatch.chdir(project_dir)
+
+    parser = build_parser()
+    args, overrides = _parse_config_args(parser, [])
+    config = resolve_config(args, overrides)
+
+    assert config.llm_model.model == "openai:gpt-5.4-mini"
+    assert config.llm_model.base_url == "https://project.example/v1"
+    assert config.llm_model.ssl_verify is False
+    assert config.llm_model.inference_provider is None
+
+    cumulative = resolve_ursa_config(merge_ursa_config(args, "project+"))
+    assert cumulative.llm_model.base_url == "https://project.example/v1"
 
 
 def test_model_config_kwargs_includes_extra():
@@ -659,7 +799,7 @@ def test_chat_model_config_initializes_chat_model(monkeypatch):
     assert captured_kwargs["use_responses_api"] is True
 
 
-def test_chat_model_config_requires_referenced_provider_mapping(monkeypatch):
+def test_chat_model_config_rejects_unresolved_provider(monkeypatch):
     monkeypatch.setattr(
         "ursa.cli.config.init_chat_model",
         lambda **kwargs: "chat-model",
@@ -669,7 +809,10 @@ def test_chat_model_config_requires_referenced_provider_mapping(monkeypatch):
         inference_provider="shared",
     )
 
-    with pytest.raises(ValueError, match="Unknown inference_provider 'shared'"):
+    with pytest.raises(
+        ValueError,
+        match="references unresolved inference provider 'shared'",
+    ):
         cfg.init_chat_model()
 
 
@@ -717,14 +860,16 @@ def test_model_config_ollama_uses_client_kwargs():
 def test_api_key_env(monkeypatch, tmp_path):
     monkeypatch.setenv("TEST_ENV_API_KEY", "super-secret-key")
     parser = build_parser()
-    args = parser.parse_args([
-        "--workspace",
-        str(tmp_path),
-        "--llm_model.api_key_env",
-        "TEST_ENV_API_KEY",
-    ])
+    config = _resolve_args(
+        parser,
+        [
+            "--workspace",
+            str(tmp_path),
+            "--llm_model.api_key_env",
+            "TEST_ENV_API_KEY",
+        ],
+    )
 
-    config = UrsaConfig.from_namespace(args)
     assert config.llm_model.api_key_env == "TEST_ENV_API_KEY"
     assert config.llm_model.kwargs["api_key"] == "super-secret-key"
     assert "api_key_env" not in config.llm_model.kwargs.keys()
@@ -863,24 +1008,44 @@ def test_unknown_inference_provider_is_validation_error():
         )
 
 
-def test_inference_provider_is_not_forwarded_to_langchain_kwargs():
+def test_model_config_kwargs_rejects_unresolved_inference_provider():
     cfg = ChatModelConfig(
         model="openai:gpt-5",
         inference_provider="shared-provider",
     )
 
-    kwargs = cfg.kwargs
+    with pytest.raises(
+        ValueError,
+        match="references unresolved inference provider 'shared-provider'",
+    ):
+        _ = cfg.kwargs
 
-    assert "inference_provider" not in kwargs
 
-
-def test_model_config_resolve_provider_materializes_ssl_default():
+def test_model_config_ssl_verify_defaults_to_true():
     cfg = ChatModelConfig(model="openai:gpt-5")
 
     resolved = cfg.resolve_inference_provider({})
 
-    assert cfg.ssl_verify is None
+    assert cfg.ssl_verify is True
     assert resolved.ssl_verify is True
+
+
+def test_model_config_explicit_null_extra_clears_provider_default():
+    config = UrsaConfig(
+        inference_providers={"shared": {"timeout": 30}},
+        llm_model={
+            "model": "openai:gpt-5",
+            "inference_provider": "shared",
+            "timeout": None,
+        },
+    )
+
+    resolved = config.llm_model.resolve_inference_provider(
+        config.inference_providers
+    )
+
+    assert resolved.model_extra["timeout"] is None
+    assert "timeout" not in resolved.kwargs
 
 
 def test_resolve_config_resolves_inference_provider_at_final_stage(tmp_path):
@@ -898,8 +1063,7 @@ def test_resolve_config_resolves_inference_provider_at_final_stage(tmp_path):
     )
 
     parser = build_parser()
-    args = parser.parse_args(["--config", str(cfg_path)])
-    config = resolve_config(args)
+    config = _resolve_args(parser, ["--config", str(cfg_path)])
 
     assert config.llm_model.inference_provider is None
     assert config.llm_model.base_url == "https://api.openai.com/v1"
@@ -922,9 +1086,75 @@ def test_resolve_config_inherits_provider_ssl_verify(tmp_path):
     )
 
     parser = build_parser()
-    config = resolve_config(parser.parse_args(["--config", str(cfg_path)]))
+    config = _resolve_args(parser, ["--config", str(cfg_path)])
 
     assert config.llm_model.ssl_verify is False
+
+
+@pytest.mark.parametrize(
+    ("stage", "expected_model"),
+    [
+        ("merged", {"inference_provider": "shared"}),
+        (
+            "resolved",
+            {
+                "base_url": "https://provider.example/v1",
+                "ssl_verify": False,
+            },
+        ),
+    ],
+)
+def test_print_config_omits_defaults_and_nulls(
+    tmp_path, capsys, stage, expected_model
+):
+    cfg_path = tmp_path / "ursa.yml"
+    cfg_path.write_text(
+        yaml.safe_dump({
+            "inference_providers": {
+                "shared": {
+                    "base_url": "https://provider.example/v1",
+                    "ssl_verify": False,
+                }
+            },
+            "llm_model": {
+                "model": "openai:gpt-5.4",
+                "inference_provider": "shared",
+            },
+            "mcp_servers": {
+                "example": {
+                    "transport": "stdio",
+                    "command": "example-server",
+                }
+            },
+        })
+    )
+    parser = build_parser()
+    args, overrides = _parse_config_args(
+        parser,
+        [
+            "--config",
+            str(cfg_path),
+            f"--print-config={stage}",
+        ],
+    )
+
+    assert print_config(args, overrides) is True
+
+    output = yaml.safe_load(capsys.readouterr().out)
+    assert "workspace" not in output
+    assert output["llm_model"] == expected_model
+    assert output["inference_providers"] == {
+        "shared": {
+            "base_url": "https://provider.example/v1",
+            "ssl_verify": False,
+        }
+    }
+    assert output["mcp_servers"] == {
+        "example": {
+            "transport": "stdio",
+            "command": "example-server",
+        }
+    }
 
 
 def test_resolve_ursa_config_promotes_use_web_to_agent_config():

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -668,7 +668,11 @@ def test_xdg_config_search_paths_honor_env_overrides(tmp_path, monkeypatch):
     xdg_dir_2 = tmp_path / "xdg-dir-2"
 
     monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_home))
-    monkeypatch.setenv("XDG_CONFIG_DIRS", f"{xdg_dir_1}:{xdg_dir_2}")
+    path_list_separator = ";" if tmp_path.drive else ":"
+    monkeypatch.setenv(
+        "XDG_CONFIG_DIRS",
+        path_list_separator.join((str(xdg_dir_1), str(xdg_dir_2))),
+    )
 
     assert xdg_config_search_paths() == [
         xdg_dir_2 / "ursa" / "config.yaml",
@@ -684,7 +688,13 @@ def test_first_xdg_config_dir_has_higher_precedence(tmp_path, monkeypatch):
     low.parent.mkdir(parents=True)
     high.write_text("group: high\n", encoding="utf-8")
     low.write_text("group: low\n", encoding="utf-8")
-    monkeypatch.setenv("XDG_CONFIG_DIRS", f"{high.parents[1]}:{low.parents[1]}")
+    path_list_separator = ";" if tmp_path.drive else ":"
+    monkeypatch.setenv(
+        "XDG_CONFIG_DIRS",
+        path_list_separator.join(
+            (str(high.parents[1]), str(low.parents[1]))
+        ),
+    )
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "missing"))
 
     config = merge_ursa_config(Namespace(), overrides={})

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -5,12 +5,8 @@ import pytest
 import yaml
 from openai import OpenAIError
 
-from ursa.cli import (
-    _xdg_config_search_paths,
-    build_parser,
-    main,
-    resolve_config,
-)
+from ursa.cli import _xdg_config_search_paths, build_parser, main, resolve_config
+from ursa.cli.print_config import parse_print_config_spec
 from ursa.cli.config import (
     ChatModelConfig,
     EmbModelConfig,
@@ -216,7 +212,7 @@ def test_cli_parses_typed_flags(tmp_path):
     assert config.llm_model.max_completion_tokens == 2048
 
 
-def test_print_config_flag_sets_bool_and_preserves_defaults(
+def test_print_config_flag_defaults_to_resolved_string(
     monkeypatch, tmp_path
 ):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-missing"))
@@ -225,10 +221,25 @@ def test_print_config_flag_sets_bool_and_preserves_defaults(
     parser = build_parser()
     args = parser.parse_args(["--print-config"])
 
-    assert args["print_config"] is True
+    assert args["print_config"] == "resolved"
 
     config = resolve_config(args)
-    assert config.model_dump() == UrsaConfig().model_dump()
+    assert config.model_dump() == resolve_ursa_config(UrsaConfig()).model_dump()
+
+
+def test_parse_print_config_spec_accepts_stage_only_and_level_stage():
+    assert parse_print_config_spec("resolved") == ("final", "resolved")
+    assert parse_print_config_spec("merged") == ("final", "merged")
+    assert parse_print_config_spec("file,resolved") == (
+        "file",
+        "resolved",
+    )
+
+
+@pytest.mark.parametrize("spec", ["bogus", "final,bogus", "bogus,resolved"])
+def test_parse_print_config_spec_rejects_invalid_values(spec):
+    with pytest.raises(ValueError):
+        parse_print_config_spec(spec)
 
 
 def test_resolve_config_preserves_cli_tmp_workspace_owner():
@@ -846,7 +857,7 @@ def test_model_config_resolve_provider_returns_self_when_unset():
     assert resolved is cfg
 
 
-def test_resolve_config_preserves_unresolved_inference_provider(tmp_path):
+def test_resolve_config_resolves_inference_provider_at_final_stage(tmp_path):
     cfg_path = tmp_path / "ursa.yml"
     cfg_path.write_text(
         "\n".join([
@@ -865,7 +876,7 @@ def test_resolve_config_preserves_unresolved_inference_provider(tmp_path):
     config = resolve_config(args)
 
     assert config.llm_model.inference_provider == "openai_public"
-    assert config.llm_model.base_url is None
+    assert config.llm_model.base_url == "https://api.openai.com/v1"
     assert config.inference_providers["openai_public"].base_url == (
         "https://api.openai.com/v1"
     )
@@ -878,6 +889,25 @@ def test_resolve_ursa_config_promotes_use_web_to_agent_config():
 
     for agent_name in ["chat", "execute", "deep_review", "prompt"]:
         assert resolved.agent_config[agent_name]["use_web"] is True
+
+
+def test_resolve_ursa_config_use_web_only_fills_missing_values():
+    config = UrsaConfig(
+        use_web=True,
+        agent_config={
+            "chat": {"use_web": False},
+            "execute": {},
+            "prompt": {"temperature": 0.2},
+        },
+    )
+
+    resolved = resolve_ursa_config(config)
+
+    assert resolved.agent_config["chat"]["use_web"] is False
+    assert resolved.agent_config["execute"]["use_web"] is True
+    assert resolved.agent_config["deep_review"]["use_web"] is True
+    assert resolved.agent_config["prompt"]["use_web"] is True
+    assert resolved.agent_config["prompt"]["temperature"] == 0.2
 
 
 def test_resolve_ursa_config_creates_tmp_workspace():

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -16,6 +16,7 @@ from ursa.cli.config import (
     EmbModelConfig,
     ModelConfig,
     UrsaConfig,
+    resolve_ursa_config,
 )
 
 
@@ -845,7 +846,7 @@ def test_model_config_resolve_provider_returns_self_when_unset():
     assert resolved is cfg
 
 
-def test_print_config_preserves_unresolved_inference_provider(tmp_path):
+def test_resolve_config_preserves_unresolved_inference_provider(tmp_path):
     cfg_path = tmp_path / "ursa.yml"
     cfg_path.write_text(
         "\n".join([
@@ -868,3 +869,47 @@ def test_print_config_preserves_unresolved_inference_provider(tmp_path):
     assert config.inference_providers["openai_public"].base_url == (
         "https://api.openai.com/v1"
     )
+
+
+def test_resolve_ursa_config_promotes_use_web_to_agent_config():
+    config = UrsaConfig(use_web=True)
+
+    resolved = resolve_ursa_config(config)
+
+    for agent_name in ["chat", "execute", "deep_review", "prompt"]:
+        assert resolved.agent_config[agent_name]["use_web"] is True
+
+
+def test_resolve_ursa_config_creates_tmp_workspace():
+    config = UrsaConfig(workspace="tmp")
+
+    resolved = resolve_ursa_config(config)
+
+    assert resolved.workspace.exists()
+    assert resolved._temp_workspace is not None
+    assert resolved._temp_workspace.name == str(resolved.workspace)
+
+
+def test_resolve_ursa_config_enforces_group_base_url_policy(tmp_path, monkeypatch):
+    from ursa import security
+    from ursa.security import GroupBaseURLPolicyError
+
+    root = tmp_path / "ursa"
+    group_root = root / "science"
+    group_root.mkdir(parents=True)
+    (group_root / "group.yaml").write_text(
+        "allowed_base_urls:\n  - https://models.example.test\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(security, "URSA_CACHE_DIR", root)
+
+    config = UrsaConfig(
+        group="science",
+        llm_model={
+            "model": "openai:gpt-test",
+            "base_url": "https://disallowed.example.test/v1",
+        },
+    )
+
+    with pytest.raises(GroupBaseURLPolicyError, match="not allowed"):
+        resolve_ursa_config(config)

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -857,8 +857,19 @@ def test_emb_model_config_initializes_embedding_model(monkeypatch):
 
     assert result == "embedding-model"
     assert captured_kwargs["model"] == "text-embedding-3-large"
-    assert captured_kwargs["model_provider"] == "openai"
+    assert captured_kwargs["provider"] == "openai"
+    assert "model_provider" not in captured_kwargs
     assert "use_responses_api" not in captured_kwargs
+
+
+def test_emb_model_kwargs_use_embedding_provider_argument():
+    config = EmbModelConfig(
+        model="text-embedding-3-small",
+        model_provider="openai",
+    )
+
+    assert config.kwargs["provider"] == "openai"
+    assert "model_provider" not in config.kwargs
 
 
 def test_model_config_openai_uses_truststore_client():
@@ -983,6 +994,39 @@ def test_inference_provider_applies_to_llm_model():
     assert "inference_provider" not in resolved.kwargs
 
 
+def test_model_config_model_provider_overrides_inference_provider():
+    config = UrsaConfig(
+        inference_providers={"gateway": {"model_provider": "anthropic"}},
+        llm_model={
+            "model": "gpt-test",
+            "model_provider": "openai",
+            "inference_provider": "gateway",
+        },
+    )
+
+    resolved = config.resolve()
+
+    assert resolved.llm_model.model_provider == "openai"
+    assert resolved.inference_providers["gateway"].model_extra == {
+        "model_provider": "anthropic"
+    }
+
+
+def test_inference_provider_sets_unset_model_provider():
+    config = UrsaConfig(
+        inference_providers={"gateway": {"model_provider": "anthropic"}},
+        llm_model={
+            "model": "gpt-test",
+            "inference_provider": "gateway",
+        },
+    )
+
+    resolved = config.resolve()
+
+    assert "model_provider" not in config.llm_model.model_fields_set
+    assert resolved.llm_model.model_provider == "anthropic"
+
+
 def test_inference_provider_applies_to_embedding_model():
     config = UrsaConfig(
         inference_providers={
@@ -1040,6 +1084,8 @@ def test_model_config_explicit_values_override_inference_provider():
     assert resolved.api_key == SecretReference(env="MODEL_API_KEY")
     assert resolved.model_extra["timeout"] == 60
     assert resolved.model_extra["seed"] == 111
+    assert resolved.model_fields_set == config.llm_model.model_fields_set
+    assert "seed" not in resolved.model_fields_set
 
 
 def test_unknown_inference_provider_is_validation_error():

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -7,7 +7,7 @@ import pytest
 import yaml
 from jsonargparse import Namespace
 from openai import OpenAIError
-from pydantic import ValidationError
+from pydantic import SecretStr, ValidationError
 
 from ursa.cli import (
     build_parser,
@@ -15,6 +15,7 @@ from ursa.cli import (
     resolve_config,
 )
 from ursa.cli.config import (
+    APIKeyConfig,
     ChatModelConfig,
     EmbModelConfig,
     ModelConfig,
@@ -33,6 +34,7 @@ from ursa.cli.print_config import (
 
 @pytest.fixture(autouse=True)
 def _isolate_xdg_config(monkeypatch, tmp_path):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-home"))
     monkeypatch.setenv("XDG_CONFIG_DIRS", str(tmp_path / "xdg-dirs"))
 
@@ -663,11 +665,13 @@ def test_agent_config_null_is_normalized_with_deprecation_warning(caplog):
 
 
 def test_xdg_config_search_paths_honor_env_overrides(tmp_path, monkeypatch):
+    home = tmp_path / "home"
     xdg_home = tmp_path / "xdg-home"
     xdg_dir_1 = tmp_path / "xdg-dir-1"
     xdg_dir_2 = tmp_path / "xdg-dir-2"
 
     monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_home))
+    monkeypatch.setattr(Path, "home", lambda: home)
     path_list_separator = ";" if tmp_path.drive else ":"
     monkeypatch.setenv(
         "XDG_CONFIG_DIRS",
@@ -675,13 +679,16 @@ def test_xdg_config_search_paths_honor_env_overrides(tmp_path, monkeypatch):
     )
 
     assert xdg_config_search_paths() == [
-        xdg_dir_2 / "ursa" / "config.yaml",
-        xdg_dir_1 / "ursa" / "config.yaml",
+        Path("/Library/Application Support/ursa/config.yaml"),
+        home / "Library/Application Support/ursa/config.yaml",
+        home / ".config/ursa/config.yaml",
         xdg_home / "ursa" / "config.yaml",
     ]
 
 
-def test_first_xdg_config_dir_has_higher_precedence(tmp_path, monkeypatch):
+def test_xdg_config_dirs_do_not_replace_native_system_config(
+    tmp_path, monkeypatch
+):
     high = tmp_path / "high" / "ursa" / "config.yaml"
     low = tmp_path / "low" / "ursa" / "config.yaml"
     high.parent.mkdir(parents=True)
@@ -691,11 +698,10 @@ def test_first_xdg_config_dir_has_higher_precedence(tmp_path, monkeypatch):
     path_list_separator = ";" if tmp_path.drive else ":"
     monkeypatch.setenv(
         "XDG_CONFIG_DIRS",
-        path_list_separator.join(
-            (str(high.parents[1]), str(low.parents[1]))
-        ),
+        path_list_separator.join((str(high.parents[1]), str(low.parents[1]))),
     )
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "missing"))
+    monkeypatch.setattr("ursa.cli.config.system_config_path", lambda: high)
 
     config = merge_ursa_config(Namespace(), overrides={})
 
@@ -846,19 +852,20 @@ def test_model_config_ollama_uses_client_kwargs():
 def test_api_key_env(monkeypatch, tmp_path):
     monkeypatch.setenv("TEST_ENV_API_KEY", "super-secret-key")
     parser = build_parser()
-    config = _resolve_args(
-        parser,
-        [
-            "--workspace",
-            str(tmp_path),
-            "--llm_model.api_key_env",
-            "TEST_ENV_API_KEY",
-        ],
-    )
+    with pytest.warns(DeprecationWarning, match="api_key_env is deprecated"):
+        config = _resolve_args(
+            parser,
+            [
+                "--workspace",
+                str(tmp_path),
+                "--llm_model.api_key_env",
+                "TEST_ENV_API_KEY",
+            ],
+        )
 
-    assert config.llm_model.api_key_env == "TEST_ENV_API_KEY"
+    assert isinstance(config.llm_model.api_key, SecretStr)
     assert config.llm_model.kwargs["api_key"] == "super-secret-key"
-    assert "api_key_env" not in config.llm_model.kwargs.keys()
+    assert "api_key_env" not in config.llm_model.model_dump()
 
 
 def test_model_config_omits_unset_or_blank_base_url_for_provider_default():
@@ -889,9 +896,8 @@ def test_model_config_omits_blank_api_key_env(monkeypatch):
 
     kwargs = cfg.kwargs
 
-    assert cfg.api_key_env is None
     assert "api_key" not in kwargs
-    assert "api_key_env" not in kwargs
+    assert "api_key_env" not in cfg.model_dump()
 
 
 def test_inference_provider_applies_to_llm_model():
@@ -919,7 +925,7 @@ def test_inference_provider_applies_to_llm_model():
     assert resolved.inference_provider is None
     assert resolved.base_url == "https://models.example.org/v1"
     assert resolved.ssl_verify is False
-    assert resolved.api_key_env == "PROVIDER_API_KEY"
+    assert resolved.api_key == APIKeyConfig(env="PROVIDER_API_KEY")
     assert resolved.model_extra["timeout"] == 45
 
 
@@ -977,14 +983,14 @@ def test_model_config_explicit_values_override_inference_provider():
 
     assert resolved.base_url == "https://model.example.org/v1"
     assert resolved.ssl_verify is True
-    assert resolved.api_key_env == "MODEL_API_KEY"
+    assert resolved.api_key == APIKeyConfig(env="MODEL_API_KEY")
     assert resolved.model_extra["timeout"] == 60
     assert resolved.model_extra["seed"] == 111
 
 
 def test_unknown_inference_provider_is_validation_error():
     with pytest.raises(
-        ValueError, match="Unknown inference_provider 'missing'"
+        ValueError, match="unknown inference_provider 'missing'"
     ):
         UrsaConfig(
             llm_model={
@@ -1119,12 +1125,14 @@ def test_print_config_includes_defaults_and_nulls(
     assert output["agent_config"] == {}
     for key, value in expected_model.items():
         assert output["llm_model"][key] == value
-    assert output["inference_providers"] == {
-        "shared": {
-            "base_url": "https://provider.example/v1",
-            "api_key_env": None,
-            "ssl_verify": False,
-        }
+    assert output["inference_providers"]["shared"] == {
+        "base_url": "https://provider.example/v1",
+        "api_key": None,
+        "ssl_verify": False,
+    }
+    assert output["inference_providers"]["openai"]["api_key"] == {
+        "env": "OPENAI_API_KEY",
+        "keyring": None,
     }
     assert output["mcp_servers"] == {
         "example": {

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -547,3 +547,145 @@ def test_model_config_omits_blank_api_key_env(monkeypatch):
     assert cfg.api_key_env is None
     assert "api_key" not in kwargs
     assert "api_key_env" not in kwargs
+
+
+def test_inference_provider_applies_to_llm_model():
+    config = UrsaConfig(
+        inference_providers={
+            "local-openai": {
+                "base_url": " https://models.example.org/v1 ",
+                "ssl_verify": False,
+                "api_key_env": "PROVIDER_API_KEY",
+                "timeout": 45,
+            }
+        },
+        llm_model={
+            "model": "openai:gpt-5",
+            "inference_provider": "local-openai",
+        },
+    )
+
+    resolved = config.llm_model.resolve_inference_provider(
+        config.inference_providers
+    )
+
+    assert config.llm_model.inference_provider == "local-openai"
+    assert config.llm_model.base_url is None
+    assert resolved.base_url == "https://models.example.org/v1"
+    assert resolved.ssl_verify is False
+    assert resolved.api_key_env == "PROVIDER_API_KEY"
+    assert resolved.model_extra["timeout"] == 45
+
+
+def test_inference_provider_applies_to_embedding_model():
+    config = UrsaConfig(
+        inference_providers={
+            "local-embeddings": {
+                "base_url": "https://embeddings.example.org/v1",
+                "ssl_verify": False,
+                "cache_dir": "/tmp/provider-cache",
+            }
+        },
+        emb_model={
+            "model": "openai:text-embedding-3-large",
+            "inference_provider": "local-embeddings",
+        },
+    )
+
+    assert config.emb_model is not None
+    resolved = config.emb_model.resolve_inference_provider(
+        config.inference_providers
+    )
+    assert config.emb_model.inference_provider == "local-embeddings"
+    assert config.emb_model.base_url is None
+    assert resolved.base_url == "https://embeddings.example.org/v1"
+    assert resolved.ssl_verify is False
+    assert resolved.model_extra["cache_dir"] == "/tmp/provider-cache"
+
+
+def test_model_config_explicit_values_override_inference_provider():
+    config = UrsaConfig(
+        inference_providers={
+            "shared": {
+                "base_url": "https://provider.example.org/v1",
+                "ssl_verify": False,
+                "api_key_env": "PROVIDER_API_KEY",
+                "timeout": 30,
+                "seed": 111,
+            }
+        },
+        llm_model={
+            "model": "openai:gpt-5",
+            "inference_provider": "shared",
+            "base_url": "https://model.example.org/v1",
+            "ssl_verify": True,
+            "api_key_env": "MODEL_API_KEY",
+            "timeout": 60,
+        },
+    )
+
+    resolved = config.llm_model.resolve_inference_provider(
+        config.inference_providers
+    )
+
+    assert resolved.base_url == "https://model.example.org/v1"
+    assert resolved.ssl_verify is True
+    assert resolved.api_key_env == "MODEL_API_KEY"
+    assert resolved.model_extra["timeout"] == 60
+    assert resolved.model_extra["seed"] == 111
+
+
+def test_unknown_inference_provider_is_validation_error():
+    with pytest.raises(
+        ValueError, match="Unknown inference_provider 'missing'"
+    ):
+        UrsaConfig(
+            llm_model={
+                "model": "openai:gpt-5",
+                "inference_provider": "missing",
+            }
+        )
+
+
+def test_inference_provider_is_not_forwarded_to_langchain_kwargs():
+    cfg = ChatModelConfig(
+        model="openai:gpt-5",
+        inference_provider="shared-provider",
+    )
+
+    kwargs = cfg.kwargs
+
+    assert "inference_provider" not in kwargs
+
+
+def test_model_config_resolve_provider_returns_self_when_unset():
+    cfg = ChatModelConfig(model="openai:gpt-5")
+
+    resolved = cfg.resolve_inference_provider({})
+
+    assert resolved is cfg
+
+
+def test_print_config_preserves_unresolved_inference_provider(tmp_path):
+    cfg_path = tmp_path / "ursa.yml"
+    cfg_path.write_text(
+        "\n".join([
+            "inference_providers:",
+            "  openai_public:",
+            "    base_url: https://api.openai.com/v1",
+            "    api_key_env: OPENAI_API_KEY",
+            "llm_model:",
+            "  model: openai:gpt-5.4",
+            "  inference_provider: openai_public",
+        ])
+    )
+
+    parser = build_parser()
+    args = parser.parse_args(["--config", str(cfg_path)])
+    config = resolve_config(args)
+
+    assert config.llm_model.inference_provider == "openai_public"
+    assert config.llm_model.base_url is None
+    assert config.inference_providers["openai_public"].base_url == (
+        "https://api.openai.com/v1"
+    )

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -434,7 +434,9 @@ def test_print_config_yaml_round_trip(tmp_path):
             "openai:gpt-5-nano",
         ],
     )
-    yaml_text = yaml.safe_dump(original_config.model_dump())
+    serialized = original_config.model_dump()
+    serialized["llm_model"]["inference_provider"] = None
+    yaml_text = yaml.safe_dump(serialized)
 
     cfg_path = tmp_path / "round-trip.yml"
     cfg_path.write_text(yaml_text)
@@ -442,7 +444,7 @@ def test_print_config_yaml_round_trip(tmp_path):
     parser = build_parser()
     loaded_config = _resolve_args(parser, ["--config", str(cfg_path)])
 
-    assert loaded_config.model_dump() == original_config.model_dump()
+    assert loaded_config.model_dump() == serialized
 
 
 def test_config_env_cli_precedence(tmp_path, monkeypatch):
@@ -1171,7 +1173,7 @@ def test_print_config_includes_defaults_and_nulls(
     monkeypatch.setattr(
         print_config_module,
         "merge_ursa_config",
-        lambda cfg, level, overrides: merged,
+        lambda cfg, level, env_overrides, cli_overrides: merged,
     )
     monkeypatch.setattr(
         print_config_module,

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -8,7 +8,7 @@ import pytest
 import yaml
 from jsonargparse import Namespace
 from openai import OpenAIError
-from pydantic import SecretStr, ValidationError
+from pydantic import ValidationError
 
 from ursa.cli import (
     build_parser,
@@ -16,7 +16,6 @@ from ursa.cli import (
     resolve_config,
 )
 from ursa.cli.config import (
-    APIKeyConfig,
     ChatModelConfig,
     EmbModelConfig,
     ModelConfig,
@@ -32,6 +31,7 @@ from ursa.cli.print_config import (
     print_config,
 )
 from ursa.util.crossplatform import system_config_path, user_config_paths
+from ursa.util.secrets import SecretReference
 
 
 @pytest.fixture(autouse=True)
@@ -881,7 +881,7 @@ def test_api_key_env_cli_option(monkeypatch, tmp_path):
         )
 
     assert not any("api_key_env" in str(item.message) for item in warnings)
-    assert isinstance(config.llm_model.api_key, SecretStr)
+    assert config.llm_model.api_key == SecretReference(env="TEST_ENV_API_KEY")
     assert config.llm_model.kwargs["api_key"] == "super-secret-key"
     assert "api_key_env" not in config.llm_model.model_dump()
 
@@ -959,7 +959,7 @@ def test_inference_provider_applies_to_llm_model():
     assert resolved.inference_provider == "local-openai"
     assert resolved.base_url == "https://models.example.org/v1"
     assert resolved.ssl_verify is False
-    assert resolved.api_key == APIKeyConfig(env="PROVIDER_API_KEY")
+    assert resolved.api_key == SecretReference(env="PROVIDER_API_KEY")
     assert resolved.model_extra["timeout"] == 45
     assert "inference_provider" not in resolved.kwargs
 
@@ -1006,7 +1006,6 @@ def test_model_config_explicit_values_override_inference_provider():
         llm_model={
             "model": "openai:gpt-5",
             "inference_provider": "shared",
-            "base_url": "https://model.example.org/v1",
             "ssl_verify": True,
             "api_key_env": "MODEL_API_KEY",
             "timeout": 60,
@@ -1017,9 +1016,9 @@ def test_model_config_explicit_values_override_inference_provider():
         config.inference_providers
     )
 
-    assert resolved.base_url == "https://model.example.org/v1"
+    assert resolved.base_url == "https://provider.example.org/v1"
     assert resolved.ssl_verify is True
-    assert resolved.api_key == APIKeyConfig(env="MODEL_API_KEY")
+    assert resolved.api_key == SecretReference(env="MODEL_API_KEY")
     assert resolved.model_extra["timeout"] == 60
     assert resolved.model_extra["seed"] == 111
 
@@ -1102,13 +1101,20 @@ def test_resolve_ursa_config_applies_inference_provider():
     assert "inference_provider" not in resolved.llm_model.kwargs
 
 
-def test_resolved_config_can_be_dumped_reloaded_and_resolved_again():
-    resolved = UrsaConfig().resolve()
+def test_resolved_config_without_inference_provider_can_be_reloaded():
+    resolved = UrsaConfig(
+        llm_model={
+            "model": "openai:gpt-5",
+            "base_url": "https://models.example/v1",
+        }
+    ).resolve()
 
     reloaded = UrsaConfig.model_validate(resolved.model_dump()).resolve()
 
-    assert reloaded.llm_model.inference_provider == "openai"
-    assert "inference_provider" not in reloaded.llm_model.kwargs
+    assert reloaded.llm_model.inference_provider is None
+    assert reloaded.llm_model.base_url == "https://models.example/v1"
+    assert reloaded.llm_model.model == "gpt-5"
+    assert reloaded.llm_model.model_provider == "openai"
 
 
 @pytest.mark.parametrize(

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -2,6 +2,7 @@ import gc
 import importlib
 from pathlib import Path
 from unittest.mock import MagicMock
+from warnings import catch_warnings, simplefilter
 
 import pytest
 import yaml
@@ -848,10 +849,11 @@ def test_model_config_ollama_uses_client_kwargs():
     assert kwargs["client_kwargs"]["verify"] is not False
 
 
-def test_api_key_env(monkeypatch, tmp_path):
+def test_api_key_env_cli_option(monkeypatch, tmp_path):
     monkeypatch.setenv("TEST_ENV_API_KEY", "super-secret-key")
     parser = build_parser()
-    with pytest.warns(DeprecationWarning, match="api_key_env is deprecated"):
+    with catch_warnings(record=True) as warnings:
+        simplefilter("always")
         config = _resolve_args(
             parser,
             [
@@ -862,9 +864,26 @@ def test_api_key_env(monkeypatch, tmp_path):
             ],
         )
 
+    assert not any("api_key_env" in str(item.message) for item in warnings)
     assert isinstance(config.llm_model.api_key, SecretStr)
     assert config.llm_model.kwargs["api_key"] == "super-secret-key"
     assert "api_key_env" not in config.llm_model.model_dump()
+
+
+def test_api_key_env_cli_options_are_visible_in_help():
+    parser = build_parser()
+    help_text = parser.format_help()
+
+    assert "--llm_model.api_key_env" in help_text
+    assert "--emb_model.api_key_env" in help_text
+    assert (
+        parser._option_string_actions["--llm_model.api_key_env"].container
+        is parser._option_string_actions["--llm_model"].container
+    )
+    assert (
+        parser._option_string_actions["--emb_model.api_key_env"].container
+        is parser._option_string_actions["--emb_model"].container
+    )
 
 
 def test_model_config_omits_unset_or_blank_base_url_for_provider_default():

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -5,8 +5,12 @@ import pytest
 import yaml
 from openai import OpenAIError
 
-from ursa.cli import _xdg_config_search_paths, build_parser, main, resolve_config
-from ursa.cli.print_config import parse_print_config_spec
+from ursa.cli import (
+    _xdg_config_search_paths,
+    build_parser,
+    main,
+    resolve_config,
+)
 from ursa.cli.config import (
     ChatModelConfig,
     EmbModelConfig,
@@ -14,6 +18,13 @@ from ursa.cli.config import (
     UrsaConfig,
     resolve_ursa_config,
 )
+from ursa.cli.print_config import parse_print_config_spec
+
+
+@pytest.fixture(autouse=True)
+def _isolate_xdg_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-home"))
+    monkeypatch.setenv("XDG_CONFIG_DIRS", str(tmp_path / "xdg-dirs"))
 
 
 def _stub_mcp_server(monkeypatch):
@@ -212,9 +223,7 @@ def test_cli_parses_typed_flags(tmp_path):
     assert config.llm_model.max_completion_tokens == 2048
 
 
-def test_print_config_flag_defaults_to_resolved_string(
-    monkeypatch, tmp_path
-):
+def test_print_config_flag_defaults_to_resolved_string(monkeypatch, tmp_path):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-missing"))
     monkeypatch.setenv("XDG_CONFIG_DIRS", str(tmp_path / "xdg-dirs-missing"))
     monkeypatch.chdir(tmp_path)
@@ -650,6 +659,20 @@ def test_chat_model_config_initializes_chat_model(monkeypatch):
     assert captured_kwargs["use_responses_api"] is True
 
 
+def test_chat_model_config_requires_referenced_provider_mapping(monkeypatch):
+    monkeypatch.setattr(
+        "ursa.cli.config.init_chat_model",
+        lambda **kwargs: "chat-model",
+    )
+    cfg = ChatModelConfig(
+        model="openai:gpt-5",
+        inference_provider="shared",
+    )
+
+    with pytest.raises(ValueError, match="Unknown inference_provider 'shared'"):
+        cfg.init_chat_model()
+
+
 def test_emb_model_config_initializes_embedding_model(monkeypatch):
     captured_kwargs = {}
 
@@ -762,6 +785,7 @@ def test_inference_provider_applies_to_llm_model():
 
     assert config.llm_model.inference_provider == "local-openai"
     assert config.llm_model.base_url is None
+    assert resolved.inference_provider is None
     assert resolved.base_url == "https://models.example.org/v1"
     assert resolved.ssl_verify is False
     assert resolved.api_key_env == "PROVIDER_API_KEY"
@@ -789,6 +813,7 @@ def test_inference_provider_applies_to_embedding_model():
     )
     assert config.emb_model.inference_provider == "local-embeddings"
     assert config.emb_model.base_url is None
+    assert resolved.inference_provider is None
     assert resolved.base_url == "https://embeddings.example.org/v1"
     assert resolved.ssl_verify is False
     assert resolved.model_extra["cache_dir"] == "/tmp/provider-cache"
@@ -849,12 +874,13 @@ def test_inference_provider_is_not_forwarded_to_langchain_kwargs():
     assert "inference_provider" not in kwargs
 
 
-def test_model_config_resolve_provider_returns_self_when_unset():
+def test_model_config_resolve_provider_materializes_ssl_default():
     cfg = ChatModelConfig(model="openai:gpt-5")
 
     resolved = cfg.resolve_inference_provider({})
 
-    assert resolved is cfg
+    assert cfg.ssl_verify is None
+    assert resolved.ssl_verify is True
 
 
 def test_resolve_config_resolves_inference_provider_at_final_stage(tmp_path):
@@ -875,11 +901,30 @@ def test_resolve_config_resolves_inference_provider_at_final_stage(tmp_path):
     args = parser.parse_args(["--config", str(cfg_path)])
     config = resolve_config(args)
 
-    assert config.llm_model.inference_provider == "openai_public"
+    assert config.llm_model.inference_provider is None
     assert config.llm_model.base_url == "https://api.openai.com/v1"
     assert config.inference_providers["openai_public"].base_url == (
         "https://api.openai.com/v1"
     )
+
+
+def test_resolve_config_inherits_provider_ssl_verify(tmp_path):
+    cfg_path = tmp_path / "ursa.yml"
+    cfg_path.write_text(
+        "\n".join([
+            "inference_providers:",
+            "  shared:",
+            "    ssl_verify: false",
+            "llm_model:",
+            "  model: openai:gpt-5.4",
+            "  inference_provider: shared",
+        ])
+    )
+
+    parser = build_parser()
+    config = resolve_config(parser.parse_args(["--config", str(cfg_path)]))
+
+    assert config.llm_model.ssl_verify is False
 
 
 def test_resolve_ursa_config_promotes_use_web_to_agent_config():
@@ -920,7 +965,9 @@ def test_resolve_ursa_config_creates_tmp_workspace():
     assert resolved._temp_workspace.name == str(resolved.workspace)
 
 
-def test_resolve_ursa_config_enforces_group_base_url_policy(tmp_path, monkeypatch):
+def test_resolve_ursa_config_enforces_group_base_url_policy(
+    tmp_path, monkeypatch
+):
     from ursa import security
     from ursa.security import GroupBaseURLPolicyError
 

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -940,11 +940,12 @@ def test_inference_provider_applies_to_llm_model():
 
     assert config.llm_model.inference_provider == "local-openai"
     assert config.llm_model.base_url is None
-    assert resolved.inference_provider is None
+    assert resolved.inference_provider == "local-openai"
     assert resolved.base_url == "https://models.example.org/v1"
     assert resolved.ssl_verify is False
     assert resolved.api_key == APIKeyConfig(env="PROVIDER_API_KEY")
     assert resolved.model_extra["timeout"] == 45
+    assert "inference_provider" not in resolved.kwargs
 
 
 def test_inference_provider_applies_to_embedding_model():
@@ -968,10 +969,11 @@ def test_inference_provider_applies_to_embedding_model():
     )
     assert config.emb_model.inference_provider == "local-embeddings"
     assert config.emb_model.base_url is None
-    assert resolved.inference_provider is None
+    assert resolved.inference_provider == "local-embeddings"
     assert resolved.base_url == "https://embeddings.example.org/v1"
     assert resolved.ssl_verify is False
     assert resolved.model_extra["cache_dir"] == "/tmp/provider-cache"
+    assert "inference_provider" not in resolved.kwargs
 
 
 def test_model_config_explicit_values_override_inference_provider():
@@ -1079,8 +1081,18 @@ def test_resolve_ursa_config_applies_inference_provider():
 
     resolved = resolve_ursa_config(config)
 
-    assert resolved.llm_model.inference_provider is None
+    assert resolved.llm_model.inference_provider == "openai_public"
     assert resolved.llm_model.base_url == "https://api.openai.com/v1"
+    assert "inference_provider" not in resolved.llm_model.kwargs
+
+
+def test_resolved_config_can_be_dumped_reloaded_and_resolved_again():
+    resolved = UrsaConfig().resolve()
+
+    reloaded = UrsaConfig.model_validate(resolved.model_dump()).resolve()
+
+    assert reloaded.llm_model.inference_provider == "openai"
+    assert "inference_provider" not in reloaded.llm_model.kwargs
 
 
 @pytest.mark.parametrize(
@@ -1091,6 +1103,7 @@ def test_resolve_ursa_config_applies_inference_provider():
             "resolved",
             {
                 "base_url": "https://provider.example/v1",
+                "inference_provider": "shared",
                 "ssl_verify": False,
             },
         ),
@@ -1114,14 +1127,7 @@ def test_print_config_includes_defaults_and_nulls(
             }
         },
     )
-    resolved = UrsaConfig(
-        inference_providers=merged.inference_providers,
-        llm_model={
-            "base_url": "https://provider.example/v1",
-            "ssl_verify": False,
-        },
-        mcp_servers=merged.mcp_servers,
-    )
+    resolved = resolve_ursa_config(merged)
     print_config_module = importlib.import_module("ursa.cli.print_config")
     monkeypatch.setattr(
         print_config_module,

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -1,8 +1,9 @@
-from pathlib import Path
+import importlib
 from unittest.mock import MagicMock
 
 import pytest
 import yaml
+from jsonargparse import Namespace
 from openai import OpenAIError
 
 from ursa.cli import (
@@ -15,6 +16,7 @@ from ursa.cli.config import (
     EmbModelConfig,
     ModelConfig,
     UrsaConfig,
+    config_search_paths,
     merge_ursa_config,
     resolve_ursa_config,
     xdg_config_search_paths,
@@ -225,34 +227,25 @@ def test_mcp_server_passes_http_options_when_running(monkeypatch):
 
 def test_cli_parses_typed_flags(tmp_path):
     parser = build_parser()
-    config = _resolve_args(
-        parser,
-        [
-            "--workspace",
-            str(tmp_path / "workspace"),
-            "--llm_model.model",
-            "openai:gpt-5-nano",
-            "--llm_model.max_completion_tokens",
-            "2048",
-        ],
-    )
+    args = parser.parse_args([
+        "--workspace",
+        str(tmp_path / "workspace"),
+        "--llm_model.model",
+        "openai:gpt-5-nano",
+        "--llm_model.max_completion_tokens",
+        "2048",
+    ])
 
-    assert config.workspace == tmp_path / "workspace"
-    assert config.llm_model.model == "openai:gpt-5-nano"
-    assert config.llm_model.max_completion_tokens == 2048
+    assert args.workspace == tmp_path / "workspace"
+    assert args.llm_model.model == "openai:gpt-5-nano"
+    assert args.llm_model.max_completion_tokens == 2048
 
 
-def test_print_config_flag_defaults_to_resolved_string(monkeypatch, tmp_path):
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-missing"))
-    monkeypatch.setenv("XDG_CONFIG_DIRS", str(tmp_path / "xdg-dirs-missing"))
-    monkeypatch.chdir(tmp_path)
+def test_print_config_flag_defaults_to_resolved_string():
     parser = build_parser()
-    args, overrides = _parse_config_args(parser, ["--print-config"])
+    args = parser.parse_args(["--print-config"])
 
     assert args["print_config"] == "resolved"
-
-    config = resolve_config(args, overrides)
-    assert config.model_dump() == resolve_ursa_config(UrsaConfig()).model_dump()
 
 
 def test_parse_print_config_spec_accepts_stage_only_and_level_stage():
@@ -465,34 +458,40 @@ def test_config_file_and_cli_are_merged(tmp_path):
     assert config.emb_model.model_extra["cache_dir"] == "/tmp/cache"
 
 
-def test_sparse_parser_preserves_only_explicit_config_values():
+def test_sparse_parser_omits_config_defaults():
     parser = build_parser()
 
     assert parser.parse_args([], defaults=False).as_dict() == {}
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"), [("true", True), ("false", False)]
+)
+def test_cli_parser_preserves_explicit_ssl_verify(value, expected):
+    parser = build_parser()
+
     assert parser.parse_args(
-        ["--group", "default", "--llm_model.ssl_verify", "true"],
+        ["--group", "default", "--llm_model.ssl_verify", value],
         defaults=False,
     ).as_dict() == {
+        "group": "default",
+        "llm_model": {"ssl_verify": expected},
+    }
+
+
+def test_sparse_parser_reads_environment(monkeypatch):
+    monkeypatch.setenv("URSA_GROUP", "default")
+    monkeypatch.setenv("URSA_LLM_MODEL__SSL_VERIFY", "true")
+
+    overrides = build_parser().parse_args([], defaults=False)
+
+    assert overrides.as_dict() == {
         "group": "default",
         "llm_model": {"ssl_verify": True},
     }
 
 
-@pytest.mark.parametrize(
-    ("subcommand_args", "expected_subcommand"),
-    [
-        ([], None),
-        (["exec", "hello"], "exec"),
-        (["mcp-server"], "mcp-server"),
-        (
-            ["rag-query", "--name", "docs", "What is indexed?"],
-            "rag-query",
-        ),
-    ],
-)
-def test_explicit_schema_defaults_override_file_for_all_runtime_commands(
-    tmp_path, subcommand_args, expected_subcommand
-):
+def test_merge_ursa_config_applies_sparse_overrides(tmp_path, monkeypatch):
     cfg_path = tmp_path / "ursa.yml"
     cfg_path.write_text(
         yaml.safe_dump({
@@ -503,44 +502,24 @@ def test_explicit_schema_defaults_override_file_for_all_runtime_commands(
             },
         })
     )
-    parser = build_parser()
-    args = [
-        "--config",
-        str(cfg_path),
-        "--group",
-        "default",
-        "--llm_model.model",
-        "openai:gpt-5.4",
-        "--llm_model.ssl_verify",
-        "true",
-        *subcommand_args,
-    ]
-    cfg, overrides = _parse_config_args(parser, args)
+    monkeypatch.setattr(
+        "ursa.cli.config.config_search_paths",
+        lambda cfg, level="final": [cfg_path],
+    )
 
-    config = resolve_config(cfg, overrides)
+    config = merge_ursa_config(
+        Namespace(),
+        overrides={
+            "group": "default",
+            "llm_model": {
+                "model": "openai:gpt-5.4",
+                "ssl_verify": True,
+            },
+        },
+    )
 
-    assert cfg.get("subcommand") == expected_subcommand
     assert config.group == "default"
     assert config.llm_model.model == "openai:gpt-5.4"
-    assert config.llm_model.ssl_verify is True
-
-
-def test_explicit_environment_defaults_override_config_file(
-    tmp_path, monkeypatch
-):
-    cfg_path = tmp_path / "ursa.yml"
-    cfg_path.write_text(
-        yaml.safe_dump({
-            "group": "restricted",
-            "llm_model": {"ssl_verify": False},
-        })
-    )
-    monkeypatch.setenv("URSA_GROUP", "default")
-    monkeypatch.setenv("URSA_LLM_MODEL__SSL_VERIFY", "true")
-
-    config = _resolve_args(build_parser(), ["--config", str(cfg_path)])
-
-    assert config.group == "default"
     assert config.llm_model.ssl_verify is True
 
 
@@ -559,168 +538,35 @@ def test_xdg_config_search_paths_honor_env_overrides(tmp_path, monkeypatch):
     ]
 
 
-def test_resolve_config_merges_xdg_local_file_and_cli_layers(
+def test_config_search_paths_returns_existing_sources_in_precedence_order(
     tmp_path, monkeypatch
 ):
-    monkeypatch.setattr(
-        "ursa.cli.config.enforce_group_base_url_policy",
-        lambda base_url, group: None,
-    )
-    xdg_dir = tmp_path / "xdg-home"
-    xdg_dir_1 = tmp_path / "xdg-dir-1"
+    xdg_dir = tmp_path / "xdg"
     project_dir = tmp_path / "project"
     explicit_cfg = tmp_path / "explicit.yaml"
-    cli_workspace = tmp_path / "cli-workspace"
-    cli_workspace.mkdir()
-
-    xdg_dir_config = xdg_dir_1 / "ursa" / "config.yaml"
-    xdg_dir_config.parent.mkdir(parents=True)
-    xdg_dir_config.write_text(
-        yaml.safe_dump({
-            "workspace": "xdg-dir-workspace",
-            "llm_model": {
-                "model": "openai:gpt-5-mini",
-                "max_completion_tokens": 1024,
-            },
-        })
-    )
-
-    xdg_config = xdg_dir / "ursa" / "config.yaml"
-    xdg_config.parent.mkdir(parents=True)
-    xdg_config.write_text(
-        yaml.safe_dump({
-            "workspace": "xdg-workspace",
-            "group": "xdg-group",
-            "llm_model": {
-                "model": "openai:gpt-5-mini",
-                "base_url": "https://xdg.example/v1",
-            },
-            "agent_config": {"chat": {"temperature": 0.1}},
-        })
-    )
-
-    local_config = project_dir / ".ursa" / "config.yaml"
-    local_config.parent.mkdir(parents=True)
-    local_config.write_text(
-        yaml.safe_dump({
-            "group": "local-group",
-            "llm_model": {
-                "model": "openai:gpt-5-mini",
-                "base_url": "https://local.example/v1",
-            },
-            "emb_model": {"model": "openai:text-embedding-3-small"},
-            "agent_config": {"chat": {"top_p": 0.9}},
-        })
-    )
-
-    explicit_cfg.write_text(
-        yaml.safe_dump({
-            "group": "file-group",
-            "llm_model": {
-                "model": "openai:gpt-5-mini",
-                "api_key_env": "EXPLICIT_KEY",
-            },
-            "agent_config": {"chat": {"seed": 7}},
-        })
-    )
+    user_cfg = xdg_dir / "ursa" / "config.yaml"
+    project_cfg = project_dir / ".ursa" / "config.yaml"
+    user_cfg.parent.mkdir(parents=True)
+    project_cfg.parent.mkdir(parents=True)
+    for path in (user_cfg, project_cfg, explicit_cfg):
+        path.write_text("{}\n")
 
     monkeypatch.chdir(project_dir)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_dir))
-    monkeypatch.setenv("XDG_CONFIG_DIRS", str(xdg_dir_1))
+    monkeypatch.setenv("XDG_CONFIG_DIRS", str(tmp_path / "missing"))
 
-    parser = build_parser()
-    config = _resolve_args(
-        parser,
-        [
-            "--config",
-            str(explicit_cfg),
-            "--workspace",
-            str(cli_workspace),
-            "--group",
-            "cli-group",
-            "--llm_model.model",
-            "openai:gpt-5-nano",
-        ],
-    )
-
-    assert config.workspace == cli_workspace
-    assert config.group == "cli-group"
-    assert config.llm_model.model == "openai:gpt-5-nano"
-    assert config.llm_model.base_url == "https://local.example/v1"
-    assert config.llm_model.api_key_env == "EXPLICIT_KEY"
-    assert config.llm_model.max_completion_tokens == 1024
-    assert config.emb_model is not None
-    assert config.emb_model.model == "openai:text-embedding-3-small"
-    assert config.agent_config["chat"] == {
-        "temperature": 0.1,
-        "top_p": 0.9,
-        "seed": 7,
-    }
+    assert config_search_paths(Namespace(config=explicit_cfg)) == [
+        user_cfg,
+        project_cfg,
+        explicit_cfg,
+    ]
 
 
-def test_resolve_config_uses_local_and_xdg_defaults_without_explicit_config(
+def test_merge_ursa_config_validates_provider_after_merging_layers(
     tmp_path, monkeypatch
 ):
-    monkeypatch.setattr(
-        "ursa.cli.config.enforce_group_base_url_policy",
-        lambda base_url, group: None,
-    )
-    xdg_config_dir = tmp_path / "xdg-home"
-    xdg_dir_config_dir = tmp_path / "xdg-dir"
-    xdg_config = xdg_config_dir / "ursa" / "config.yaml"
-    local_config = tmp_path / "local-config.yaml"
-
-    xdg_dir_config = xdg_dir_config_dir / "ursa" / "config.yaml"
-    xdg_dir_config.parent.mkdir(parents=True)
-    xdg_dir_config.write_text(
-        yaml.safe_dump({
-            "workspace": "xdg-dir-workspace",
-            "llm_model": {"model": "openai:gpt-5-mini"},
-        })
-    )
-
-    xdg_config.parent.mkdir(parents=True)
-    xdg_config.write_text(
-        yaml.safe_dump({
-            "group": "xdg-group",
-            "llm_model": {"model": "openai:gpt-5-mini"},
-        })
-    )
-    local_config.write_text(
-        yaml.safe_dump({
-            "group": "local-group",
-            "llm_model": {
-                "model": "openai:gpt-5-mini",
-                "base_url": "https://local.example/v1",
-            },
-        })
-    )
-
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_config_dir))
-    monkeypatch.setenv("XDG_CONFIG_DIRS", str(xdg_dir_config_dir))
-    monkeypatch.chdir(tmp_path)
-    local_path = tmp_path / ".ursa" / "config.yaml"
-    local_path.parent.mkdir(parents=True)
-    local_path.write_text(local_config.read_text())
-
-    parser = build_parser()
-    config = _resolve_args(parser, [])
-
-    assert config.workspace == Path("xdg-dir-workspace")
-    assert config.group == "local-group"
-    assert config.llm_model.model == "openai:gpt-5-mini"
-    assert config.llm_model.base_url == "https://local.example/v1"
-
-
-def test_project_config_can_select_provider_from_user_config(
-    tmp_path, monkeypatch
-):
-    xdg_home = tmp_path / "xdg-home"
-    project_dir = tmp_path / "project"
-    user_config = xdg_home / "ursa" / "config.yaml"
-    project_config = project_dir / ".ursa" / "config.yaml"
-    user_config.parent.mkdir(parents=True)
-    project_config.parent.mkdir(parents=True)
+    user_config = tmp_path / "user.yaml"
+    project_config = tmp_path / "project.yaml"
     user_config.write_text(
         yaml.safe_dump({
             "inference_providers": {
@@ -739,20 +585,16 @@ def test_project_config_can_select_provider_from_user_config(
             }
         })
     )
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_home))
-    monkeypatch.chdir(project_dir)
+    monkeypatch.setattr(
+        "ursa.cli.config.config_search_paths",
+        lambda cfg, level="final": [user_config, project_config],
+    )
 
-    parser = build_parser()
-    args, overrides = _parse_config_args(parser, [])
-    config = resolve_config(args, overrides)
+    config = merge_ursa_config(Namespace(), overrides={})
 
+    assert "openai_project" in config.inference_providers
     assert config.llm_model.model == "openai:gpt-5.4-mini"
-    assert config.llm_model.base_url == "https://project.example/v1"
-    assert config.llm_model.ssl_verify is False
-    assert config.llm_model.inference_provider is None
-
-    cumulative = resolve_ursa_config(merge_ursa_config(args, "project+"))
-    assert cumulative.llm_model.base_url == "https://project.example/v1"
+    assert config.llm_model.inference_provider == "openai_project"
 
 
 def test_model_config_kwargs_includes_extra():
@@ -1024,10 +866,7 @@ def test_model_config_kwargs_rejects_unresolved_inference_provider():
 def test_model_config_ssl_verify_defaults_to_true():
     cfg = ChatModelConfig(model="openai:gpt-5")
 
-    resolved = cfg.resolve_inference_provider({})
-
     assert cfg.ssl_verify is True
-    assert resolved.ssl_verify is True
 
 
 def test_model_config_explicit_null_extra_clears_provider_default():
@@ -1048,47 +887,18 @@ def test_model_config_explicit_null_extra_clears_provider_default():
     assert "timeout" not in resolved.kwargs
 
 
-def test_resolve_config_resolves_inference_provider_at_final_stage(tmp_path):
-    cfg_path = tmp_path / "ursa.yml"
-    cfg_path.write_text(
-        "\n".join([
-            "inference_providers:",
-            "  openai_public:",
-            "    base_url: https://api.openai.com/v1",
-            "    api_key_env: OPENAI_API_KEY",
-            "llm_model:",
-            "  model: openai:gpt-5.4",
-            "  inference_provider: openai_public",
-        ])
+def test_resolve_ursa_config_applies_inference_provider():
+    config = UrsaConfig(
+        inference_providers={
+            "openai_public": {"base_url": "https://api.openai.com/v1"}
+        },
+        llm_model={"inference_provider": "openai_public"},
     )
 
-    parser = build_parser()
-    config = _resolve_args(parser, ["--config", str(cfg_path)])
+    resolved = resolve_ursa_config(config)
 
-    assert config.llm_model.inference_provider is None
-    assert config.llm_model.base_url == "https://api.openai.com/v1"
-    assert config.inference_providers["openai_public"].base_url == (
-        "https://api.openai.com/v1"
-    )
-
-
-def test_resolve_config_inherits_provider_ssl_verify(tmp_path):
-    cfg_path = tmp_path / "ursa.yml"
-    cfg_path.write_text(
-        "\n".join([
-            "inference_providers:",
-            "  shared:",
-            "    ssl_verify: false",
-            "llm_model:",
-            "  model: openai:gpt-5.4",
-            "  inference_provider: shared",
-        ])
-    )
-
-    parser = build_parser()
-    config = _resolve_args(parser, ["--config", str(cfg_path)])
-
-    assert config.llm_model.ssl_verify is False
+    assert resolved.llm_model.inference_provider is None
+    assert resolved.llm_model.base_url == "https://api.openai.com/v1"
 
 
 @pytest.mark.parametrize(
@@ -1105,40 +915,44 @@ def test_resolve_config_inherits_provider_ssl_verify(tmp_path):
     ],
 )
 def test_print_config_omits_defaults_and_nulls(
-    tmp_path, capsys, stage, expected_model
+    monkeypatch, capsys, stage, expected_model
 ):
-    cfg_path = tmp_path / "ursa.yml"
-    cfg_path.write_text(
-        yaml.safe_dump({
-            "inference_providers": {
-                "shared": {
-                    "base_url": "https://provider.example/v1",
-                    "ssl_verify": False,
-                }
-            },
-            "llm_model": {
-                "model": "openai:gpt-5.4",
-                "inference_provider": "shared",
-            },
-            "mcp_servers": {
-                "example": {
-                    "transport": "stdio",
-                    "command": "example-server",
-                }
-            },
-        })
+    merged = UrsaConfig(
+        inference_providers={
+            "shared": {
+                "base_url": "https://provider.example/v1",
+                "ssl_verify": False,
+            }
+        },
+        llm_model={"inference_provider": "shared"},
+        mcp_servers={
+            "example": {
+                "transport": "stdio",
+                "command": "example-server",
+            }
+        },
     )
-    parser = build_parser()
-    args, overrides = _parse_config_args(
-        parser,
-        [
-            "--config",
-            str(cfg_path),
-            f"--print-config={stage}",
-        ],
+    resolved = UrsaConfig(
+        inference_providers=merged.inference_providers,
+        llm_model={
+            "base_url": "https://provider.example/v1",
+            "ssl_verify": False,
+        },
+        mcp_servers=merged.mcp_servers,
+    )
+    print_config_module = importlib.import_module("ursa.cli.print_config")
+    monkeypatch.setattr(
+        print_config_module,
+        "merge_ursa_config",
+        lambda cfg, level, overrides: merged,
+    )
+    monkeypatch.setattr(
+        print_config_module,
+        "resolve_ursa_config",
+        lambda config: resolved if config is merged else config,
     )
 
-    assert print_config(args, overrides) is True
+    assert print_config(Namespace(print_config=stage), {}) is True
 
     output = yaml.safe_load(capsys.readouterr().out)
     assert "workspace" not in output
@@ -1195,28 +1009,27 @@ def test_resolve_ursa_config_creates_tmp_workspace():
     assert resolved._temp_workspace.name == str(resolved.workspace)
 
 
-def test_resolve_ursa_config_enforces_group_base_url_policy(
-    tmp_path, monkeypatch
-):
-    from ursa import security
-    from ursa.security import GroupBaseURLPolicyError
-
-    root = tmp_path / "ursa"
-    group_root = root / "science"
-    group_root.mkdir(parents=True)
-    (group_root / "group.yaml").write_text(
-        "allowed_base_urls:\n  - https://models.example.test\n",
-        encoding="utf-8",
+def test_resolve_ursa_config_checks_group_base_url_policy(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "ursa.cli.config.enforce_group_base_url_policy",
+        lambda base_url, group: calls.append((base_url, group)),
     )
-    monkeypatch.setattr(security, "URSA_CACHE_DIR", root)
-
     config = UrsaConfig(
         group="science",
         llm_model={
             "model": "openai:gpt-test",
-            "base_url": "https://disallowed.example.test/v1",
+            "base_url": "https://models.example.test/v1",
+        },
+        emb_model={
+            "model": "openai:text-embedding-test",
+            "base_url": "https://embeddings.example.test/v1",
         },
     )
 
-    with pytest.raises(GroupBaseURLPolicyError, match="not allowed"):
-        resolve_ursa_config(config)
+    resolve_ursa_config(config)
+
+    assert calls == [
+        ("https://models.example.test/v1", "science"),
+        ("https://embeddings.example.test/v1", "science"),
+    ]

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -30,6 +30,7 @@ from ursa.cli.print_config import (
     parse_print_config_spec,
     print_config,
 )
+from ursa.util.crossplatform import system_config_path, user_config_paths
 
 
 @pytest.fixture(autouse=True)
@@ -679,10 +680,8 @@ def test_xdg_config_search_paths_honor_env_overrides(tmp_path, monkeypatch):
     )
 
     assert xdg_config_search_paths() == [
-        Path("/Library/Application Support/ursa/config.yaml"),
-        home / "Library/Application Support/ursa/config.yaml",
-        home / ".config/ursa/config.yaml",
-        xdg_home / "ursa" / "config.yaml",
+        system_config_path(),
+        *user_config_paths(),
     ]
 
 

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -1,10 +1,16 @@
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 import yaml
 from openai import OpenAIError
 
-from ursa.cli import build_parser, main, resolve_config
+from ursa.cli import (
+    _xdg_config_search_paths,
+    build_parser,
+    main,
+    resolve_config,
+)
 from ursa.cli.config import (
     ChatModelConfig,
     EmbModelConfig,
@@ -209,7 +215,14 @@ def test_cli_parses_typed_flags(tmp_path):
     assert config.llm_model.max_completion_tokens == 2048
 
 
-def test_print_config_flag_sets_bool_and_preserves_defaults():
+def test_print_config_flag_sets_bool_and_preserves_defaults(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-missing"))
+    monkeypatch.setenv(
+        "XDG_CONFIG_DIRS", str(tmp_path / "xdg-dirs-missing")
+    )
+    monkeypatch.chdir(tmp_path)
     parser = build_parser()
     args = parser.parse_args(["--print-config"])
 
@@ -413,6 +426,177 @@ def test_config_file_and_cli_are_merged(tmp_path):
     assert config.llm_model.model_extra["temperature"] == 0.4
     assert config.emb_model.model == "openai:text-embedding-3-large"
     assert config.emb_model.model_extra["cache_dir"] == "/tmp/cache"
+
+
+def test_xdg_config_search_paths_honor_env_overrides(tmp_path, monkeypatch):
+    xdg_home = tmp_path / "xdg-home"
+    xdg_dir_1 = tmp_path / "xdg-dir-1"
+    xdg_dir_2 = tmp_path / "xdg-dir-2"
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_home))
+    monkeypatch.setenv(
+        "XDG_CONFIG_DIRS", f"{xdg_dir_1}:{xdg_dir_2}"
+    )
+
+    assert _xdg_config_search_paths() == [
+        xdg_dir_1 / "ursa" / "config.yaml",
+        xdg_dir_2 / "ursa" / "config.yaml",
+        xdg_home / "ursa" / "config.yaml",
+    ]
+
+
+
+def test_resolve_config_merges_xdg_local_file_and_cli_layers(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(
+        "ursa.cli.config.enforce_group_base_url_policy",
+        lambda base_url, group: None,
+    )
+    xdg_dir = tmp_path / "xdg-home"
+    xdg_dir_1 = tmp_path / "xdg-dir-1"
+    project_dir = tmp_path / "project"
+    explicit_cfg = tmp_path / "explicit.yaml"
+    cli_workspace = tmp_path / "cli-workspace"
+    cli_workspace.mkdir()
+
+    xdg_dir_config = xdg_dir_1 / "ursa" / "config.yaml"
+    xdg_dir_config.parent.mkdir(parents=True)
+    xdg_dir_config.write_text(
+        yaml.safe_dump({
+            "workspace": "xdg-dir-workspace",
+            "llm_model": {
+                "model": "openai:gpt-5-mini",
+                "max_completion_tokens": 1024,
+            },
+        })
+    )
+
+    xdg_config = xdg_dir / "ursa" / "config.yaml"
+    xdg_config.parent.mkdir(parents=True)
+    xdg_config.write_text(
+        yaml.safe_dump({
+            "workspace": "xdg-workspace",
+            "group": "xdg-group",
+            "llm_model": {
+                "model": "openai:gpt-5-mini",
+                "base_url": "https://xdg.example/v1",
+            },
+            "agent_config": {"chat": {"temperature": 0.1}},
+        })
+    )
+
+    local_config = project_dir / ".ursa" / "config.yaml"
+    local_config.parent.mkdir(parents=True)
+    local_config.write_text(
+        yaml.safe_dump({
+            "group": "local-group",
+            "llm_model": {
+                "model": "openai:gpt-5-mini",
+                "base_url": "https://local.example/v1",
+            },
+            "emb_model": {"model": "openai:text-embedding-3-small"},
+            "agent_config": {"chat": {"top_p": 0.9}},
+        })
+    )
+
+    explicit_cfg.write_text(
+        yaml.safe_dump({
+            "group": "file-group",
+            "llm_model": {
+                "model": "openai:gpt-5-mini",
+                "api_key_env": "EXPLICIT_KEY",
+            },
+            "agent_config": {"chat": {"seed": 7}},
+        })
+    )
+
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_dir))
+    monkeypatch.setenv("XDG_CONFIG_DIRS", str(xdg_dir_1))
+
+    parser = build_parser()
+    args = parser.parse_args([
+        "--config",
+        str(explicit_cfg),
+        "--workspace",
+        str(cli_workspace),
+        "--group",
+        "cli-group",
+        "--llm_model.model",
+        "openai:gpt-5-nano",
+    ])
+
+    config = resolve_config(args)
+
+    assert config.workspace == cli_workspace
+    assert config.group == "cli-group"
+    assert config.llm_model.model == "openai:gpt-5-nano"
+    assert config.llm_model.base_url == "https://local.example/v1"
+    assert config.llm_model.api_key_env == "EXPLICIT_KEY"
+    assert config.llm_model.max_completion_tokens == 1024
+    assert config.emb_model is not None
+    assert config.emb_model.model == "openai:text-embedding-3-small"
+    assert config.agent_config["chat"] == {
+        "temperature": 0.1,
+        "top_p": 0.9,
+        "seed": 7,
+    }
+
+
+def test_resolve_config_uses_local_and_xdg_defaults_without_explicit_config(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(
+        "ursa.cli.config.enforce_group_base_url_policy",
+        lambda base_url, group: None,
+    )
+    xdg_config_dir = tmp_path / "xdg-home"
+    xdg_dir_config_dir = tmp_path / "xdg-dir"
+    xdg_config = xdg_config_dir / "ursa" / "config.yaml"
+    local_config = tmp_path / "local-config.yaml"
+
+    xdg_dir_config = xdg_dir_config_dir / "ursa" / "config.yaml"
+    xdg_dir_config.parent.mkdir(parents=True)
+    xdg_dir_config.write_text(
+        yaml.safe_dump({
+            "workspace": "xdg-dir-workspace",
+            "llm_model": {"model": "openai:gpt-5-mini"},
+        })
+    )
+
+    xdg_config.parent.mkdir(parents=True)
+    xdg_config.write_text(
+        yaml.safe_dump({
+            "group": "xdg-group",
+            "llm_model": {"model": "openai:gpt-5-mini"},
+        })
+    )
+    local_config.write_text(
+        yaml.safe_dump({
+            "group": "local-group",
+            "llm_model": {
+                "model": "openai:gpt-5-mini",
+                "base_url": "https://local.example/v1",
+            },
+        })
+    )
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_config_dir))
+    monkeypatch.setenv("XDG_CONFIG_DIRS", str(xdg_dir_config_dir))
+    monkeypatch.chdir(tmp_path)
+    local_path = tmp_path / ".ursa" / "config.yaml"
+    local_path.parent.mkdir(parents=True)
+    local_path.write_text(local_config.read_text())
+
+    parser = build_parser()
+    args = parser.parse_args([])
+    config = resolve_config(args)
+
+    assert config.workspace == Path("xdg-dir-workspace")
+    assert config.group == "local-group"
+    assert config.llm_model.model == "openai:gpt-5-mini"
+    assert config.llm_model.base_url == "https://local.example/v1"
 
 
 def test_model_config_kwargs_includes_extra():

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -13,7 +13,6 @@ from pydantic import ValidationError
 from ursa.cli import (
     build_parser,
     main,
-    resolve_config,
 )
 from ursa.cli.config import (
     ChatModelConfig,
@@ -69,8 +68,8 @@ def _parse_config_args(parser, args):
 
 
 def _resolve_args(parser, args):
-    cfg, overrides = _parse_config_args(parser, args)
-    return resolve_config(cfg, overrides)
+    cfg, env_overrides = _parse_config_args(parser, args)
+    return merge_ursa_config(cfg, env_overrides=env_overrides).resolve()
 
 
 def test_cli_warns_about_legacy_unnamed_checkpoint(
@@ -185,7 +184,7 @@ def test_rag_metadata_commands_dispatch_before_config_resolution(
     handle = MagicMock(return_value=True)
     monkeypatch.setattr("ursa.cli.handle_rag_command", handle)
     monkeypatch.setattr(
-        "ursa.cli.resolve_config",
+        "ursa.cli.merge_ursa_config",
         MagicMock(side_effect=AssertionError("must not resolve config")),
     )
 
@@ -381,7 +380,7 @@ def test_print_config_parser_rejects_invalid_values(spec):
         build_parser().parse_args([f"--print-config={spec}"])
 
 
-def test_resolve_config_preserves_cli_tmp_workspace_owner():
+def test_cli_config_resolution_preserves_tmp_workspace_owner():
     parser = build_parser()
     config = _resolve_args(parser, ["--workspace", "tmp"])
 
@@ -390,7 +389,7 @@ def test_resolve_config_preserves_cli_tmp_workspace_owner():
     assert config._temp_workspace.name == str(config.workspace)
 
 
-def test_resolve_config_preserves_file_tmp_workspace_owner(tmp_path):
+def test_file_config_resolution_preserves_tmp_workspace_owner(tmp_path):
     cfg_path = tmp_path / "ursa.yml"
     cfg_path.write_text("workspace: tmp\n")
     parser = build_parser()
@@ -629,7 +628,7 @@ def test_merge_ursa_config_applies_sparse_overrides(tmp_path, monkeypatch):
 
     config = merge_ursa_config(
         Namespace(),
-        overrides={
+        env_overrides={
             "group": "default",
             "llm_model": {
                 "model": "openai:gpt-5.4",
@@ -652,7 +651,7 @@ def test_merge_ursa_config_normalizes_empty_yaml(tmp_path, monkeypatch):
         lambda cfg, level="final": [cfg_path],
     )
 
-    config = merge_ursa_config(Namespace(), overrides={})
+    config = merge_ursa_config(Namespace(), env_overrides={})
 
     assert config == UrsaConfig()
     assert load_config_file(cfg_path) == {}
@@ -712,7 +711,7 @@ def test_xdg_config_dirs_do_not_replace_native_system_config(
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "missing"))
     monkeypatch.setattr("ursa.cli.config.system_config_path", lambda: high)
 
-    config = merge_ursa_config(Namespace(), overrides={})
+    config = merge_ursa_config(Namespace(), env_overrides={})
 
     assert config.group == "high"
 
@@ -736,6 +735,24 @@ def test_config_search_paths_ignores_project_config(tmp_path, monkeypatch):
         user_cfg,
         explicit_cfg,
     ]
+
+
+def test_config_search_paths_cumulative_levels_include_lower_precedence(
+    tmp_path, monkeypatch
+):
+    system = tmp_path / "system.yaml"
+    user = tmp_path / "user.yaml"
+    explicit = tmp_path / "explicit.yaml"
+    for path in (system, user, explicit):
+        path.write_text("{}\n")
+    monkeypatch.setattr("ursa.cli.config.system_config_paths", lambda: [system])
+    monkeypatch.setattr("ursa.cli.config.user_config_paths", lambda: [user])
+    cfg = Namespace(config=explicit)
+
+    assert config_search_paths(cfg, "user") == [user]
+    assert config_search_paths(cfg, "user+") == [system, user]
+    assert config_search_paths(cfg, "file") == [explicit]
+    assert config_search_paths(cfg, "file+") == [system, user, explicit]
 
 
 def test_merge_ursa_config_validates_provider_after_merging_layers(
@@ -766,7 +783,7 @@ def test_merge_ursa_config_validates_provider_after_merging_layers(
         lambda cfg, level="final": [user_config, project_config],
     )
 
-    config = merge_ursa_config(Namespace(), overrides={})
+    config = merge_ursa_config(Namespace(), env_overrides={})
 
     assert "openai_project" in config.inference_providers
     assert config.llm_model.model == "gpt-5.4-mini"

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -641,23 +641,6 @@ def test_chat_model_config_initializes_chat_model(monkeypatch):
     assert captured_kwargs["use_responses_api"] is True
 
 
-def test_chat_model_config_rejects_unresolved_provider(monkeypatch):
-    monkeypatch.setattr(
-        "ursa.cli.config.init_chat_model",
-        lambda **kwargs: "chat-model",
-    )
-    cfg = ChatModelConfig(
-        model="openai:gpt-5",
-        inference_provider="shared",
-    )
-
-    with pytest.raises(
-        ValueError,
-        match="references unresolved inference provider 'shared'",
-    ):
-        cfg.init_chat_model()
-
-
 def test_emb_model_config_initializes_embedding_model(monkeypatch):
     captured_kwargs = {}
 
@@ -969,15 +952,6 @@ def test_print_config_omits_defaults_and_nulls(
             "command": "example-server",
         }
     }
-
-
-def test_resolve_ursa_config_promotes_use_web_to_agent_config():
-    config = UrsaConfig(use_web=True)
-
-    resolved = resolve_ursa_config(config)
-
-    for agent_name in ["chat", "execute", "deep_review", "prompt"]:
-        assert resolved.agent_config[agent_name]["use_web"] is True
 
 
 def test_resolve_ursa_config_use_web_only_fills_missing_values():

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -219,9 +219,7 @@ def test_print_config_flag_sets_bool_and_preserves_defaults(
     monkeypatch, tmp_path
 ):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-missing"))
-    monkeypatch.setenv(
-        "XDG_CONFIG_DIRS", str(tmp_path / "xdg-dirs-missing")
-    )
+    monkeypatch.setenv("XDG_CONFIG_DIRS", str(tmp_path / "xdg-dirs-missing"))
     monkeypatch.chdir(tmp_path)
     parser = build_parser()
     args = parser.parse_args(["--print-config"])
@@ -434,16 +432,13 @@ def test_xdg_config_search_paths_honor_env_overrides(tmp_path, monkeypatch):
     xdg_dir_2 = tmp_path / "xdg-dir-2"
 
     monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_home))
-    monkeypatch.setenv(
-        "XDG_CONFIG_DIRS", f"{xdg_dir_1}:{xdg_dir_2}"
-    )
+    monkeypatch.setenv("XDG_CONFIG_DIRS", f"{xdg_dir_1}:{xdg_dir_2}")
 
     assert _xdg_config_search_paths() == [
         xdg_dir_1 / "ursa" / "config.yaml",
         xdg_dir_2 / "ursa" / "config.yaml",
         xdg_home / "ursa" / "config.yaml",
     ]
-
 
 
 def test_resolve_config_merges_xdg_local_file_and_cli_layers(

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 import ursa.cli.config as config_mod
@@ -81,3 +83,31 @@ def test_model_config_model_parsing(cls):
     cfg = cls(model="bar:gpt-5.4")
     assert cfg.model == "gpt-5.4"
     assert cfg.model_provider == "bar"
+
+
+def test_model_merge_keeps_provider_defaults_resolvable():
+    config = config_mod.UrsaConfig().model_merge({
+        "llm_model": {"model": "openai:gpt-5.4"}
+    })
+
+    resolved = config.resolve()
+
+    assert resolved.llm_model.inference_provider == "openai"
+    assert resolved.llm_model.base_url == "https://api.openai.com/v1"
+    assert resolved.llm_model.api_key.env == "OPENAI_API_KEY"
+
+
+def test_ursa_config_merge_preserves_explicit_fields():
+    merged = config_mod.UrsaConfig().model_merge({"group": "science"})
+
+    assert merged.model_fields_set == {"group"}
+
+
+def test_ursa_config_merge_can_be_reused_as_sparse_layer():
+    sparse = config_mod.UrsaConfig().model_merge({"group": "science"})
+    merged = config_mod.UrsaConfig(
+        workspace=Path("/tmp/custom-workspace")
+    ).model_merge(sparse)
+
+    assert merged.group == "science"
+    assert merged.workspace == Path("/tmp/custom-workspace")

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,3 +1,5 @@
+import pytest
+
 import ursa.cli.config as config_mod
 
 
@@ -65,3 +67,17 @@ def test_deep_interp_env_recurses_nested_dictionaries(
     }
     # Confirm original structure is untouched
     assert data["layer1"]["with_env"] == "prefix ${URSA_DEEP_VALUE} suffix"
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [
+        config_mod.ModelConfig,
+        config_mod.ChatModelConfig,
+        config_mod.EmbModelConfig,
+    ],
+)
+def test_model_config_model_parsing(cls):
+    cfg = cls(model="bar:gpt-5.4")
+    assert cfg.model == "gpt-5.4"
+    assert cfg.model_provider == "bar"

--- a/tests/cli/test_config_auth_layers.py
+++ b/tests/cli/test_config_auth_layers.py
@@ -29,7 +29,8 @@ def test_config_precedence_all_six_layers(tmp_path, monkeypatch):
         lambda cfg, level="final": [system, user, explicit],
     )
 
-    assert UrsaConfig().llm_model.model == "openai:gpt-5.4"
+    assert UrsaConfig().llm_model.model == "gpt-5.4"
+    assert UrsaConfig().llm_model.model_provider == "openai"
     namespace = Namespace(config=explicit)
     config_flag = {"config": explicit}
     assert (

--- a/tests/cli/test_config_auth_layers.py
+++ b/tests/cli/test_config_auth_layers.py
@@ -10,6 +10,7 @@ from ursa.cli.config import (
     ChatModelConfig,
     UrsaConfig,
     merge_ursa_config,
+    resolve_ursa_config,
 )
 from ursa.cli.print_config import parse_print_config_spec
 from ursa.util import crossplatform
@@ -137,9 +138,16 @@ def test_default_openai_provider_is_explicit():
     config = UrsaConfig()
 
     assert config.llm_model.inference_provider == "openai"
+    assert (
+        config.inference_providers["openai"].base_url
+        == "https://api.openai.com/v1"
+    )
     assert config.inference_providers["openai"].api_key == APIKeyConfig(
         env="OPENAI_API_KEY"
     )
+
+    resolved = resolve_ursa_config(config)
+    assert resolved.llm_model.base_url == "https://api.openai.com/v1"
 
 
 def test_print_config_level_gets_default_stage():

--- a/tests/cli/test_config_auth_layers.py
+++ b/tests/cli/test_config_auth_layers.py
@@ -34,14 +34,14 @@ def test_config_precedence_all_six_layers(tmp_path, monkeypatch):
     config_flag = {"config": explicit}
     assert (
         merge_ursa_config(
-            namespace, overrides={}, cli_overrides=config_flag
+            namespace, env_overrides={}, cli_overrides=config_flag
         ).llm_model.model
         == "explicit"
     )
     assert (
         merge_ursa_config(
             namespace,
-            overrides={"llm_model": {"model": "env"}},
+            env_overrides={"llm_model": {"model": "env"}},
             cli_overrides=config_flag,
         ).llm_model.model
         == "explicit"
@@ -49,7 +49,7 @@ def test_config_precedence_all_six_layers(tmp_path, monkeypatch):
     assert (
         merge_ursa_config(
             namespace,
-            overrides={"llm_model": {"model": "env"}},
+            env_overrides={"llm_model": {"model": "env"}},
             cli_overrides={
                 "config": explicit,
                 "llm_model": {"model": "cli"},
@@ -116,7 +116,7 @@ def test_config_merge_base_url_clears_lower_priority_provider(
         lambda cfg, level="final": [user, explicit],
     )
 
-    config = merge_ursa_config(Namespace(), overrides={})
+    config = merge_ursa_config(Namespace(), env_overrides={})
 
     assert config.llm_model.base_url == "https://models.example/v1"
     assert config.llm_model.inference_provider is None
@@ -329,6 +329,6 @@ def test_user_config_precedence_is_platform_then_dot_config_then_xdg(
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(f"group: {group}\n", encoding="utf-8")
 
-    config = merge_ursa_config(Namespace(), overrides={})
+    config = merge_ursa_config(Namespace(), env_overrides={})
 
     assert config.group == "xdg"

--- a/tests/cli/test_config_auth_layers.py
+++ b/tests/cli/test_config_auth_layers.py
@@ -72,6 +72,15 @@ def test_secret_reference_requires_exactly_one_source():
         SecretReference(env="TOKEN", keyring="account")
 
 
+def test_secret_reference_maybe_validate():
+    reference = SecretReference.maybe_validate({"env": "TOKEN"})
+
+    assert reference == SecretReference(env="TOKEN")
+    assert SecretReference.maybe_validate({"unrelated": True}) == {
+        "unrelated": True
+    }
+
+
 def test_secret_reference_get_secret_value(monkeypatch):
     monkeypatch.setenv("MODEL_TOKEN", "secret")
 
@@ -81,6 +90,26 @@ def test_secret_reference_get_secret_value(monkeypatch):
             env="MODEL_TOKEN", template="Bearer %s"
         ).get_secret_value()
         == "Bearer secret"
+    )
+
+
+def test_loaded_config_exposes_typed_secret_references():
+    config = UrsaConfig.model_validate({
+        "inference_providers": {"hosted": {"api_key": {"keyring": True}}},
+        "mcp_servers": {
+            "tools": {
+                "transport": "streamable-http",
+                "url": "https://example.test/mcp",
+                "headers": {"Authorization": {"env": "MCP_TOKEN"}},
+            }
+        },
+    })
+
+    assert isinstance(
+        config.inference_providers["hosted"].api_key, SecretReference
+    )
+    assert isinstance(
+        config.mcp_servers["tools"].headers["Authorization"], SecretTemplate
     )
 
 

--- a/tests/cli/test_config_auth_layers.py
+++ b/tests/cli/test_config_auth_layers.py
@@ -6,7 +6,6 @@ from pydantic import SecretStr
 
 from ursa.cli import build_parser
 from ursa.cli.config import (
-    APIKeyConfig,
     ChatModelConfig,
     UrsaConfig,
     merge_ursa_config,
@@ -72,17 +71,23 @@ def test_model_merge_base_url_clears_inherited_inference_provider():
     assert merged.inference_provider is None
 
 
-def test_model_merge_preserves_explicit_inference_provider_with_base_url():
-    base = ChatModelConfig(
-        model="openai:gpt-5.4",
-        inference_provider="openai",
-    )
+def test_model_config_rejects_base_url_with_inference_provider():
+    with pytest.raises(
+        ValueError,
+        match="base_url and inference_provider cannot both be configured",
+    ):
+        ChatModelConfig(
+            base_url="https://models.example/v1",
+            inference_provider="hosted",
+        )
 
-    merged = base.model_merge({
-        "base_url": "https://models.example/v1",
-        "inference_provider": "hosted",
-    })
 
+def test_model_merge_inference_provider_clears_inherited_base_url():
+    base = ChatModelConfig(base_url="https://models.example/v1")
+
+    merged = base.model_merge({"inference_provider": "hosted"})
+
+    assert merged.base_url is None
     assert merged.inference_provider == "hosted"
 
 
@@ -183,10 +188,7 @@ def test_api_key_env_reference_resolves(monkeypatch):
         model="provider:model", api_key={"env": "MODEL_TOKEN"}
     )
 
-    resolved = config.resolve_api_key("provider")
-
-    assert isinstance(resolved.api_key, SecretStr)
-    assert resolved.kwargs["api_key"] == "secret"
+    assert config.kwargs["api_key"] == "secret"
 
 
 @pytest.mark.parametrize(
@@ -198,12 +200,16 @@ def test_api_key_keyring_reference(monkeypatch, setting, username):
         "keyring.get_password",
         lambda system, user: calls.append((system, user)) or "secret",
     )
-    config = ChatModelConfig(
-        model="provider:model", api_key={"keyring": setting}
+    config = UrsaConfig(
+        inference_providers={"acme": {"api_key": {"keyring": setting}}},
+        llm_model={"model": "provider:model", "inference_provider": "acme"},
     )
 
-    resolved = config.resolve_api_key("acme")
+    resolved = config.resolve().llm_model
 
+    assert isinstance(resolved.api_key, SecretReference)
+    assert resolved.api_key.keyring == username
+    assert calls == []
     assert resolved.kwargs["api_key"] == "secret"
     assert calls == [("ursa", username)]
 
@@ -217,9 +223,7 @@ def test_legacy_api_key_env_is_migrated_with_warning(monkeypatch):
             model="provider:model", api_key_env="OLD_TOKEN"
         )
 
-    resolved = config.resolve_api_key("provider")
-
-    assert resolved.kwargs["api_key"] == "secret"
+    assert config.kwargs["api_key"] == "secret"
     assert "api_key_env" not in config.model_dump()
 
 
@@ -231,7 +235,7 @@ def test_default_openai_provider_is_explicit():
         config.inference_providers["openai"].base_url
         == "https://api.openai.com/v1"
     )
-    assert config.inference_providers["openai"].api_key == APIKeyConfig(
+    assert config.inference_providers["openai"].api_key == SecretReference(
         env="OPENAI_API_KEY"
     )
     resolved = resolve_ursa_config(config)

--- a/tests/cli/test_config_auth_layers.py
+++ b/tests/cli/test_config_auth_layers.py
@@ -152,7 +152,9 @@ def test_api_key_keyring_reference(monkeypatch, setting, username):
 
 def test_legacy_api_key_env_is_migrated_with_warning(monkeypatch):
     monkeypatch.setenv("OLD_TOKEN", "secret")
-    with pytest.warns(DeprecationWarning, match="api_key_env is deprecated"):
+    with pytest.warns(
+        DeprecationWarning, match="api_key_env is deprecated in config files"
+    ):
         config = ChatModelConfig(
             model="provider:model", api_key_env="OLD_TOKEN"
         )

--- a/tests/cli/test_config_auth_layers.py
+++ b/tests/cli/test_config_auth_layers.py
@@ -59,6 +59,63 @@ def test_config_precedence_all_six_layers(tmp_path, monkeypatch):
     )
 
 
+def test_model_merge_base_url_clears_inherited_inference_provider():
+    base = ChatModelConfig(
+        model="openai:gpt-5.4",
+        inference_provider="openai",
+    )
+
+    merged = base.model_merge({"base_url": "https://models.example/v1"})
+
+    assert merged.base_url == "https://models.example/v1"
+    assert merged.inference_provider is None
+
+
+def test_model_merge_preserves_explicit_inference_provider_with_base_url():
+    base = ChatModelConfig(
+        model="openai:gpt-5.4",
+        inference_provider="openai",
+    )
+
+    merged = base.model_merge({
+        "base_url": "https://models.example/v1",
+        "inference_provider": "hosted",
+    })
+
+    assert merged.inference_provider == "hosted"
+
+
+def test_model_merge_only_applies_explicit_model_fields():
+    base = ChatModelConfig(
+        model="openai:gpt-5.4",
+        ssl_verify=False,
+        max_completion_tokens=100,
+    )
+
+    merged = base.model_merge(ChatModelConfig(max_completion_tokens=200))
+
+    assert merged.ssl_verify is False
+    assert merged.max_completion_tokens == 200
+
+
+def test_config_merge_base_url_clears_lower_priority_provider(
+    tmp_path, monkeypatch
+):
+    user = tmp_path / "user.yaml"
+    explicit = tmp_path / "explicit.yaml"
+    user.write_text("llm_model:\n  inference_provider: openai\n")
+    explicit.write_text("llm_model:\n  base_url: https://models.example/v1\n")
+    monkeypatch.setattr(
+        "ursa.cli.config.config_search_paths",
+        lambda cfg, level="final": [user, explicit],
+    )
+
+    config = merge_ursa_config(Namespace(), overrides={})
+
+    assert config.llm_model.base_url == "https://models.example/v1"
+    assert config.llm_model.inference_provider is None
+
+
 def test_api_key_direct_value_is_secret():
     config = ChatModelConfig(model="provider:model", api_key="secret")
 

--- a/tests/cli/test_config_auth_layers.py
+++ b/tests/cli/test_config_auth_layers.py
@@ -176,9 +176,21 @@ def test_default_openai_provider_is_explicit():
     assert config.inference_providers["openai"].api_key == APIKeyConfig(
         env="OPENAI_API_KEY"
     )
-
     resolved = resolve_ursa_config(config)
     assert resolved.llm_model.base_url == "https://api.openai.com/v1"
+
+
+def test_ursa_config_resolve_delegates_to_canonical_function(monkeypatch):
+    config = UrsaConfig()
+    resolved = object()
+    calls = []
+    monkeypatch.setattr(
+        "ursa.cli.config.resolve_ursa_config",
+        lambda value: calls.append(value) or resolved,
+    )
+
+    assert config.resolve() is resolved
+    assert calls == [config]
 
 
 def test_print_config_level_gets_default_stage():

--- a/tests/cli/test_config_auth_layers.py
+++ b/tests/cli/test_config_auth_layers.py
@@ -1,0 +1,221 @@
+from pathlib import Path
+
+import pytest
+from jsonargparse import Namespace
+from pydantic import SecretStr
+
+from ursa.cli import build_parser
+from ursa.cli.config import (
+    APIKeyConfig,
+    ChatModelConfig,
+    UrsaConfig,
+    merge_ursa_config,
+)
+from ursa.cli.print_config import parse_print_config_spec
+from ursa.util import crossplatform
+from ursa.util.secrets import SecretReference, SecretTemplate
+
+
+def test_config_precedence_all_six_layers(tmp_path, monkeypatch):
+    system = tmp_path / "system.yaml"
+    user = tmp_path / "user.yaml"
+    explicit = tmp_path / "explicit.yaml"
+    system.write_text("llm_model:\n  model: system\n")
+    user.write_text("llm_model:\n  model: user\n")
+    explicit.write_text("llm_model:\n  model: explicit\n")
+    monkeypatch.setattr(
+        "ursa.cli.config.config_search_paths",
+        lambda cfg, level="final": [system, user, explicit],
+    )
+
+    assert UrsaConfig().llm_model.model == "openai:gpt-5.4"
+    namespace = Namespace(config=explicit)
+    config_flag = {"config": explicit}
+    assert (
+        merge_ursa_config(
+            namespace, overrides={}, cli_overrides=config_flag
+        ).llm_model.model
+        == "explicit"
+    )
+    assert (
+        merge_ursa_config(
+            namespace,
+            overrides={"llm_model": {"model": "env"}},
+            cli_overrides=config_flag,
+        ).llm_model.model
+        == "explicit"
+    )
+    assert (
+        merge_ursa_config(
+            namespace,
+            overrides={"llm_model": {"model": "env"}},
+            cli_overrides={
+                "config": explicit,
+                "llm_model": {"model": "cli"},
+            },
+        ).llm_model.model
+        == "cli"
+    )
+
+
+def test_api_key_direct_value_is_secret():
+    config = ChatModelConfig(model="provider:model", api_key="secret")
+
+    assert isinstance(config.api_key, SecretStr)
+    assert config.kwargs["api_key"] == "secret"
+    assert "secret" not in repr(config)
+
+
+def test_secret_reference_requires_exactly_one_source():
+    with pytest.raises(ValueError, match="exactly one source"):
+        SecretReference(env="TOKEN", keyring="account")
+
+
+def test_secret_reference_get_secret_value(monkeypatch):
+    monkeypatch.setenv("MODEL_TOKEN", "secret")
+
+    assert SecretReference(env="MODEL_TOKEN").get_secret_value() == "secret"
+    assert (
+        SecretTemplate(
+            env="MODEL_TOKEN", template="Bearer %s"
+        ).get_secret_value()
+        == "Bearer secret"
+    )
+
+
+@pytest.mark.parametrize("template", ["Bearer", "%s:%s"])
+def test_secret_template_requires_one_placeholder(template):
+    with pytest.raises(ValueError, match="exactly one"):
+        SecretTemplate(env="MODEL_TOKEN", template=template)
+
+
+def test_api_key_env_reference_resolves(monkeypatch):
+    monkeypatch.setenv("MODEL_TOKEN", "secret")
+    config = ChatModelConfig(
+        model="provider:model", api_key={"env": "MODEL_TOKEN"}
+    )
+
+    resolved = config.resolve_api_key("provider")
+
+    assert isinstance(resolved.api_key, SecretStr)
+    assert resolved.kwargs["api_key"] == "secret"
+
+
+@pytest.mark.parametrize(
+    ("setting", "username"), [(True, "acme"), ("account", "account")]
+)
+def test_api_key_keyring_reference(monkeypatch, setting, username):
+    calls = []
+    monkeypatch.setattr(
+        "keyring.get_password",
+        lambda system, user: calls.append((system, user)) or "secret",
+    )
+    config = ChatModelConfig(
+        model="provider:model", api_key={"keyring": setting}
+    )
+
+    resolved = config.resolve_api_key("acme")
+
+    assert resolved.kwargs["api_key"] == "secret"
+    assert calls == [("ursa", username)]
+
+
+def test_legacy_api_key_env_is_migrated_with_warning(monkeypatch):
+    monkeypatch.setenv("OLD_TOKEN", "secret")
+    with pytest.warns(DeprecationWarning, match="api_key_env is deprecated"):
+        config = ChatModelConfig(
+            model="provider:model", api_key_env="OLD_TOKEN"
+        )
+
+    resolved = config.resolve_api_key("provider")
+
+    assert resolved.kwargs["api_key"] == "secret"
+    assert "api_key_env" not in config.model_dump()
+
+
+def test_default_openai_provider_is_explicit():
+    config = UrsaConfig()
+
+    assert config.llm_model.inference_provider == "openai"
+    assert config.inference_providers["openai"].api_key == APIKeyConfig(
+        env="OPENAI_API_KEY"
+    )
+
+
+def test_print_config_level_gets_default_stage():
+    assert parse_print_config_spec("user") == ("user", "resolved")
+    assert parse_print_config_spec("system") == ("system", "resolved")
+    assert parse_print_config_spec("file+") == ("file+", "resolved")
+
+
+def test_invalid_print_config_shows_concise_error_without_function_repr(capsys):
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["--print-config=invalid"])
+
+    error = capsys.readouterr().err
+    assert "URSA: The Universal Research and Scientific Agent" not in error
+    assert "usage: ursa" in error
+    assert "_validate_print_config_spec" not in error
+    assert "Unknown print-config level or stage 'invalid'" in error
+
+
+@pytest.mark.parametrize(
+    ("platform", "expected"),
+    [
+        ("linux", Path("/etc/ursa/config.yaml")),
+        ("darwin", Path("/Library/Application Support/ursa/config.yaml")),
+        ("win32", Path("C:/ProgramData/ursa/config.yaml")),
+    ],
+)
+def test_system_config_path_is_platform_specific(
+    monkeypatch, platform, expected
+):
+    monkeypatch.setattr(crossplatform.sys, "platform", platform)
+    monkeypatch.delenv("PROGRAMDATA", raising=False)
+
+    assert crossplatform.system_config_path() == expected
+
+
+@pytest.mark.parametrize("platform", ["linux", "darwin", "win32"])
+def test_portable_and_xdg_user_paths_override_platform_default(
+    tmp_path, monkeypatch, platform
+):
+    home = tmp_path / "home"
+    xdg_home = tmp_path / "xdg"
+    monkeypatch.setattr(crossplatform.sys, "platform", platform)
+    monkeypatch.setattr(crossplatform.Path, "home", lambda: home)
+    monkeypatch.setenv("APPDATA", str(home / "AppData/Roaming"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_home))
+
+    paths = crossplatform.user_config_paths()
+
+    assert paths[-2:] == [
+        home / ".config/ursa/config.yaml",
+        xdg_home / "ursa/config.yaml",
+    ]
+    if platform in {"darwin", "win32"}:
+        assert len(paths) == 3
+
+
+def test_user_config_precedence_is_platform_then_dot_config_then_xdg(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "home"
+    xdg_home = tmp_path / "xdg"
+    monkeypatch.setattr(crossplatform.sys, "platform", "darwin")
+    monkeypatch.setattr(crossplatform.Path, "home", lambda: home)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_home))
+    monkeypatch.delenv("XDG_CONFIG_DIRS", raising=False)
+
+    native, portable, xdg = crossplatform.user_config_paths()
+    for path, group in (
+        (native, "native"),
+        (portable, "portable"),
+        (xdg, "xdg"),
+    ):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"group: {group}\n", encoding="utf-8")
+
+    config = merge_ursa_config(Namespace(), overrides={})
+
+    assert config.group == "xdg"

--- a/tests/cli/test_config_auth_layers.py
+++ b/tests/cli/test_config_auth_layers.py
@@ -214,6 +214,22 @@ def test_api_key_keyring_reference(monkeypatch, setting, username):
     assert calls == [("ursa", username)]
 
 
+def test_resolution_populates_provider_keyring_username():
+    config = UrsaConfig(
+        inference_providers={"acme": {"api_key": {"keyring": True}}},
+        llm_model={"model": "provider:model", "inference_provider": "acme"},
+    )
+
+    resolved = config.resolve()
+
+    assert resolved.inference_providers["acme"].api_key == SecretReference(
+        keyring="acme"
+    )
+    assert config.inference_providers["acme"].api_key == SecretReference(
+        keyring=True
+    )
+
+
 def test_legacy_api_key_env_is_migrated_with_warning(monkeypatch):
     monkeypatch.setenv("OLD_TOKEN", "secret")
     with pytest.warns(

--- a/tests/cli/test_hitl.py
+++ b/tests/cli/test_hitl.py
@@ -79,7 +79,8 @@ DOCS_ROOT = Path(__file__).resolve().parents[2]
 DOC_EXAMPLE_CONFIG = DOCS_ROOT / "configs" / "example.yaml"
 
 
-def test_example_config_smoke():
+def test_example_config_smoke(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-api-key")
     assert DOC_EXAMPLE_CONFIG.is_file()
     ursa_config = resolve_ursa_config(UrsaConfig.from_file(DOC_EXAMPLE_CONFIG))
     hitl = HITL(ursa_config)

--- a/tests/cli/test_hitl.py
+++ b/tests/cli/test_hitl.py
@@ -777,24 +777,6 @@ def test_agent_config_unknown_agent_raises(tmp_path, monkeypatch):
         HITL(config)
 
 
-def test_hitl_uses_resolved_agent_config_for_use_web(tmp_path, monkeypatch):
-    _stub_hitl_dependencies(monkeypatch)
-    config = resolve_ursa_config(
-        UrsaConfig(
-            workspace=tmp_path / "global-workspace",
-            use_web=True,
-            emb_model=EmbModelConfig(model="fake-embedding"),
-        )
-    )
-
-    hitl = HITL(config)
-
-    assert hitl.agents["chat"].config["use_web"] is True
-    assert hitl.agents["execute"].config["use_web"] is True
-    assert hitl.agents["deep_review"].config["use_web"] is True
-    assert hitl.agents["prompt"].config["use_web"] is True
-
-
 def test_agent_config_none_value_errors(tmp_path, monkeypatch):
     _stub_hitl_dependencies(monkeypatch)
     config = UrsaConfig(

--- a/tests/cli/test_hitl.py
+++ b/tests/cli/test_hitl.py
@@ -15,9 +15,10 @@ from mcp import StdioServerParameters
 from pydantic import ValidationError
 from rich.console import Console as RealConsole
 
+from ursa import agents
 from ursa.agents.base import URSA_VERSION, AgentWithTools
 from ursa.cli.callbacks import HITLLogEventHandler
-from ursa.cli.config import EmbModelConfig, UrsaConfig
+from ursa.cli.config import EmbModelConfig, UrsaConfig, resolve_ursa_config
 from ursa.cli.hitl import HITL, AgentHITL, UrsaRepl, ursa_banner
 from ursa.util.events import DEFAULT_EVENT_NAME
 from ursa.util.has_optional_dep_group import has_optional_dep_group
@@ -80,7 +81,7 @@ DOC_EXAMPLE_CONFIG = DOCS_ROOT / "configs" / "example.yaml"
 
 def test_example_config_smoke():
     assert DOC_EXAMPLE_CONFIG.is_file()
-    ursa_config = UrsaConfig.from_file(DOC_EXAMPLE_CONFIG)
+    ursa_config = resolve_ursa_config(UrsaConfig.from_file(DOC_EXAMPLE_CONFIG))
     hitl = HITL(ursa_config)
     repl = UrsaRepl(hitl)
     for name in hitl.agents:
@@ -92,6 +93,36 @@ def test_has_all_agent_do_methods(ursa_config):
     repl = UrsaRepl(hitl)
     for name in hitl.agents:
         assert hasattr(repl, f"do_{name}")
+
+
+@pytest.mark.parametrize(
+    ("agent_name", "agent_class_name", "deps"),
+    [
+        ("chat", "ChatAgent", None),
+        ("arxiv", "ArxivAgent", None),
+        ("dsi", "DSIAgent", "dsi"),
+        ("execute", "ExecutionAgent", None),
+        ("deep_review", "DeepReviewAgent", None),
+        ("hypothesize", "HypothesizerAgent", None),
+        ("plan", "PlanningAgent", None),
+        ("prompt", "PromptingAgent", None),
+        ("web", "WebSearchAgent", None),
+        ("lammps", "LammpsAgent", "lammps"),
+    ],
+)
+def test_hitl_agent_registry_respects_optional_deps(
+    ursa_config, agent_name, agent_class_name, deps
+):
+    hitl = HITL(ursa_config)
+
+    if deps is not None and not has_optional_dep_group(deps):
+        assert agent_name not in hitl.agents
+        return
+
+    assert agent_name in hitl.agents
+    assert hitl.agents[agent_name].agent_class is getattr(
+        agents, agent_class_name
+    )
 
 
 def test_banner_shows_version():
@@ -257,15 +288,12 @@ def _stub_hitl_dependencies(monkeypatch):
     [
         "chat",
         "arxiv",
-        "dsi",
         "execute",
         "hypothesize",
         "plan",
         "web",
     ]
-    + ["dsi"]
-    if has_optional_dep_group("dsi")
-    else [],
+    + (["dsi"] if has_optional_dep_group("dsi") else []),
 )
 async def test_agents_apply_agent_config_overrides(
     agent_name, tmp_path, monkeypatch
@@ -746,6 +774,24 @@ def test_agent_config_unknown_agent_raises(tmp_path, monkeypatch):
 
     with pytest.raises(AssertionError, match="Unknown agent ghost"):
         HITL(config)
+
+
+def test_hitl_uses_resolved_agent_config_for_use_web(tmp_path, monkeypatch):
+    _stub_hitl_dependencies(monkeypatch)
+    config = resolve_ursa_config(
+        UrsaConfig(
+            workspace=tmp_path / "global-workspace",
+            use_web=True,
+            emb_model=EmbModelConfig(model="fake-embedding"),
+        )
+    )
+
+    hitl = HITL(config)
+
+    assert hitl.agents["chat"].config["use_web"] is True
+    assert hitl.agents["execute"].config["use_web"] is True
+    assert hitl.agents["deep_review"].config["use_web"] is True
+    assert hitl.agents["prompt"].config["use_web"] is True
 
 
 def test_agent_config_none_value_errors(tmp_path, monkeypatch):

--- a/tests/dashboard/test_settings_config.py
+++ b/tests/dashboard/test_settings_config.py
@@ -75,45 +75,6 @@ def test_dashboard_config_maps_cli_emb_model_to_dashboard_settings(tmp_path):
     }
 
 
-def test_dashboard_config_resolves_shared_inference_provider(tmp_path):
-    cfg_path = tmp_path / "provider.yaml"
-    cfg_path.write_text(
-        "\n".join([
-            "inference_providers:",
-            "  shared:",
-            "    base_url: https://models.example.org/v1",
-            "    api_key_env: SHARED_API_KEY",
-            "    timeout: 60",
-            "llm_model:",
-            "  model: openai:gpt-test",
-            "  inference_provider: shared",
-            "  timeout: 30",
-            "emb_model:",
-            "  model: openai:text-embedding-3-large",
-            "  inference_provider: shared",
-            "  dimensions: 1024",
-        ]),
-        encoding="utf-8",
-    )
-
-    patch = dashboard_llm_patch_from_ursa_config(cfg_path)
-
-    assert patch["llm"] == {
-        "model": "openai:gpt-test",
-        "base_url": "https://models.example.org/v1",
-        "api_key_env": "SHARED_API_KEY",
-        "credential_source": "environment",
-        "model_kwargs": {"timeout": 30},
-    }
-    assert patch["embedding"] == {
-        "model": "openai:text-embedding-3-large",
-        "base_url": "https://models.example.org/v1",
-        "api_key_env": "SHARED_API_KEY",
-        "credential_source": "environment",
-        "model_kwargs": {"timeout": 60, "dimensions": 1024},
-    }
-
-
 def test_dashboard_config_rejects_raw_api_key(tmp_path):
     cfg_path = tmp_path / "endpoint.yaml"
     cfg_path.write_text(

--- a/tests/dashboard/test_settings_config.py
+++ b/tests/dashboard/test_settings_config.py
@@ -12,7 +12,10 @@ from ursa_dashboard.settings import (
 )
 
 
-def test_dashboard_config_maps_cli_llm_model_to_dashboard_settings(tmp_path):
+def test_dashboard_config_maps_cli_llm_model_to_dashboard_settings(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("SAFE_API_KEY", "secret")
     cfg_path = tmp_path / "endpoint.yaml"
     cfg_path.write_text(
         "\n".join([
@@ -47,7 +50,10 @@ def test_dashboard_config_maps_cli_llm_model_to_dashboard_settings(tmp_path):
     }
 
 
-def test_dashboard_config_maps_cli_emb_model_to_dashboard_settings(tmp_path):
+def test_dashboard_config_maps_cli_emb_model_to_dashboard_settings(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("SAFE_EMBEDDING_KEY", "secret")
     cfg_path = tmp_path / "endpoint.yaml"
     cfg_path.write_text(
         "\n".join([

--- a/tests/dashboard/test_settings_config.py
+++ b/tests/dashboard/test_settings_config.py
@@ -75,6 +75,45 @@ def test_dashboard_config_maps_cli_emb_model_to_dashboard_settings(tmp_path):
     }
 
 
+def test_dashboard_config_resolves_shared_inference_provider(tmp_path):
+    cfg_path = tmp_path / "provider.yaml"
+    cfg_path.write_text(
+        "\n".join([
+            "inference_providers:",
+            "  shared:",
+            "    base_url: https://models.example.org/v1",
+            "    api_key_env: SHARED_API_KEY",
+            "    timeout: 60",
+            "llm_model:",
+            "  model: openai:gpt-test",
+            "  inference_provider: shared",
+            "  timeout: 30",
+            "emb_model:",
+            "  model: openai:text-embedding-3-large",
+            "  inference_provider: shared",
+            "  dimensions: 1024",
+        ]),
+        encoding="utf-8",
+    )
+
+    patch = dashboard_llm_patch_from_ursa_config(cfg_path)
+
+    assert patch["llm"] == {
+        "model": "openai:gpt-test",
+        "base_url": "https://models.example.org/v1",
+        "api_key_env": "SHARED_API_KEY",
+        "credential_source": "environment",
+        "model_kwargs": {"timeout": 30},
+    }
+    assert patch["embedding"] == {
+        "model": "openai:text-embedding-3-large",
+        "base_url": "https://models.example.org/v1",
+        "api_key_env": "SHARED_API_KEY",
+        "credential_source": "environment",
+        "model_kwargs": {"timeout": 60, "dimensions": 1024},
+    }
+
+
 def test_dashboard_config_rejects_raw_api_key(tmp_path):
     cfg_path = tmp_path / "endpoint.yaml"
     cfg_path.write_text(

--- a/tests/dashboard/test_settings_config.py
+++ b/tests/dashboard/test_settings_config.py
@@ -29,7 +29,7 @@ def test_dashboard_config_maps_cli_llm_model_to_dashboard_settings(tmp_path):
         encoding="utf-8",
     )
 
-    patch = dashboard_llm_patch_from_ursa_config(cfg_path)
+    patch = dashboard_llm_patch_from_ursa_config(cfg_path, group="default")
 
     assert patch == {
         "llm": {
@@ -64,7 +64,7 @@ def test_dashboard_config_maps_cli_emb_model_to_dashboard_settings(tmp_path):
         encoding="utf-8",
     )
 
-    patch = dashboard_llm_patch_from_ursa_config(cfg_path)
+    patch = dashboard_llm_patch_from_ursa_config(cfg_path, group="default")
 
     assert patch["embedding"] == {
         "model": "openai:text-embedding-3-large",
@@ -87,7 +87,7 @@ def test_dashboard_config_rejects_raw_api_key(tmp_path):
     )
 
     with pytest.raises(ValueError, match="does not store raw"):
-        dashboard_llm_patch_from_ursa_config(cfg_path)
+        dashboard_llm_patch_from_ursa_config(cfg_path, group="default")
 
 
 def test_dashboard_config_rejects_raw_embedding_api_key(tmp_path):
@@ -106,7 +106,34 @@ def test_dashboard_config_rejects_raw_embedding_api_key(tmp_path):
     with pytest.raises(
         ValueError, match="does not store raw emb_model.api_key"
     ):
-        dashboard_llm_patch_from_ursa_config(cfg_path)
+        dashboard_llm_patch_from_ursa_config(cfg_path, group="default")
+
+
+def test_dashboard_patch_enforces_selected_group_not_config_file_group(
+    tmp_path, monkeypatch
+):
+    cfg_path = tmp_path / "endpoint.yaml"
+    cfg_path.write_text(
+        "\n".join([
+            "group: source-group",
+            "llm_model:",
+            "  model: openai:gpt-test",
+            "  base_url: https://models.example.org/v1",
+        ]),
+        encoding="utf-8",
+    )
+    calls = []
+    monkeypatch.setattr(
+        "ursa.cli.config.enforce_group_base_url_policy",
+        lambda base_url, group: calls.append((base_url, group)),
+    )
+
+    patch = dashboard_llm_patch_from_ursa_config(
+        cfg_path, group="dashboard-group"
+    )
+
+    assert patch["llm"]["base_url"] == "https://models.example.org/v1"
+    assert calls == [("https://models.example.org/v1", "dashboard-group")]
 
 
 def test_apply_dashboard_config_validates_group_before_persisting(
@@ -140,6 +167,17 @@ def test_apply_dashboard_config_validates_group_before_persisting(
     assert settings.llm.model == "openai:gpt-safe"
     assert settings.llm.base_url == "https://safe.example.org/v1"
 
+    model_only_cfg = tmp_path / "model_only.yaml"
+    model_only_cfg.write_text(
+        "llm_model:\n  model: openai:gpt-updated\n",
+        encoding="utf-8",
+    )
+    settings = apply_dashboard_config(
+        store, model_only_cfg, group="my_safety_group"
+    )
+    assert settings.llm.model == "openai:gpt-updated"
+    assert settings.llm.base_url == "https://safe.example.org/v1"
+
     unsafe_cfg = tmp_path / "unsafe_endpoint.yaml"
     unsafe_cfg.write_text(
         "\n".join([
@@ -154,6 +192,6 @@ def test_apply_dashboard_config_validates_group_before_persisting(
         apply_dashboard_config(store, unsafe_cfg, group="my_safety_group")
 
     persisted = json.loads(store.path.read_text(encoding="utf-8"))
-    assert persisted["llm"]["model"] == "openai:gpt-safe"
+    assert persisted["llm"]["model"] == "openai:gpt-updated"
     assert persisted["llm"]["base_url"] == "https://safe.example.org/v1"
     assert persisted["updated_at"] != original.updated_at

--- a/tests/environments/test_environments.py
+++ b/tests/environments/test_environments.py
@@ -555,6 +555,38 @@ def test_environment_config_defaults_use_group_cache(monkeypatch, tmp_path):
     assert saved_symposium.exists()
 
 
+def test_team_config_resolves_inference_provider_keyring(monkeypatch, tmp_path):
+    calls = []
+    monkeypatch.setattr(
+        "keyring.get_password",
+        lambda service, username: calls.append((service, username)) or "secret",
+    )
+    path = tmp_path / "team.yaml"
+    path.write_text(
+        """
+name: keyring_team
+inference_providers:
+  openai:
+    api_key:
+      keyring: true
+members:
+  - name: researcher
+    model:
+      model: openai:gpt-test
+      inference_provider: openai
+""".strip(),
+        encoding="utf-8",
+    )
+
+    loaded = load_team_config(path)
+
+    assert loaded.members[0].model is not None
+    assert loaded.members[0].model.kwargs["api_key"] == "secret"
+    assert calls == [("ursa", "openai")]
+    saved = save_team_config(loaded, tmp_path / "saved.yaml")
+    assert load_team_config(saved).members[0].model is not None
+
+
 def test_result_to_text_extracts_common_result_shapes():
     assert result_to_text({"final": "done"}) == "done"
     assert (

--- a/tests/environments/test_environments.py
+++ b/tests/environments/test_environments.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import logging
 
-import pytest
 from langchain_core.language_models.fake_chat_models import FakeListChatModel
 
 from ursa import security
@@ -20,7 +19,6 @@ from ursa.environments.base import result_to_text
 from ursa.environments.config import (
     EnvironmentMemberConfig,
     load_object,
-    make_llm,
     symposium_cache_dir,
     team_cache_dir,
 )
@@ -516,23 +514,6 @@ members:
         symposium, tmp_path / "saved_symposium.yaml"
     )
     assert saved_symposium.exists()
-
-
-def test_member_model_rejects_unresolved_inference_provider():
-    member = EnvironmentMemberConfig.from_mapping({
-        "name": "analyst",
-        "model": {
-            "model": "openai:gpt-test",
-            "inference_provider": "shared",
-        },
-    })
-    default_llm = FakeListChatModel(responses=["default"])
-
-    with pytest.raises(
-        ValueError,
-        match="references unresolved inference provider 'shared'",
-    ):
-        make_llm(default_llm, member.model)
 
 
 def test_environment_config_defaults_use_group_cache(monkeypatch, tmp_path):

--- a/tests/environments/test_environments.py
+++ b/tests/environments/test_environments.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 
+import pytest
 from langchain_core.language_models.fake_chat_models import FakeListChatModel
 
 from ursa import security
@@ -19,6 +20,7 @@ from ursa.environments.base import result_to_text
 from ursa.environments.config import (
     EnvironmentMemberConfig,
     load_object,
+    make_llm,
     symposium_cache_dir,
     team_cache_dir,
 )
@@ -514,6 +516,23 @@ members:
         symposium, tmp_path / "saved_symposium.yaml"
     )
     assert saved_symposium.exists()
+
+
+def test_member_model_rejects_unresolved_inference_provider():
+    member = EnvironmentMemberConfig.from_mapping({
+        "name": "analyst",
+        "model": {
+            "model": "openai:gpt-test",
+            "inference_provider": "shared",
+        },
+    })
+    default_llm = FakeListChatModel(responses=["default"])
+
+    with pytest.raises(
+        ValueError,
+        match="references unresolved inference provider 'shared'",
+    ):
+        make_llm(default_llm, member.model)
 
 
 def test_environment_config_defaults_use_group_cache(monkeypatch, tmp_path):

--- a/tests/rag/test_persistent_rag.py
+++ b/tests/rag/test_persistent_rag.py
@@ -31,22 +31,12 @@ def test_normalize_rag_tool_names_accepts_comma_separated_values():
 
 
 def test_rag_subcommands_accept_config_after_subcommand(tmp_path: Path):
-    from ursa.cli import build_parser, resolve_config
+    from ursa.cli import build_parser
 
     source = tmp_path / "docs"
     source.mkdir()
     config_file = tmp_path / "special_group_config.yaml"
-    config_file.write_text(
-        "\n".join([
-            "llm_model:",
-            "  model: openai:gpt-test",
-            "  base_url: https://models.example.test/v1",
-            "emb_model:",
-            "  model: openai:text-embedding-test",
-            "  base_url: https://embeddings.example.test/v1",
-        ]),
-        encoding="utf-8",
-    )
+    config_file.write_text("{}\n", encoding="utf-8")
 
     parser = build_parser()
     ingest_args = [
@@ -60,14 +50,9 @@ def test_rag_subcommands_accept_config_after_subcommand(tmp_path: Path):
         str(config_file),
     ]
     cfg = parser.parse_args(ingest_args)
-    overrides = parser.parse_args(ingest_args, defaults=False)
-    resolved = resolve_config(cfg, overrides)
 
-    assert resolved.llm_model.model == "openai:gpt-test"
-    assert resolved.llm_model.base_url == "https://models.example.test/v1"
-    assert resolved.emb_model is not None
-    assert resolved.emb_model.model == "openai:text-embedding-test"
-    assert resolved.emb_model.base_url == "https://embeddings.example.test/v1"
+    assert cfg.subcommand == "rag-ingest"
+    assert cfg["rag-ingest"].config == config_file
 
     query_args = [
         "rag-query",
@@ -82,12 +67,9 @@ def test_rag_subcommands_accept_config_after_subcommand(tmp_path: Path):
         "indexed?",
     ]
     cfg = parser.parse_args(query_args)
-    overrides = parser.parse_args(query_args, defaults=False)
-    resolved = resolve_config(cfg, overrides)
 
-    assert resolved.llm_model.model == "openai:gpt-test"
-    assert resolved.emb_model is not None
-    assert resolved.emb_model.model == "openai:text-embedding-test"
+    assert cfg.subcommand == "rag-query"
+    assert cfg["rag-query"].config == config_file
 
 
 def test_resolve_ingest_source_validates_without_copying(tmp_path: Path):

--- a/tests/rag/test_persistent_rag.py
+++ b/tests/rag/test_persistent_rag.py
@@ -49,7 +49,7 @@ def test_rag_subcommands_accept_config_after_subcommand(tmp_path: Path):
     )
 
     parser = build_parser()
-    cfg = parser.parse_args([
+    ingest_args = [
         "rag-ingest",
         str(source),
         "--name",
@@ -58,8 +58,10 @@ def test_rag_subcommands_accept_config_after_subcommand(tmp_path: Path):
         "special-group",
         "--config",
         str(config_file),
-    ])
-    resolved = resolve_config(cfg)
+    ]
+    cfg = parser.parse_args(ingest_args)
+    overrides = parser.parse_args(ingest_args, defaults=False)
+    resolved = resolve_config(cfg, overrides)
 
     assert resolved.llm_model.model == "openai:gpt-test"
     assert resolved.llm_model.base_url == "https://models.example.test/v1"
@@ -67,7 +69,7 @@ def test_rag_subcommands_accept_config_after_subcommand(tmp_path: Path):
     assert resolved.emb_model.model == "openai:text-embedding-test"
     assert resolved.emb_model.base_url == "https://embeddings.example.test/v1"
 
-    cfg = parser.parse_args([
+    query_args = [
         "rag-query",
         "--name",
         "new-rag-agent",
@@ -78,8 +80,10 @@ def test_rag_subcommands_accept_config_after_subcommand(tmp_path: Path):
         "What",
         "is",
         "indexed?",
-    ])
-    resolved = resolve_config(cfg)
+    ]
+    cfg = parser.parse_args(query_args)
+    overrides = parser.parse_args(query_args, defaults=False)
+    resolved = resolve_config(cfg, overrides)
 
     assert resolved.llm_model.model == "openai:gpt-test"
     assert resolved.emb_model is not None

--- a/tests/rag/test_persistent_rag.py
+++ b/tests/rag/test_persistent_rag.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 import pytest
 from langchain_core.tools import BaseTool
 
-from ursa.cli.config import UrsaConfig
+from ursa.cli.config import ChatModelConfig, EmbModelConfig, UrsaConfig
 from ursa.rag import persistence
 from ursa.rag.persistence import (
     normalize_rag_tool_names,
@@ -70,6 +70,51 @@ def test_rag_subcommands_accept_config_after_subcommand(tmp_path: Path):
 
     assert cfg.subcommand == "rag-query"
     assert cfg["rag-query"].config == config_file
+
+
+def test_rag_models_check_group_policy_before_construction(monkeypatch):
+    from jsonargparse import Namespace
+
+    from ursa.cli.rag_management import _init_models
+
+    events = []
+    monkeypatch.setattr(
+        "ursa.cli.rag_management.enforce_group_base_url_policy",
+        lambda base_url, group: events.append(("url-policy", base_url, group)),
+    )
+    monkeypatch.setattr(
+        "ursa.cli.rag_management.enforce_model_group_policy",
+        lambda model, group: events.append(("model-policy", model, group)),
+    )
+    monkeypatch.setattr(
+        ChatModelConfig,
+        "init_chat_model",
+        lambda self: events.append(("init", "llm")) or "llm",
+    )
+    monkeypatch.setattr(
+        EmbModelConfig,
+        "init_embedding",
+        lambda self: events.append(("init", "embedding")) or "embedding",
+    )
+    config = UrsaConfig(
+        group="root-group",
+        llm_model={"base_url": "https://llm.example/v1"},
+        emb_model={
+            "model": "openai:text-embedding-test",
+            "base_url": "https://embedding.example/v1",
+        },
+    )
+
+    _init_models(Namespace(), Namespace(group="rag-group"), config=config)
+
+    assert events == [
+        ("url-policy", "https://llm.example/v1", "rag-group"),
+        ("init", "llm"),
+        ("model-policy", "llm", "rag-group"),
+        ("url-policy", "https://embedding.example/v1", "rag-group"),
+        ("init", "embedding"),
+        ("model-policy", "embedding", "rag-group"),
+    ]
 
 
 def test_resolve_ingest_source_validates_without_copying(tmp_path: Path):

--- a/tests/util/test_mcp.py
+++ b/tests/util/test_mcp.py
@@ -5,6 +5,7 @@ from mcp.client.session_group import (
 )
 
 from ursa.util import mcp as mcp_mod
+from ursa.util.secrets import SecretTemplate
 
 
 def test_start_mcp_client_adds_httpx_factory_for_sse(monkeypatch):
@@ -73,6 +74,21 @@ def test_mcp_header_resolves_keyring_secret_template(monkeypatch):
     assert captured["connections"]["demo"]["headers"] == {
         "Authorization": "Bearer token"
     }
+
+
+def test_mcp_config_loading_types_secret_headers():
+    config = mcp_mod.validate_server_parameters({
+        "transport": "streamable-http",
+        "url": "https://example.com/mcp",
+        "headers": {
+            "Authorization": {
+                "env": "MCP_TOKEN",
+                "template": "Bearer %s",
+            }
+        },
+    })
+
+    assert isinstance(config.headers["Authorization"], SecretTemplate)
 
 
 def test_mcp_header_reports_missing_environment_secret(monkeypatch):

--- a/tests/util/test_mcp.py
+++ b/tests/util/test_mcp.py
@@ -1,3 +1,4 @@
+import pytest
 from mcp.client.session_group import (
     SseServerParameters,
     StreamableHttpParameters,
@@ -40,3 +41,57 @@ def test_start_mcp_client_adds_httpx_factory_for_streamable_http(monkeypatch):
     conn = captured["connections"]["demo"]
     assert conn["transport"] == "streamable_http"
     assert conn["httpx_client_factory"] is mcp_mod.build_mcp_httpx_async_client
+
+
+def test_mcp_header_resolves_keyring_secret_template(monkeypatch):
+    captured = {}
+
+    class DummyClient:
+        def __init__(self, connections):
+            captured["connections"] = connections
+
+    monkeypatch.setattr(mcp_mod, "MultiServerMCPClient", DummyClient)
+    monkeypatch.setattr(
+        "keyring.get_password",
+        lambda service, username: (
+            "token" if (service, username) == ("ursa", "demo") else None
+        ),
+    )
+
+    mcp_mod.start_mcp_client({
+        "demo": StreamableHttpParameters(
+            url="https://example.com/mcp",
+            headers={
+                "Authorization": {
+                    "keyring": True,
+                    "template": "Bearer %s",
+                }
+            },
+        )
+    })
+
+    assert captured["connections"]["demo"]["headers"] == {
+        "Authorization": "Bearer token"
+    }
+
+
+def test_mcp_header_reports_missing_environment_secret(monkeypatch):
+    monkeypatch.delenv("MCP_TOKEN", raising=False)
+
+    with pytest.raises(ValueError, match="MCP server 'demo' is not set"):
+        mcp_mod.start_mcp_client({
+            "demo": StreamableHttpParameters(
+                url="https://example.com/mcp",
+                headers={"Authorization": {"env": "MCP_TOKEN"}},
+            )
+        })
+
+
+def test_mcp_header_rejects_invalid_secret_mapping():
+    with pytest.raises(ValueError, match="Extra inputs are not permitted"):
+        mcp_mod.start_mcp_client({
+            "demo": StreamableHttpParameters(
+                url="https://example.com/mcp",
+                headers={"Authorization": {"enb": "MCP_TOKEN"}},
+            )
+        })

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'darwin'",
@@ -1774,7 +1774,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
     { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
     { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
@@ -1785,7 +1784,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
-    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -1796,7 +1794,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -1807,7 +1804,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -4242,7 +4238,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -4253,7 +4249,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -4280,9 +4276,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -4293,7 +4289,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -4839,7 +4835,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -6715,8 +6711,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -6921,23 +6917,23 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.12'" },
-    { name = "babel", marker = "python_full_version < '3.12'" },
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version < '3.12'" },
-    { name = "imagesize", marker = "python_full_version < '3.12'" },
-    { name = "jinja2", marker = "python_full_version < '3.12'" },
-    { name = "packaging", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "requests", marker = "python_full_version < '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version < '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -6960,23 +6956,23 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
@@ -7592,6 +7588,7 @@ dependencies = [
     { name = "fastmcp" },
     { name = "jsonargparse" },
     { name = "justext" },
+    { name = "keyring" },
     { name = "langchain" },
     { name = "langchain-anthropic" },
     { name = "langchain-chroma" },
@@ -7618,7 +7615,6 @@ dependencies = [
 [package.optional-dependencies]
 dashboard = [
     { name = "fastapi" },
-    { name = "keyring" },
     { name = "uvicorn" },
 ]
 dsi = [
@@ -7686,7 +7682,7 @@ requires-dist = [
     { name = "fastmcp", specifier = "~=3.0" },
     { name = "jsonargparse", specifier = ">=4.45.0" },
     { name = "justext", specifier = ">=3.0.2" },
-    { name = "keyring", marker = "extra == 'dashboard'", specifier = ">=25.0.0,<26.0.0" },
+    { name = "keyring", specifier = ">=25.0.0,<26.0.0" },
     { name = "langchain", specifier = ">=1.3.2" },
     { name = "langchain-anthropic", specifier = ">=1.4" },
     { name = "langchain-chroma", specifier = ">=1.0.0" },


### PR DESCRIPTION
Fixes #151 

Main things:
1. Splitting configuration resolution into 3 steps: Parsing, Merging and Resolution. Resolution is handles looking llm/emb model configuration from the inference store and creating a tmp workspace. Group Policy checks have been moved into validation (runtime checks remain)
2. Configuration files can be layered! Basically `~/.config/ursa/config.yaml` will now be loaded as URSA's base config, with `--config`, cli flags and env vars layering on top. There's currently not a way to say "only this config" but later layers can fully override. It's not as clever as the dashboard's layering (some entries replace other merge), but I think that's a) probably find and b) keeps us from becoming a full on configuration management tool
3. `ursa --print-config` learned new tricks

Plus more docs!
