### PR TITLE
fix: surface invalid agent names as 400s and check them in the UI

### DIFF
--- a/src/ursa/cli/agent_management.py
+++ b/src/ursa/cli/agent_management.py
@@ -195,7 +195,7 @@ def validate_agent_name(name: str) -> str:
         raise ValueError("Agent name must be a simple directory name")
     if not _AGENT_NAME_RE.fullmatch(name):
         raise ValueError(
-            "Agent name may only contain letters, numbers, dot, underscore, and hyphen"
+            "Agent name may only contain letters, numbers, dot, underscore, and hyphen, and must start with a letter or number"
         )
     return name
 

--- a/src/ursa_dashboard/app.py
+++ b/src/ursa_dashboard/app.py
@@ -155,6 +155,13 @@ from .settings import (
 )
 
 
+def _validated_agent_name(raw: str) -> str:
+    try:
+        return validate_agent_name(raw)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
 def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
     auth = AuthConfig.from_env()
 
@@ -596,7 +603,7 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
     def create_session(req: SessionCreateRequest) -> SessionDetail:
         agent_name = str(req.agent_name or "").strip() or None
         if agent_name is not None:
-            validate_agent_name(agent_name)
+            _validated_agent_name(agent_name)
             # New named agents are allowed. If the directory does not yet exist,
             # the underlying agent class will create persistent state on first use.
 
@@ -873,7 +880,9 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
         dependencies=[Depends(require_auth)],
     )
     def save_named_agent(payload: dict[str, Any]) -> dict[str, Any]:
-        name = validate_agent_name(str(payload.get("agent_name") or "").strip())
+        name = _validated_agent_name(
+            str(payload.get("agent_name") or "").strip()
+        )
         cli_save_agent(name, dashboard_group)
         return {
             "ok": True,
@@ -887,10 +896,10 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
         dependencies=[Depends(require_auth)],
     )
     def copy_named_agent(payload: dict[str, Any]) -> dict[str, Any]:
-        source = validate_agent_name(
+        source = _validated_agent_name(
             str(payload.get("source_agent_name") or "").strip()
         )
-        new_name = validate_agent_name(
+        new_name = _validated_agent_name(
             str(payload.get("new_agent_name") or "").strip()
         )
         cli_copy_agent(new_name, source, dashboard_group, dashboard_group)
@@ -907,7 +916,9 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
         dependencies=[Depends(require_auth)],
     )
     def delete_named_agent(payload: dict[str, Any]) -> dict[str, Any]:
-        name = validate_agent_name(str(payload.get("agent_name") or "").strip())
+        name = _validated_agent_name(
+            str(payload.get("agent_name") or "").strip()
+        )
         cli_delete_agent(name, dashboard_group)
         return {
             "ok": True,
@@ -3513,6 +3524,10 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
           alert('Agent name cannot be empty.');
           return;
         }
+        if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(trimmed)) {
+          alert('Agent name may only contain letters, numbers, dot, underscore, and hyphen, and must start with a letter or number.');
+          return;
+        }
         await startSession('', trimmed);
       };
     }
