### PR TITLE
fix: capture reasoning and cached tokens from all usage carriers

### DIFF
--- a/src/ursa/observability/timing.py
+++ b/src/ursa/observability/timing.py
@@ -498,6 +498,13 @@ def _to_int(x, default=0):
     return default
 
 
+def _detail_dict(v) -> dict:
+    """Read a detail container defensively: raw side-channel dicts are not
+    schema-validated, and a malformed container must read as empty rather
+    than poison the whole event's usage parse."""
+    return v if isinstance(v, dict) else {}
+
+
 def _reasoning_from(d: dict) -> int:
     """Strongest reasoning count among all known carriers in one dict.
 
@@ -508,11 +515,13 @@ def _reasoning_from(d: dict) -> int:
     """
     candidates = [
         d.get("reasoning_tokens"),
-        (d.get("completion_tokens_details") or {}).get("reasoning_tokens"),
-        (d.get("output_tokens_details") or {}).get("reasoning_tokens"),
-        (d.get("output_tokens_details") or {}).get("thinking_tokens"),
+        _detail_dict(d.get("completion_tokens_details")).get(
+            "reasoning_tokens"
+        ),
+        _detail_dict(d.get("output_tokens_details")).get("reasoning_tokens"),
+        _detail_dict(d.get("output_tokens_details")).get("thinking_tokens"),
     ]
-    details = d.get("output_token_details") or {}
+    details = _detail_dict(d.get("output_token_details"))
     for key, value in details.items():
         if key == "reasoning" or key.endswith("_reasoning"):
             candidates.append(value)
@@ -529,12 +538,12 @@ def _cached_from(d: dict) -> int:
     candidates = [
         d.get("cached_tokens"),
         d.get("cached_input_tokens"),
-        (d.get("prompt_tokens_details") or {}).get("cached_tokens"),
+        _detail_dict(d.get("prompt_tokens_details")).get("cached_tokens"),
         d.get("prompt_cache_hits"),
         d.get("cache_read_input_tokens"),
-        (d.get("input_tokens_details") or {}).get("cached_tokens"),
+        _detail_dict(d.get("input_tokens_details")).get("cached_tokens"),
     ]
-    details = d.get("input_token_details") or {}
+    details = _detail_dict(d.get("input_token_details"))
     for key, value in details.items():
         if key == "cache_read" or key.endswith("_cache_read"):
             candidates.append(value)

--- a/src/ursa/observability/timing.py
+++ b/src/ursa/observability/timing.py
@@ -498,6 +498,49 @@ def _to_int(x, default=0):
     return default
 
 
+def _reasoning_from(d: dict) -> int:
+    """Strongest reasoning count among all known carriers in one dict.
+
+    Covers the raw provider namings (completion_tokens_details for Chat
+    Completions, output_tokens_details for the Responses API and for
+    Anthropic thinking counts) and langchain's standardized
+    output_token_details, including service-tier-prefixed keys.
+    """
+    candidates = [
+        d.get("reasoning_tokens"),
+        (d.get("completion_tokens_details") or {}).get("reasoning_tokens"),
+        (d.get("output_tokens_details") or {}).get("reasoning_tokens"),
+        (d.get("output_tokens_details") or {}).get("thinking_tokens"),
+    ]
+    details = d.get("output_token_details") or {}
+    for key, value in details.items():
+        if key == "reasoning" or key.endswith("_reasoning"):
+            candidates.append(value)
+    return max((_to_int(v) for v in candidates), default=0)
+
+
+def _cached_from(d: dict) -> int:
+    """Strongest cache-read count among all known carriers in one dict.
+
+    Cache-creation counts are intentionally excluded: pricing treats
+    cached_tokens as the cache-read discount, and cache writes bill
+    differently.
+    """
+    candidates = [
+        d.get("cached_tokens"),
+        d.get("cached_input_tokens"),
+        (d.get("prompt_tokens_details") or {}).get("cached_tokens"),
+        d.get("prompt_cache_hits"),
+        d.get("cache_read_input_tokens"),
+        (d.get("input_tokens_details") or {}).get("cached_tokens"),
+    ]
+    details = d.get("input_token_details") or {}
+    for key, value in details.items():
+        if key == "cache_read" or key.endswith("_cache_read"):
+            candidates.append(value)
+    return max((_to_int(v) for v in candidates), default=0)
+
+
 def _acc_from(d: dict, roll: dict):
     # Map whatever keys exist into our canonical fields
     it = _to_int(d.get("input_tokens", d.get("prompt_tokens")))