@@ -3797,19 +3812,23 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
   }
 
   async function startSession(agentId, agentName='') {
-    const workspace = await chooseWorkspaceSelection({
-      title: 'Choose a workspace for this session',
-    });
-    if (!workspace) return;
-    const payload = {};
-    if (String(agentId || '').trim()) payload.agent_id = String(agentId || '').trim();
-    if (String(agentName || '').trim()) payload.agent_name = String(agentName || '').trim();
-    payload.workspace_mode = workspace.workspace_mode;
-    if (workspace.workspace_path) payload.workspace_path = workspace.workspace_path;
-    const res = await api('POST', '/sessions', payload);
-    await refreshAgents();
-    await refreshSessions();
-    await loadSession(res.session.session_id);
+    try {
+      const workspace = await chooseWorkspaceSelection({
+        title: 'Choose a workspace for this session',
+      });
+      if (!workspace) return;
+      const payload = {};
+      if (String(agentId || '').trim()) payload.agent_id = String(agentId || '').trim();
+      if (String(agentName || '').trim()) payload.agent_name = String(agentName || '').trim();
+      payload.workspace_mode = workspace.workspace_mode;
+      if (workspace.workspace_path) payload.workspace_path = workspace.workspace_path;
+      const res = await api('POST', '/sessions', payload);
+      await refreshAgents();
+      await refreshSessions();
+      await loadSession(res.session.session_id);
+    } catch (e) {
+      alert(String(e && e.message ? e.message : e));
+    }
   }
 
   async function renameSession(sessionId, newTitle) {
@@ -4515,9 +4534,13 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
         saveBtn.type = 'button';
         saveBtn.textContent = 'Checkpoint';
         saveBtn.onclick = async () => {
-          await api('POST', '/agent-management/save', { agent_name: item.agent_name });
-          await refreshAgents();
-          await refreshAgentManagement();
+          try {
+            await api('POST', '/agent-management/save', { agent_name: item.agent_name });
+            await refreshAgents();
+            await refreshAgentManagement();
+          } catch (e) {
+            alert(String(e && e.message ? e.message : e));
+          }
         };
 
         const copyBtn = document.createElement('button');
@@ -4527,9 +4550,22 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
         copyBtn.onclick = async () => {
           const newName = prompt('New name for copied agent', item.agent_name + '.copy');
           if (newName === null) return;
-          await api('POST', '/agent-management/copy', { source_agent_name: item.agent_name, new_agent_name: newName });
-          await refreshAgents();
-          await refreshAgentManagement();
+          const copyName = String(newName || '').trim();
+          if (!copyName) {
+            alert('Agent name cannot be empty.');
+            return;
+          }
+          if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(copyName)) {
+            alert('Agent name may only contain letters, numbers, dot, underscore, and hyphen, and must start with a letter or number.');
+            return;
+          }
+          try {
+            await api('POST', '/agent-management/copy', { source_agent_name: item.agent_name, new_agent_name: copyName });
+            await refreshAgents();
+            await refreshAgentManagement();
+          } catch (e) {
+            alert(String(e && e.message ? e.message : e));
+          }
         };
 
         const delBtn = document.createElement('button');
@@ -4538,9 +4574,13 @@ def create_app(*, credential_store: CredentialStore | None = None) -> FastAPI:
         delBtn.textContent = 'Delete';
         delBtn.onclick = async () => {
           if (!confirm('Delete agent ' + item.agent_name + '?')) return;
-          await api('POST', '/agent-management/delete', { agent_name: item.agent_name });
-          await refreshAgents();
-          await refreshAgentManagement();
+          try {
+            await api('POST', '/agent-management/delete', { agent_name: item.agent_name });
+            await refreshAgents();
+            await refreshAgentManagement();
+          } catch (e) {
+            alert(String(e && e.message ? e.message : e));
+          }
         };
 
         actions.appendChild(saveBtn);

--- a/tests/dashboard/test_agent_name_validation.py
+++ b/tests/dashboard/test_agent_name_validation.py
@@ -1,0 +1,112 @@
+"""Regression coverage for issue #319: invalid agent names must surface as
+clear 400s, not silent 500s, at every dashboard endpoint that names an
+agent, and the served UI must pre-check names with the same rule."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ursa import security
+from ursa.cli.agent_management import _AGENT_NAME_RE
+from ursa_dashboard.app import create_app
+from ursa_dashboard.credentials import MemoryCredentialStore
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(security, "URSA_CACHE_DIR", tmp_path / "ursa-cache")
+    app = create_app(credential_store=MemoryCredentialStore())
+    with TestClient(app, raise_server_exceptions=False) as test_client:
+        yield test_client, tmp_path
+
+
+def _create_payload(tmp_path: Path, name: str) -> dict:
+    return {
+        "agent_id": "chat_agent",
+        "agent_name": name,
+        "workspace_mode": "folder",
+        "workspace_path": str(tmp_path / "ws"),
+    }
+
+
+def test_create_session_rejects_spaced_name_with_400(client) -> None:
+    test_client, tmp_path = client
+
+    response = test_client.post(
+        "/sessions", json=_create_payload(tmp_path, "Swiss Roll")
+    )
+
+    assert response.status_code == 400
+    assert "letters, numbers" in response.json()["detail"]
+
+
+def test_agent_save_rejects_spaced_name_with_400(client) -> None:
+    test_client, _ = client
+
+    response = test_client.post(
+        "/agent-management/save", json={"agent_name": "Swiss Roll"}
+    )
+
+    assert response.status_code == 400
+    assert "letters, numbers" in response.json()["detail"]
+
+
+def test_agent_delete_rejects_spaced_name_with_400(client) -> None:
+    test_client, _ = client
+
+    response = test_client.post(
+        "/agent-management/delete", json={"agent_name": "Swiss Roll"}
+    )
+
+    assert response.status_code == 400
+    assert "letters, numbers" in response.json()["detail"]
+
+
+def test_agent_copy_rejects_spaced_new_name_with_400(client) -> None:
+    test_client, _ = client
+
+    response = test_client.post(
+        "/agent-management/copy",
+        json={"source_agent_name": "SwissRoll", "new_agent_name": "My Copy"},
+    )
+
+    assert response.status_code == 400
+    assert "letters, numbers" in response.json()["detail"]
+
+
+def test_create_session_rejects_leading_dot_with_clear_message(client) -> None:
+    # The rule requires an alphanumeric first character; the message must
+    # say so rather than implying dot is always allowed.
+    test_client, tmp_path = client
+
+    response = test_client.post(
+        "/sessions", json=_create_payload(tmp_path, ".hidden")
+    )
+
+    assert response.status_code == 400
+    assert "must start with a letter or number" in response.json()["detail"]
+
+
+def test_create_session_accepts_valid_name(client) -> None:
+    test_client, tmp_path = client
+
+    response = test_client.post(
+        "/sessions", json=_create_payload(tmp_path, "SwissRoll")
+    )
+
+    assert response.status_code == 200
+    assert response.json()["session"]["agent_name"] == "SwissRoll"
+
+
+def test_ui_embeds_the_backend_name_rule(client) -> None:
+    # Drift guard: the client-side pre-check must mirror the backend rule;
+    # if _AGENT_NAME_RE changes, this containment check fails until the
+    # served JS follows.
+    test_client, _ = client
+
+    html = test_client.get("/ui").text
+
+    assert _AGENT_NAME_RE.pattern in html


### PR DESCRIPTION
## Summary

Fixes #319. Naming a new dashboard session with a space failed silently: the name prompt checks only emptiness, the workspace chooser then appears as the normal next step, and the create request dies inside `validate_agent_name`, whose bare `ValueError` becomes a detail-free 500 because the app registers no exception handler. The frontend has no catch on that path, so the rejection is unhandled and nothing is shown. The same bare-call pattern exists at five endpoints (session create, agent save, copy source and target, delete), so for example an agent directory that somehow carries an invalid name is listed by the UI but cannot be checkpointed or deleted through it, also silently. The Copy prompt had the identical silent shape with a user-typed name and no validation at all.

## The change

- The five endpoints convert validation failures to `HTTPException(400, detail)` carrying the validator's own message.
- The two name prompts (new session, agent copy) pre-check the same rule client-side, so the user learns immediately instead of after choosing a workspace.
- `startSession` and the agent-management buttons (checkpoint, copy, delete) surface request failures with the alert idiom the rest of the page already uses; this also surfaces the workspace 400s that were silently swallowed on the create path before.
- The validator's message now mentions the alphanumeric first-character requirement it already enforced, since "-lead" or ".hidden" contain only characters the old message called allowed yet were rejected.

Scope notes: the rename-session prompt shares the missing-catch pattern but titles accept spaces, so it is not the #319 symptom and is left alone here. Allowing spaces in session naming by decoupling the display title from the agent directory name would be a design change for you to weigh; titles already hold spaces today, so this PR keeps the minimal shape of rejecting clearly and early.

## Tests

Seven tests in a new `tests/dashboard/test_agent_name_validation.py`, six committed red first and flipped by the fix with no test edits: 400s with the validator's detail at all four user-reachable endpoints, the first-character message on a leading-dot name, and a drift guard asserting the served page embeds `_AGENT_NAME_RE.pattern` imported from the backend module, so a future rule change fails CI until the client mirror follows. A valid-name guard pins the healthy path. Running the test commit without the fix commit reproduces the exact 6 failed / 1 passed pattern. Full suite locally: 741 passed, 6 skipped.