@@ -513,19 +556,8 @@ def _acc_from(d: dict, roll: dict):
     roll["completion_tokens"] += _to_int(d.get("completion_tokens", ot))
 
     # extras / synonyms
-    # reasoning
-    roll["reasoning_tokens"] += _to_int(
-        d.get("reasoning_tokens")
-        or (d.get("completion_tokens_details") or {}).get("reasoning_tokens")
-    )
-    # cached
-    cached = (
-        d.get("cached_tokens")
-        or d.get("cached_input_tokens")
-        or (d.get("prompt_tokens_details") or {}).get("cached_tokens")
-        or d.get("prompt_cache_hits")
-    )
-    roll["cached_tokens"] += _to_int(cached)
+    roll["reasoning_tokens"] += _reasoning_from(d)
+    roll["cached_tokens"] += _cached_from(d)
 
     # costs if exposed (keep as floats)
     for k in ("input_cost", "output_cost", "total_cost"):
@@ -535,24 +567,6 @@ def _acc_from(d: dict, roll: dict):
                 roll[k] += float(v)
             except Exception:
                 pass
-
-
-def _maybe_add_extras(d: dict, roll: dict):
-    if not isinstance(d, dict):
-        return
-    # reasoning
-    rt = d.get("reasoning_tokens") or (
-        d.get("completion_tokens_details") or {}
-    ).get("reasoning_tokens")
-    roll["reasoning_tokens"] += _to_int(rt)
-    # cached
-    cached = (
-        d.get("cached_tokens")
-        or d.get("cached_input_tokens")
-        or (d.get("prompt_tokens_details") or {}).get("cached_tokens")
-        or d.get("prompt_cache_hits")
-    )
-    roll["cached_tokens"] += _to_int(cached)
 
 
 class PerLLMTimer(BaseCallbackHandler):
@@ -683,29 +697,9 @@ class PerLLMTimer(BaseCallbackHandler):
             def _extract_extras(d: dict) -> dict:
                 if not isinstance(d, dict):
                     return {"reasoning_tokens": 0, "cached_tokens": 0}
-                # reasoning
-                rt = d.get("reasoning_tokens") or (
-                    d.get("completion_tokens_details") or {}
-                ).get("reasoning_tokens")
-                # cached
-                cached = (
-                    d.get("cached_tokens")
-                    or d.get("cached_input_tokens")
-                    or (d.get("prompt_tokens_details") or {}).get(
-                        "cached_tokens"
-                    )
-                    or d.get("prompt_cache_hits")
-                )
-
-                def _to_int(x):
-                    try:
-                        return int(float(x))
-                    except Exception:
-                        return 0
-
                 return {
-                    "reasoning_tokens": _to_int(rt),
-                    "cached_tokens": _to_int(cached),
+                    "reasoning_tokens": _reasoning_from(d),
+                    "cached_tokens": _cached_from(d),
                 }
 
             # Enrich from non-selected sources only (avoid double-counting the same info)
@@ -720,12 +714,16 @@ class PerLLMTimer(BaseCallbackHandler):
                     extras_candidates.append(_extract_extras(d or {}))
 
             if extras_candidates:
-                # choose the strongest signal present rather than summing duplicates
-                roll["reasoning_tokens"] += max(
-                    e["reasoning_tokens"] for e in extras_candidates
+                # The selected source can now carry these counts too, so
+                # take the strongest signal overall instead of adding the
+                # side-channel copy on top of it.
+                roll["reasoning_tokens"] = max(
+                    roll["reasoning_tokens"],
+                    max(e["reasoning_tokens"] for e in extras_candidates),
                 )
-                roll["cached_tokens"] += max(
-                    e["cached_tokens"] for e in extras_candidates
+                roll["cached_tokens"] = max(
+                    roll["cached_tokens"],
+                    max(e["cached_tokens"] for e in extras_candidates),
                 )
 
             # Final consistency guards

--- a/tests/observability/test_usage_rollup.py
+++ b/tests/observability/test_usage_rollup.py
@@ -7,7 +7,6 @@ exact non-double-counting semantics. The guard tests pin the paths that
 already work today.
 """
 
-import tempfile
 import uuid
 from collections.abc import Iterator
 from types import SimpleNamespace
@@ -174,18 +173,19 @@ class _ToolReadyFakeChatModel(GenericFakeChatModel):
         return self
 
 
-def test_end_to_end_chart_surface_nonzero():
+def test_end_to_end_chart_surface_nonzero(tmp_path):
     # The exact aggregation surface from the issue's screenshot must see
-    # the counts once extraction captures them.
-    with tempfile.TemporaryDirectory() as tmp:
-        agent = ChatAgent(
-            llm=_ToolReadyFakeChatModel(messages=_standardized_stream()),
-            workspace=tmp,
-        )
-        agent.invoke({"messages": [], "query": "hello"})
-        payload = agent.telemetry.to_json(
-            include_raw_snapshot=False, include_raw_records=False
-        )
+    # the counts once extraction captures them. The workspace is a
+    # tmp_path because the agent's sqlite checkpointer keeps its file
+    # open past the test, and Windows cannot delete open files.
+    agent = ChatAgent(
+        llm=_ToolReadyFakeChatModel(messages=_standardized_stream()),
+        workspace=tmp_path,
+    )
+    agent.invoke({"messages": [], "query": "hello"})
+    payload = agent.telemetry.to_json(
+        include_raw_snapshot=False, include_raw_records=False
+    )
 
     totals, _samples = extract_llm_token_stats(payload)
     assert totals.get("reasoning_tokens") == 30

--- a/tests/observability/test_usage_rollup.py
+++ b/tests/observability/test_usage_rollup.py
@@ -1,0 +1,281 @@
+"""Acceptance tests for the 165 usage-rollup repair.
+
+Pre-registered before the fix: reasoning and cached counts must be
+captured from langchain's standardized usage_metadata detail containers
+and from the raw side-channel namings that several providers use, with
+exact non-double-counting semantics. The guard tests pin the paths that
+already work today.
+"""
+
+import tempfile
+import uuid
+from collections.abc import Iterator
+from types import SimpleNamespace
+
+from langchain_core.language_models.fake_chat_models import (
+    GenericFakeChatModel,
+)
+from langchain_core.messages import AIMessage
+from langchain_core.outputs import ChatGeneration, LLMResult
+
+from ursa.agents.chat_agent import ChatAgent
+from ursa.observability.metrics_charts import extract_llm_token_stats
+from ursa.observability.timing import PerLLMTimer
+
+_RAW_CC = {
+    "prompt_tokens": 100,
+    "completion_tokens": 80,
+    "total_tokens": 180,
+    "completion_tokens_details": {"reasoning_tokens": 30},
+    "prompt_tokens_details": {"cached_tokens": 20},
+}
+
+_STANDARDIZED = {
+    "input_tokens": 100,
+    "output_tokens": 80,
+    "total_tokens": 180,
+    "input_token_details": {"cache_read": 20},
+    "output_token_details": {"reasoning": 30},
+}
+
+
+def _roll(message=None, llm_output=None, messages=None):
+    timer = PerLLMTimer()
+    run_id = uuid.uuid4()
+    timer.on_llm_start({}, [], run_id=run_id, metadata={"model": "m"})
+    msgs = messages if messages is not None else [message]
+    generations = [[ChatGeneration(message=m) for m in msgs]]
+    timer.on_llm_end(
+        LLMResult(generations=generations, llm_output=llm_output),
+        run_id=run_id,
+    )
+    return timer.samples[-1]["metrics"].get("usage_rollup") or {}
+
+
+def test_standardized_details_captured():
+    # Issue 165: reasoning and cache_read arriving only in the
+    # standardized usage_metadata details (the Gemini, OpenAI Responses,
+    # and streaming shapes) must be captured.
+    roll = _roll(message=AIMessage("x", usage_metadata=dict(_STANDARDIZED)))
+
+    assert roll.get("reasoning_tokens") == 30
+    assert roll.get("cached_tokens") == 20
+
+
+def test_responses_raw_naming_captured():
+    # Defensive: the Responses-API raw container names.
+    roll = _roll(
+        message=AIMessage("x"),
+        llm_output={
+            "token_usage": {
+                "input_tokens": 100,
+                "output_tokens": 80,
+                "total_tokens": 180,
+                "output_tokens_details": {"reasoning_tokens": 30},
+                "input_tokens_details": {"cached_tokens": 20},
+            }
+        },
+    )
+
+    assert roll.get("reasoning_tokens") == 30
+    assert roll.get("cached_tokens") == 20
+
+
+def test_anthropic_cache_captured_exactly():
+    # Anthropic shape with BOTH carriers: cached must be exactly the
+    # cache-read count; cache_creation stays out of cached_tokens
+    # (pricing treats cached as the cache-read discount).
+    roll = _roll(
+        message=AIMessage(
+            "x",
+            usage_metadata={
+                "input_tokens": 120,
+                "output_tokens": 80,
+                "total_tokens": 200,
+                "input_token_details": {
+                    "cache_read": 20,
+                    "cache_creation": 5,
+                },
+            },
+            response_metadata={
+                "usage": {
+                    "input_tokens": 95,
+                    "output_tokens": 80,
+                    "cache_read_input_tokens": 20,
+                    "cache_creation_input_tokens": 5,
+                }
+            },
+        )
+    )
+
+    assert roll.get("cached_tokens") == 20
+
+
+def test_anthropic_raw_thinking_captured():
+    # Current Anthropic SDKs expose thinking counts in the raw usage the
+    # adapter forwards; the defensive synonym must capture them.
+    roll = _roll(
+        message=AIMessage(
+            "x",
+            response_metadata={
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 80,
+                    "output_tokens_details": {"thinking_tokens": 30},
+                }
+            },
+        )
+    )
+
+    assert roll.get("reasoning_tokens") == 30
+
+
+def test_service_tier_prefixed_details_captured():
+    # langchain-openai prefixes detail keys with the service tier; the
+    # bare tier bucket key must NOT be counted as reasoning.
+    roll = _roll(
+        message=AIMessage(
+            "x",
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 80,
+                "total_tokens": 180,
+                "input_token_details": {"flex_cache_read": 20},
+                "output_token_details": {"flex_reasoning": 30, "flex": 999},
+            },
+        )
+    )
+
+    assert roll.get("reasoning_tokens") == 30
+    assert roll.get("cached_tokens") == 20
+
+
+def test_two_generations_sum_reasoning():
+    # Per-message summation is preserved: two generations each carrying
+    # standardized reasoning must sum.
+    roll = _roll(
+        messages=[
+            AIMessage("a", usage_metadata=dict(_STANDARDIZED)),
+            AIMessage("b", usage_metadata=dict(_STANDARDIZED)),
+        ]
+    )
+
+    assert roll.get("reasoning_tokens") == 60
+    assert roll.get("cached_tokens") == 40
+
+
+def _standardized_stream() -> Iterator[AIMessage]:
+    while True:
+        yield AIMessage("ok", usage_metadata=dict(_STANDARDIZED))
+
+
+class _ToolReadyFakeChatModel(GenericFakeChatModel):
+    def bind_tools(self, tools, **kwargs):
+        return self
+
+
+def test_end_to_end_chart_surface_nonzero():
+    # The exact aggregation surface from the issue's screenshot must see
+    # the counts once extraction captures them.
+    with tempfile.TemporaryDirectory() as tmp:
+        agent = ChatAgent(
+            llm=_ToolReadyFakeChatModel(messages=_standardized_stream()),
+            workspace=tmp,
+        )
+        agent.invoke({"messages": [], "query": "hello"})
+        payload = agent.telemetry.to_json(
+            include_raw_snapshot=False, include_raw_records=False
+        )
+
+    totals, _samples = extract_llm_token_stats(payload)
+    assert totals.get("reasoning_tokens") == 30
+    assert totals.get("cached_tokens") == 20
+
+
+def test_raw_chat_completions_llm_output_pinned():
+    # Guard (green before and after): the raw Chat Completions rescue.
+    roll = _roll(
+        message=AIMessage("x"), llm_output={"token_usage": dict(_RAW_CC)}
+    )
+
+    assert roll.get("reasoning_tokens") == 30
+    assert roll.get("cached_tokens") == 20
+
+
+def test_raw_response_metadata_pinned():
+    # Guard (green before and after): raw usage in response_metadata.
+    roll = _roll(
+        message=AIMessage("x", response_metadata={"token_usage": dict(_RAW_CC)})
+    )
+
+    assert roll.get("reasoning_tokens") == 30
+    assert roll.get("cached_tokens") == 20
+
+
+def test_attr_object_coercion_pinned():
+    # Guard (green before and after): attribute-object usage coercion.
+    roll = _roll(
+        message=AIMessage("x"),
+        llm_output={
+            "token_usage": SimpleNamespace(
+                prompt_tokens=100,
+                completion_tokens=80,
+                total_tokens=180,
+                completion_tokens_details=SimpleNamespace(reasoning_tokens=30),
+                prompt_tokens_details=SimpleNamespace(cached_tokens=20),
+            )
+        },
+    )
+
+    assert roll.get("reasoning_tokens") == 30
+    assert roll.get("cached_tokens") == 20
+
+
+def test_both_carriers_no_double_count():
+    # Guard: with the standardized carrier AND the raw side-channel both
+    # present (the real ChatOpenAI shape), counts appear exactly once.
+    roll = _roll(
+        message=AIMessage("x", usage_metadata=dict(_STANDARDIZED)),
+        llm_output={"token_usage": dict(_RAW_CC)},
+    )
+
+    assert roll.get("reasoning_tokens") == 30, "double-counted reasoning"
+    assert roll.get("cached_tokens") == 20, "double-counted cached"
+
+
+def test_empty_details_clean():
+    # Guard: empty detail containers stay zero without crashing.
+    roll = _roll(
+        message=AIMessage(
+            "x",
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 80,
+                "total_tokens": 180,
+                "input_token_details": {},
+                "output_token_details": {},
+            },
+        )
+    )
+
+    assert roll.get("reasoning_tokens") == 0
+    assert roll.get("cached_tokens") == 0
+
+
+def test_dual_names_single_dict_no_double():
+    # Guard: one dict carrying the same count under two namings yields
+    # the count once.
+    roll = _roll(
+        message=AIMessage(
+            "x",
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 80,
+                "total_tokens": 180,
+                "completion_tokens_details": {"reasoning_tokens": 30},
+                "output_token_details": {"reasoning": 30},
+            },
+        )
+    )
+
+    assert roll.get("reasoning_tokens") == 30

--- a/tests/observability/test_usage_rollup.py
+++ b/tests/observability/test_usage_rollup.py
@@ -279,3 +279,29 @@ def test_dual_names_single_dict_no_double():
     )
 
     assert roll.get("reasoning_tokens") == 30
+
+
+def test_malformed_detail_containers_survive():
+    # Guard: a malformed (non-dict) detail container in a raw side-channel
+    # must not poison the event; headline counts survive and extras stay
+    # zero.
+    roll = _roll(
+        message=AIMessage("x"),
+        llm_output={
+            "token_usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 80,
+                "total_tokens": 180,
+                "completion_tokens_details": True,
+                "output_tokens_details": "oops",
+                "output_token_details": ["reasoning", 30],
+                "input_tokens_details": 7,
+                "input_token_details": "cache_read",
+            }
+        },
+    )
+
+    assert roll.get("input_tokens") == 100
+    assert roll.get("output_tokens") == 80
+    assert roll.get("reasoning_tokens") == 0
+    assert roll.get("cached_tokens") == 0


### PR DESCRIPTION
## Summary

Fixes #165. The usage rollup read reasoning and cached counts only under raw provider names (`completion_tokens_details`, `prompt_tokens_details`, and flat synonyms). Counts arriving solely in langchain's standardized `usage_metadata` details (`output_token_details.reasoning`, `input_token_details.cache_read`) were lost, and the side-channel rescue pass scanned only the raw sources. Headline counts were unaffected, so metrics looked healthy apart from permanent zeros in exactly the reasoning and cached categories.

The paths that lose counts today: every OpenAI Responses-API run (which the CLI makes the default for OpenAI models via `use_responses_api=True` since #253), every Gemini thinking run, streamed usage (a latent path today; URSA itself does not stream LLM calls), and Anthropic cache counts under their raw names. OpenAI Chat Completions was never affected because the adapter also stores raw `token_usage` in `llm_output`, where the rollup already looked. Endpoints that never report these counts (vLLM-style gateways, Ollama) still correctly show zero; the full path-by-path diagnosis is in #165.

One note: #165 has an assignee, so treat this as a ready-made option; happy to adjust or step back if a different direction is preferred.

## The change

Extraction funnels every known carrier through two helpers: the standardized details including service-tier-prefixed keys (with the bare tier bucket excluded), the raw Responses-API container names, and Anthropic's `cache_read_input_tokens` and `output_tokens_details.thinking_tokens`. Within one source dict the strongest signal wins, so a response carrying the same count under two namings does not double. Across sources, the extras merge becomes a maximum rather than an addition, because the selected source can now carry the counts itself. Two deliberate exclusions: cache-creation counts stay out of `cached_tokens` (pricing treats cached as the cache-read discount, and cache writes bill differently; a separate `cache_creation` field would be its own change), and the never-called `_maybe_add_extras` helper is removed. Detail containers are also read defensively: a malformed (non-dict) container in a raw side-channel reads as empty instead of discarding the event's whole rollup through the parse-error path.

One behavior note: models configured with a `reasoning_per_1k` price will begin accruing reasoning cost once reasoning counts flow; no entry in the shipped pricing registry sets `reasoning_per_1k`, so reasoning stays at zero cost by default. Cached counts now feed the existing cache-read discount, so for models the shipped `pricing.json` prices with a `cached_input_multiplier` below 1, the computed input cost of cached runs drops to the discounted rate instead of billing all input at full price.

## Tests

Fourteen tests in a new `tests/observability/test_usage_rollup.py`. Seven were committed red first and flipped by the fix with no test edits: standardized-details capture, raw Responses naming, Anthropic cache captured as exactly the cache-read count, Anthropic raw thinking capture, service-tier-prefixed keys with the bare tier bucket excluded, per-message summation across generations, and an end-to-end run asserting nonzero counts through the exact chart-aggregation surface shown in the issue's screenshot. Six green guards pin the already-working raw paths, attribute-object coercion, exact non-double-counting with both carriers present, dual-named single dicts, and empty detail containers. The fourteenth pins the defensive container read: a truthy non-dict detail container previously discarded the event's entire rollup, and now reads as empty with the headline counts surviving. Running the test commit without the fix commits reproduces the exact 7 failed / 6 passed pattern. Full suite locally: 393 passed, 1 failed, 10 skipped; the failure is the pre-existing `test_example_config_smoke`, which requires `OPENAI_API_KEY`.
