### PR TITLE
fix: harden TUI teardown races and stabilize timing tests

### DIFF
--- a/src/ursa/cli/tui/app.py
+++ b/src/ursa/cli/tui/app.py
@@ -67,7 +67,9 @@ def _config_yaml_value(value: Any) -> Any:
     if is_dataclass(value) and not isinstance(value, type):
         return _config_yaml_value(asdict(value))
     if isinstance(value, Mapping):
-        return {str(key): _config_yaml_value(item) for key, item in value.items()}
+        return {
+            str(key): _config_yaml_value(item) for key, item in value.items()
+        }
     if isinstance(value, (list, tuple, set)):
         return [_config_yaml_value(item) for item in value]
     if isinstance(value, (Path, Enum)):
@@ -225,7 +227,13 @@ class UrsaTextualApp(App[None]):
         if agent_name := self.hitl.config.agent_name:
             items.append(f"agent {agent_name}")
         items.append(state)
-        self.query_one("#status", Static).update(Text("  •  ".join(items)))
+        # The agent worker's tail can run while teardown is pruning the
+        # tree; a bare query here crashes the worker and surfaces as
+        # WorkerFailed at run_test exit.
+        status = self.query("#status")
+        if not status:
+            return
+        status.first(Static).update(Text("  •  ".join(items)))
 
     def add_tokens(self, usage: TokenUsage) -> None:
         self.total_tokens += usage.total_tokens
@@ -558,7 +566,9 @@ class UrsaTextualApp(App[None]):
                 command.capitalize(),
                 content(),
                 config_yaml=(
-                    self._resolved_config_yaml() if command == "status" else None
+                    self._resolved_config_yaml()
+                    if command == "status"
+                    else None
                 ),
             ),
             callback=lambda _: self.query_one(PromptArea).focus(),

--- a/src/ursa/cli/tui/app.py
+++ b/src/ursa/cli/tui/app.py
@@ -329,6 +329,11 @@ class UrsaTextualApp(App[None]):
                 exc, "".join(traceback.format_exception(exc))
             )
             response = f"**Agent failed:** `{type(exc).__name__}: {exc}`"
+        if self._exit:
+            # App-level workers survive widget pruning (only widget-bound
+            # workers are cancelled on removal); do not touch the tree
+            # mid-teardown.
+            return
         turn.finish_activity(succeeded=succeeded)
         await turn.add_response(response)
         self.call_after_refresh(self._anchor_conversation_if_overflowing)

--- a/src/ursa/cli/tui/widgets.py
+++ b/src/ursa/cli/tui/widgets.py
@@ -255,7 +255,12 @@ class HotlistScreen(ModalScreen[str | None]):
             )
 
     def on_mount(self) -> None:
-        self.query_one(Input).focus()
+        # Mounting can race app teardown, leaving children absent; a bare
+        # query here would crash the app from inside the Mount dispatch.
+        inputs = self.query(Input)
+        if not inputs:
+            return
+        inputs.first().focus()
         self._highlight_first()
 
     def action_previous_choice(self) -> None:
@@ -284,8 +289,11 @@ class HotlistScreen(ModalScreen[str | None]):
         self._highlight_first()
 
     def _highlight_first(self) -> None:
-        options = self.query_one(OptionList)
-        options.highlighted = 0 if options.option_count else None
+        options = self.query(OptionList)
+        if not options:
+            return
+        option_list = options.first()
+        option_list.highlighted = 0 if option_list.option_count else None
 
     @on(OptionList.OptionSelected)
     def select_option(self, event: OptionList.OptionSelected) -> None:

--- a/src/ursa/cli/tui/widgets.py
+++ b/src/ursa/cli/tui/widgets.py
@@ -718,7 +718,12 @@ class ModelScreen(ModalScreen[ModelSelection | None]):
                 values.pop(field, None)
 
     def on_mount(self) -> None:
-        self.query_one("#chat-model-name", Select).focus()
+        # Mounting can race app teardown, leaving children absent; see
+        # HotlistScreen.on_mount.
+        selects = self.query("#chat-model-name")
+        if not selects:
+            return
+        selects.first(Select).focus()
         chat_generation = self._next_model_load_generation("chat")
         embedding_generation = self._next_model_load_generation("embedding")
         self.run_worker(

--- a/tests/cli/_app_fakes.py
+++ b/tests/cli/_app_fakes.py
@@ -86,3 +86,23 @@ async def emit_event(handler, payload=None, **details):
         DEFAULT_EVENT_NAME,
         details if payload is None else payload,
     )
+
+
+async def wait_for(pilot, condition, *, timeout=3.0, interval=0.05):
+    """Poll a condition instead of trusting one fixed pause.
+
+    Timer-driven UI (spinner frames, deferred screen pushes) advances on
+    wall-clock intervals that a loaded runner can easily miss inside a
+    single pause window; polling with a generous ceiling keeps the
+    assertion about behavior rather than scheduling.
+    """
+    import asyncio
+    import time
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if condition():
+            return True
+        await asyncio.sleep(interval)
+        await pilot.pause()
+    return bool(condition())

--- a/tests/cli/tui/event_cards/test_commands.py
+++ b/tests/cli/tui/event_cards/test_commands.py
@@ -3,7 +3,7 @@ import asyncio
 from textual.containers import VerticalScroll
 from textual.widgets import Static
 
-from tests.cli._app_fakes import FakeHITL, emit_event
+from tests.cli._app_fakes import FakeHITL, emit_event, wait_for
 from ursa.cli.tui.app import UrsaTextualApp
 from ursa.cli.tui.event_cards import CommandSafetyIndicator, RunCommandCard
 from ursa.cli.tui.event_handler import TextualEventHandler
@@ -58,6 +58,7 @@ async def test_overlapping_commands_stay_compact_and_complete_independently(
             "result": "",
         })
         await pilot.pause()
+        await wait_for(pilot, lambda: cards[0].completed)
         assert cards[0].completed
         assert cards[0].returncode == 0
         assert not cards[1].completed
@@ -239,10 +240,12 @@ async def test_run_command_card_tracks_safety_and_collapses_on_result(tmp_path):
 
         pass_safety.set()
         await pilot.pause()
+        await wait_for(pilot, lambda: safety.status == "passed")
         assert safety.status == "passed"
 
         return_result.set()
         await pilot.pause()
+        await wait_for(pilot, lambda: source.content.code == "echo line-1 …")
         assert source.content.code == "echo line-1 …"
         output = card.query_one(".command-output", Static)
         assert output.content.code == "command output"

--- a/tests/cli/tui/event_cards/test_plan.py
+++ b/tests/cli/tui/event_cards/test_plan.py
@@ -3,7 +3,7 @@ import asyncio
 from textual.containers import VerticalScroll
 from textual.widgets import Markdown, Static
 
-from tests.cli._app_fakes import FakeHITL, emit_event
+from tests.cli._app_fakes import FakeHITL, emit_event, wait_for
 from ursa.cli.tui.app import UrsaTextualApp
 from ursa.cli.tui.event_cards import PlanCard
 from ursa.cli.tui.turn import Turn
@@ -190,7 +190,7 @@ async def test_agent_completion_stops_pending_plan_review_spinner(tmp_path):
         await pilot.pause()
 
         plan = app.query_one(PlanCard)
-        assert plan.state == "complete"
+        assert await wait_for(pilot, lambda: plan.state == "complete")
         frame = plan._frame
 
         await asyncio.sleep(0.7)
@@ -212,9 +212,7 @@ async def test_failed_agent_stops_drafting_plan_spinner(tmp_path):
         plan = turn.query_one(PlanCard)
 
         turn.finish_activity(succeeded=False)
-        await pilot.pause()
-
-        assert plan.state == "revision_needed"
+        assert await wait_for(pilot, lambda: plan.state == "revision_needed")
         assert "draft completed" in plan.review_reason
         source = str(plan.query_one(Markdown).source)
         assert "Plan drafting failed" in source

--- a/tests/cli/tui/event_cards/test_tools.py
+++ b/tests/cli/tui/event_cards/test_tools.py
@@ -2,7 +2,7 @@ from langchain_core.messages import ToolMessage
 from textual.containers import VerticalScroll
 from textual.widgets import Markdown, Static
 
-from tests.cli._app_fakes import FakeHITL
+from tests.cli._app_fakes import FakeHITL, wait_for
 from ursa.cli.tui.app import UrsaTextualApp
 from ursa.cli.tui.event_cards import ToolCallCard
 from ursa.cli.tui.event_handler import TextualEventHandler
@@ -51,6 +51,7 @@ async def test_default_tool_card_switches_from_input_to_output(tmp_path):
         )
         await pilot.pause()
 
+        await wait_for(pilot, lambda: card.completed)
         assert card.completed
         assert card.query_one(".tool-call-state", Static).content == "✓"
         assert "polar" in str(

--- a/tests/cli/tui/test_app.py
+++ b/tests/cli/tui/test_app.py
@@ -629,3 +629,17 @@ async def test_user_scroll_during_anchor_start_gap_is_not_overridden(tmp_path):
         for _ in range(8):
             await asyncio.sleep(0.03)
             assert conversation.scroll_y == 0
+
+
+async def test_update_status_survives_absent_status_widget(tmp_path):
+    # The agent worker's tail calls _update_status; when teardown has
+    # already pruned the status widget, the bare query crashed the
+    # worker and surfaced as WorkerFailed at run_test exit, after every
+    # test assertion had passed (the recurring Windows CI signature).
+    app = UrsaTextualApp(FakeHITL(tmp_path))
+
+    async with app.run_test(size=(100, 36)) as pilot:
+        await app.query_one("#status").remove()
+        await pilot.pause()
+
+        app._update_status("ready")

--- a/tests/cli/tui/test_app.py
+++ b/tests/cli/tui/test_app.py
@@ -277,18 +277,17 @@ async def test_ctrl_c_reports_that_running_agent_cannot_be_cancelled(
         assert prompt.disabled
 
         await pilot.press("ctrl+c")
-        await pilot.pause()
+        assert await wait_for(pilot, lambda: len(notifications) == 1)
 
         assert prompt.disabled
         assert any(worker.group == "agent" for worker in app.workers)
-        assert len(notifications) == 1
         assert "not supported" in notifications[0][0]
         assert "Ctrl+D" in notifications[0][0]
         assert notifications[0][1]["severity"] == "warning"
 
         release.set()
         await app.workers.wait_for_complete()
-        assert not prompt.disabled
+        assert await wait_for(pilot, lambda: not prompt.disabled)
 
 
 async def test_clear_conversation_is_refused_during_active_turn(
@@ -454,7 +453,10 @@ async def test_new_cards_follow_bottom_without_moving_scrolled_view(tmp_path):
             )
             await pilot.pause()
 
-        assert conversation.scroll_y == conversation.max_scroll_y
+        assert await wait_for(
+            pilot,
+            lambda: conversation.scroll_y == conversation.max_scroll_y,
+        )
 
         conversation.scroll_to(
             y=max(0, conversation.scroll_y - 3),

--- a/tests/cli/tui/test_app.py
+++ b/tests/cli/tui/test_app.py
@@ -8,7 +8,7 @@ from textual.widgets import Markdown, Static
 
 import ursa.cli.tui.app as app_module
 import ursa.util.crossplatform as crossplatform
-from tests.cli._app_fakes import FakeHITL, emit_event
+from tests.cli._app_fakes import FakeHITL, emit_event, wait_for
 from ursa.cli.tui.app import UrsaTextualApp
 from ursa.cli.tui.event_cards import EventCard, ExceptionCard, RunCommandCard
 from ursa.cli.tui.turn import Turn
@@ -224,10 +224,10 @@ async def test_turn_spinner_animates_and_shows_reasoning_while_agent_runs(
         assert first_frame in ActivityIndicator.FRAMES
         assert str(label.content) == "Inspecting the request"
 
-        await asyncio.sleep(0.1)
-        await pilot.pause()
+        assert await wait_for(
+            pilot, lambda: str(spinner.content) != first_frame
+        )
         assert str(spinner.content) in ActivityIndicator.FRAMES
-        assert str(spinner.content) != first_frame
 
         release_agent.set()
         await pilot.pause()

--- a/tests/cli/tui/test_app.py
+++ b/tests/cli/tui/test_app.py
@@ -47,6 +47,9 @@ async def test_welcome_banner_starts_at_top_of_conversation(tmp_path):
         await turn.add_response("Short response")
         await pilot.pause()
 
+        await wait_for(
+            pilot, lambda: banner.region.y == conversation.content_region.y
+        )
         assert banner.region.y == conversation.content_region.y
 
 
@@ -84,6 +87,7 @@ async def test_prompt_submission_events_and_history(tmp_path):
         await pilot.press("h", "e", "l", "l", "o", "enter")
         await pilot.pause()
 
+        await wait_for(pilot, lambda: hitl.calls == [("chat", "hello")])
         assert hitl.calls == [("chat", "hello")]
         messages = list(app.query(MessageCard))
         assert len(messages) == 2
@@ -145,6 +149,7 @@ async def test_agent_exception_card_expands_to_full_traceback(tmp_path):
 
         card.on_click(Click())
         await pilot.pause()
+        await wait_for(pilot, lambda: card.expanded)
         assert card.expanded
         rich_traceback = card.query_one(".exception-traceback", Static)
         assert not rich_traceback.has_class("hidden")
@@ -319,6 +324,7 @@ async def test_clear_conversation_is_refused_during_active_turn(
         await pilot.press("ctrl+l")
         await pilot.pause()
 
+        await wait_for(pilot, lambda: turn.is_mounted)
         assert turn.is_mounted
         assert "not allowed" in notifications[0][0]
         assert "Ctrl+D" in notifications[0][0]
@@ -364,6 +370,7 @@ async def test_quitting_waits_for_active_agent_then_exits(
         await finished.wait()
         await pilot.pause()
 
+    await wait_for(pilot, lambda: app._exit)
     assert app._exit
 
 
@@ -422,6 +429,10 @@ async def test_turn_navigation_changes_real_scroll_position(tmp_path):
 
         await pilot.press("alt+down")
         await pilot.pause()
+        await wait_for(
+            pilot,
+            lambda: app._turn_navigation_marker is app._turn_markers()[-1],
+        )
         assert app._turn_navigation_marker is app._turn_markers()[-1]
         assert conversation.scroll_y == conversation.max_scroll_y
         assert conversation.is_anchored

--- a/tests/cli/tui/test_app.py
+++ b/tests/cli/tui/test_app.py
@@ -230,7 +230,7 @@ async def test_turn_spinner_animates_and_shows_reasoning_while_agent_runs(
         assert str(spinner.content) in ActivityIndicator.FRAMES
 
         release_agent.set()
-        await pilot.pause()
+        assert await wait_for(pilot, lambda: not app.workers)
         assert str(spinner.content) == ""
         assert str(label.content) == ""
         assert str(done_mark.content) == ""

--- a/tests/cli/tui/test_turn.py
+++ b/tests/cli/tui/test_turn.py
@@ -7,7 +7,7 @@ from textual.widgets import Static
 
 import ursa.cli.tui.event_handler as event_handler_module
 import ursa.cli.tui.turn as turn_module
-from tests.cli._app_fakes import FakeHITL, emit_event
+from tests.cli._app_fakes import FakeHITL, emit_event, wait_for
 from ursa.cli.tui.app import UrsaTextualApp
 from ursa.cli.tui.event_cards import EditCard, FileActivityCard, RunCommandCard
 from ursa.cli.tui.event_handler import TextualEventHandler
@@ -275,6 +275,9 @@ async def test_activity_kinds_keep_independent_cards_open(
         return_to_reading.set()
         await reading_updated.wait()
         await pilot.pause()
+        await wait_for(
+            pilot, lambda: list(reading.files["Reading"]) == ["fileA", "fileC"]
+        )
         assert list(reading.files["Reading"]) == ["fileA", "fileC"]
         assert len(app.query(FileActivityCard)) == 2
         assert not reading.done
@@ -289,6 +292,7 @@ async def test_activity_kinds_keep_independent_cards_open(
 
         current_reading_timer.fire()
         await pilot.pause()
+        await wait_for(pilot, lambda: reading.done)
         assert reading.done
 
         finish_agent.set()
@@ -425,6 +429,9 @@ async def test_summary_card_mounts_immediately_updates_and_finalizes_after_idle(
         emit_second.set()
         await second_emitted.wait()
         await pilot.pause()
+        await wait_for(
+            pilot, lambda: list(first.files["Reading"]) == ["fileA", "fileB"]
+        )
         assert list(first.files["Reading"]) == ["fileA", "fileB"]
         assert not first.done
         assert timers[0].stopped
@@ -432,6 +439,7 @@ async def test_summary_card_mounts_immediately_updates_and_finalizes_after_idle(
 
         timers[1].fire()
         await pilot.pause()
+        await wait_for(pilot, lambda: first.done)
         assert first.done
 
         emit_third.set()
@@ -446,6 +454,7 @@ async def test_summary_card_mounts_immediately_updates_and_finalizes_after_idle(
         finish_agent.set()
         await app.workers.wait_for_complete()
         await pilot.pause()
+        await wait_for(pilot, lambda: groups[1].done)
         assert groups[1].done
 
 

--- a/tests/cli/tui/test_widgets.py
+++ b/tests/cli/tui/test_widgets.py
@@ -2837,3 +2837,13 @@ def test_keymap_omits_compatibility_warning_when_kitty_is_expected(
 
     assert "Kitty keyboard support expected" in keymap
     assert "may not work" not in keymap
+
+
+def test_hotlist_mount_survives_absent_children():
+    # The app can begin tearing down while this screen is still mounting;
+    # the Mount dispatch then runs with children absent, and a bare
+    # query_one crashed the whole app from inside the event handler,
+    # surfacing at run_test exit and masking the test's real failure.
+    screen = HotlistScreen("pick", ["one"])
+
+    screen.on_mount()

--- a/tests/cli/tui/test_widgets.py
+++ b/tests/cli/tui/test_widgets.py
@@ -116,6 +116,7 @@ async def test_agent_hotlist_routes_selected_agent(tmp_path):
         prompt.insert("make a plan")
         await pilot.press("enter")
         await pilot.pause()
+        await wait_for(pilot, lambda: hitl.calls == [("plan", "make a plan")])
         assert hitl.calls == [("plan", "make a plan")]
 
 
@@ -131,11 +132,17 @@ async def test_agent_selection_moves_to_front_replaces_and_preserves_cursor(
 
         await pilot.press("#", "p", "l", "enter")
         await pilot.pause()
+        await wait_for(
+            pilot, lambda: prompt.text == "#plan Review docs carefully"
+        )
         assert prompt.text == "#plan Review docs carefully"
         assert prompt.cursor_location == (0, 12)
 
         await pilot.press("#", "c", "h", "enter")
         await pilot.pause()
+        await wait_for(
+            pilot, lambda: prompt.text == "#chat Review docs carefully"
+        )
         assert prompt.text == "#chat Review docs carefully"
         assert prompt.cursor_location == (0, 12)
 
@@ -165,6 +172,7 @@ async def test_macro_selectors_close_with_escape(tmp_path):
         assert prompt.text == "Review docs carefully"
         await pilot.press("ctrl+y")
         await pilot.pause()
+        await wait_for(pilot, lambda: prompt.text == "Review# docs carefully")
         assert prompt.text == "Review# docs carefully"
         assert not isinstance(app.screen, HotlistScreen)
 
@@ -198,11 +206,13 @@ async def test_escaping_command_picker_preserves_multiline_draft_and_undo(
         await pilot.press("escape")
         await pilot.pause()
 
+        await wait_for(pilot, lambda: prompt.text == "/alpha\nbeta")
         assert prompt.text == "/alpha\nbeta"
         await pilot.press("ctrl+z")
         assert prompt.text == "alpha\nbeta"
         await pilot.press("ctrl+y")
         await pilot.pause()
+        await wait_for(pilot, lambda: prompt.text == "/alpha\nbeta")
         assert prompt.text == "/alpha\nbeta"
         assert not isinstance(app.screen, HotlistScreen)
 
@@ -217,15 +227,18 @@ async def test_macro_choice_is_undoable_without_reopening_picker(tmp_path):
 
         await pilot.press("#", "p", "l", "enter")
         await pilot.pause()
+        await wait_for(pilot, lambda: prompt.text == "#plan Review docs")
         assert prompt.text == "#plan Review docs"
 
         await pilot.press("ctrl+z")
         await pilot.pause()
+        await wait_for(pilot, lambda: prompt.text == "Review# docs")
         assert prompt.text == "Review# docs"
         assert not isinstance(app.screen, HotlistScreen)
 
         await pilot.press("ctrl+y")
         await pilot.pause()
+        await wait_for(pilot, lambda: prompt.text == "#plan Review docs")
         assert prompt.text == "#plan Review docs"
         assert not isinstance(app.screen, HotlistScreen)
 
@@ -239,11 +252,13 @@ async def test_programmatic_and_pasted_macro_characters_do_not_open_picker(
         prompt = app.query_one(PromptArea)
         prompt.load_text("#plan programmatic")
         await pilot.pause()
+        await wait_for(pilot, lambda: not isinstance(app.screen, HotlistScreen))
         assert not isinstance(app.screen, HotlistScreen)
 
         prompt.load_text("")
         app.post_message(events.Paste("@notes.md /status"))
         await pilot.pause()
+        await wait_for(pilot, lambda: prompt.text == "@notes.md /status")
         assert prompt.text == "@notes.md /status"
         assert not isinstance(app.screen, HotlistScreen)
 
@@ -280,6 +295,9 @@ async def test_file_hotlist_uses_at_trigger(tmp_path):
         await pilot.pause()
         await pilot.press("d", "o", "c", "s", "enter")
         await pilot.pause()
+        await wait_for(
+            pilot, lambda: prompt.text == f"@{Path('docs')}{os.sep} "
+        )
         assert prompt.text == f"@{Path('docs')}{os.sep} "
 
 
@@ -324,6 +342,7 @@ async def test_prompt_has_markdown_highlighting_paste_undo_and_redo(tmp_path):
 
         app.post_message(events.Paste("# heading\nbody"))
         await pilot.pause()
+        await wait_for(pilot, lambda: prompt.text == "# heading\nbody")
         assert prompt.text == "# heading\nbody"
 
         await pilot.press("ctrl+z")
@@ -609,6 +628,7 @@ async def test_slash_picker_opens_status_inside_textual(tmp_path):
 
         await pilot.press("s", "t", "a", "t", "u", "s", "enter")
         await pilot.pause()
+        await wait_for(pilot, lambda: isinstance(app.screen, InformationScreen))
         assert isinstance(app.screen, InformationScreen)
         assert "LLM Endpoint" in app.screen.content
         assert "lab-assistant" in app.screen.content
@@ -645,10 +665,14 @@ async def test_slash_picker_opens_status_inside_textual(tmp_path):
         assert body.scroll_y == 0
         await pilot.press("end")
         await pilot.pause()
+        await wait_for(pilot, lambda: body.scroll_y > 0)
         assert body.scroll_y > 0
 
         await pilot.press("escape")
         await pilot.pause()
+        await wait_for(
+            pilot, lambda: not isinstance(app.screen, InformationScreen)
+        )
         assert not isinstance(app.screen, InformationScreen)
 
 
@@ -659,6 +683,7 @@ async def test_exit_command_quits_the_app(tmp_path):
         await pilot.press("/", "e", "x", "i", "t", "enter")
         await pilot.pause()
 
+        await wait_for(pilot, lambda: app._exit)
         assert app._exit
 
 
@@ -762,6 +787,11 @@ async def test_model_command_switches_provider_and_model(tmp_path, monkeypatch):
         )
         app.screen.query_one("#chat-model-name", Select).value = "claude-stale"
         await pilot.pause()
+        await wait_for(
+            pilot,
+            lambda: app.screen.query_one("#chat-model-provider", Select).value
+            == "anthropic",
+        )
         assert (
             app.screen.query_one("#chat-model-provider", Select).value
             == "anthropic"
@@ -908,6 +938,7 @@ provider_options:
         ).value = "changed-model"
         await pilot.pause()
 
+        await wait_for(pilot, lambda: "model: changed-model" in editor.text)
         assert "model: changed-model" in editor.text
         assert "temperature: 0.25" in editor.text
         assert "reasoning: high" in editor.text
@@ -944,6 +975,9 @@ provider_options:
         await app.workers.wait_for_complete()
         await pilot.pause()
 
+        await wait_for(
+            pilot, lambda: hitl.config.llm_model.model == "applied-model"
+        )
         assert hitl.config.llm_model.model == "applied-model"
         assert hitl.config.llm_model.model_extra == {
             "temperature": 0.35,
@@ -1249,6 +1283,7 @@ async def test_programmatic_control_sync_suppresses_queued_events(
         app.screen._update_controls_from_config("chat", updated)
         await pilot.pause()
 
+        await wait_for(pilot, lambda: app.screen.drafts["chat"] is updated)
         assert app.screen.drafts["chat"] is updated
         assert editor.text == app.screen._yaml_text("chat")
         assert discoveries == []
@@ -1545,6 +1580,7 @@ async def test_cancel_discards_yaml_with_pending_validation(
         app.screen.action_cancel()
         await pilot.pause()
 
+        await wait_for(pilot, lambda: not isinstance(app.screen, ModelScreen))
         assert not isinstance(app.screen, ModelScreen)
         assert hitl.config.llm_model == original
         assert timer._task is None
@@ -1574,6 +1610,7 @@ async def test_yaml_debounce_restarts_from_latest_edit(tmp_path, monkeypatch):
         assert not editor.has_class("yaml-valid", "yaml-invalid")
         await asyncio.sleep(ModelScreen.YAML_VALIDATION_DELAY / 2 + 0.1)
         await pilot.pause()
+        await wait_for(pilot, lambda: editor.has_class("yaml-valid"))
         assert editor.has_class("yaml-valid")
         assert app.screen.drafts["chat"].model == "second-edit"
 
@@ -1635,6 +1672,7 @@ api_key:
         assert isinstance(app.screen, ModelScreen)
         app.screen.query_one("#chat-advanced", Collapsible).collapsed = False
         await pilot.pause()
+        await wait_for(pilot, lambda: editor.has_class("yaml-invalid"))
         assert editor.has_class("yaml-invalid")
         error = app.screen.query_one("#chat-yaml-error", Static)
         assert "validation errors for ChatModelConfig" in str(error.content)
@@ -1866,6 +1904,7 @@ async def test_immediate_apply_clears_direct_url_for_named_provider(
         app.screen.action_apply()
         await pilot.pause()
 
+        await wait_for(pilot, lambda: not isinstance(app.screen, ModelScreen))
         assert not isinstance(app.screen, ModelScreen)
         assert hitl.config.llm_model.inference_provider == "openai"
         assert (
@@ -2080,6 +2119,7 @@ async def test_model_modal_seeded_provider_fuzz_preserves_invariants(
                 model_select.value = ModelScreen.CUSTOM_VALUE
                 custom.value = f"custom-{iteration}"
                 await pilot.pause()
+                await wait_for(pilot, lambda: not custom.has_class("hidden"))
                 assert not custom.has_class("hidden")
             elif rng.random() < 0.5:
                 model_select.value = rng.choice([
@@ -2141,6 +2181,7 @@ async def test_command_picker_prioritizes_command_name_over_description(
         await pilot.press("/", "k", "e")
         await pilot.pause()
 
+        await wait_for(pilot, lambda: isinstance(app.screen, HotlistScreen))
         assert isinstance(app.screen, HotlistScreen)
         assert app.screen.matches[0].startswith("keymap —")
         assert any(match.startswith("status —") for match in app.screen.matches)
@@ -2162,6 +2203,7 @@ async def test_theme_command_selects_theme_and_escape_preserves_it(tmp_path):
         await pilot.press("t", "h", "e", "m", "e", "enter")
         await pilot.pause()
 
+        await wait_for(pilot, lambda: isinstance(app.screen, ThemeScreen))
         assert isinstance(app.screen, ThemeScreen)
         assert app.screen.styles.background.a == 0
         assert app.screen.picker_title == "Themes"
@@ -2170,29 +2212,38 @@ async def test_theme_command_selects_theme_and_escape_preserves_it(tmp_path):
         await pilot.press("down")
         await pilot.pause()
 
+        await wait_for(pilot, lambda: app.theme == "ursa-light")
         assert app.theme == "ursa-light"
         assert status.styles.background != dark_background
         await pilot.press("up")
         await pilot.pause()
+        await wait_for(pilot, lambda: app.theme == "ursa-dark")
         assert app.theme == "ursa-dark"
         assert status.styles.background == dark_background
 
         await pilot.press("down", "enter")
         await pilot.pause()
 
+        await wait_for(pilot, lambda: app.theme == "ursa-light")
         assert app.theme == "ursa-light"
         assert status.styles.background != dark_background
         assert "| Theme | `ursa-light` |" in app._status_markdown()
 
         await app._show_command("theme")
         await pilot.pause()
+        await wait_for(
+            pilot,
+            lambda: app.screen.candidates[:2] == ["ursa-light", "ursa-dark"],
+        )
         assert app.screen.candidates[:2] == ["ursa-light", "ursa-dark"]
         await pilot.press("down")
         await pilot.pause()
+        await wait_for(pilot, lambda: app.theme == "ursa-dark")
         assert app.theme == "ursa-dark"
         await pilot.press("escape")
         await pilot.pause()
 
+        await wait_for(pilot, lambda: app.theme == "ursa-light")
         assert app.theme == "ursa-light"
         assert app.query_one(PromptArea).has_focus
 
@@ -2200,9 +2251,11 @@ async def test_theme_command_selects_theme_and_escape_preserves_it(tmp_path):
         await pilot.pause()
         app.screen.query_one(Input).value = "nord"
         await pilot.pause()
+        await wait_for(pilot, lambda: app.theme == "nord")
         assert app.theme == "nord"
         await pilot.press("escape")
         await pilot.pause()
+        await wait_for(pilot, lambda: app.theme == "ursa-light")
         assert app.theme == "ursa-light"
 
 
@@ -2231,6 +2284,7 @@ async def test_agents_command_uses_tabs_and_collapsed_tool_details(tmp_path):
         await app.workers.wait_for_complete()
         await pilot.pause()
 
+        await wait_for(pilot, lambda: isinstance(app.screen, AgentsScreen))
         assert isinstance(app.screen, AgentsScreen)
         panes = list(app.screen.query(TabPane))
         assert len(panes) == 2
@@ -2255,15 +2309,18 @@ async def test_agents_command_uses_tabs_and_collapsed_tool_details(tmp_path):
         assert "Workspace-relative file path." in detail
         tools[0].collapsed = True
         await pilot.pause()
+        await wait_for(pilot, lambda: tools[0].collapsed)
         assert tools[0].collapsed
         tools[0].collapsed = False
         await pilot.pause()
+        await wait_for(pilot, lambda: len(tools[0].query(Markdown)) == 1)
         assert len(tools[0].query(Markdown)) == 1
 
         await pilot.press("right")
         await pilot.pause()
         await app.workers.wait_for_complete()
         await pilot.pause()
+        await wait_for(pilot, lambda: len(app.screen.query(Collapsible)) == 4)
         assert len(app.screen.query(Collapsible)) == 4
 
 
@@ -2299,6 +2356,7 @@ async def test_agents_lazily_load_tools_and_only_once(tmp_path):
         await app._show_command("agents")
         await pilot.pause()
 
+        await wait_for(pilot, lambda: isinstance(app.screen, AgentsScreen))
         assert isinstance(app.screen, AgentsScreen)
         assert calls == ["plan"]
         # A callback already queued when hydration stops must tolerate the
@@ -2318,6 +2376,7 @@ async def test_agents_lazily_load_tools_and_only_once(tmp_path):
         ready.set()
         await app.workers.wait_for_complete()
         await pilot.pause()
+        await wait_for(pilot, lambda: app.screen.agents[0].tools_loaded)
         assert app.screen.agents[0].tools_loaded
         # Hydration of the hidden plan tab updates state without mounting its
         # potentially expensive Markdown tool cards on the UI thread.
@@ -2326,6 +2385,10 @@ async def test_agents_lazily_load_tools_and_only_once(tmp_path):
 
         await pilot.press("left")
         await pilot.pause()
+        await wait_for(
+            pilot,
+            lambda: len(app.screen.query("#agent-tools-0 .agent-tool")) == 1,
+        )
         assert len(app.screen.query("#agent-tools-0 .agent-tool")) == 1
         assert app.screen._tool_panes_pending_render == set()
 
@@ -2436,6 +2499,10 @@ async def test_immediate_switch_preempts_large_tool_render(
         await pilot.pause()
         await app.workers.wait_for_complete()
         await pilot.pause()
+        await wait_for(
+            pilot,
+            lambda: len(app.screen.query("#agent-tools-1 .agent-tool")) == 100,
+        )
         assert len(app.screen.query("#agent-tools-1 .agent-tool")) == 100
         assert not app.screen.query("#agent-tools-1 .agent-tool Markdown")
         assert not app.screen.query("#agent-tools-1 .agent-tools-loading")
@@ -2490,6 +2557,11 @@ async def test_agent_tool_render_failure_is_displayed(tmp_path, monkeypatch):
 
         await pilot.press("left")
         await pilot.pause()
+        await wait_for(
+            pilot,
+            lambda: app.screen.query_one("#agents-tabs", TabbedContent).active
+            == "agent-tab-0",
+        )
         assert app.screen.query_one("#agents-tabs", TabbedContent).active == (
             "agent-tab-0"
         )
@@ -2543,6 +2615,11 @@ async def test_initialized_tools_render_while_schema_hydration_is_pending(
             schema_release.set()
             await app.workers.wait_for_complete()
             await pilot.pause()
+            await wait_for(
+                pilot,
+                lambda: len(app.screen.query("#agent-tools-0 .agent-tool"))
+                == 1,
+            )
             assert len(app.screen.query("#agent-tools-0 .agent-tool")) == 1
     finally:
         schema_release.set()
@@ -2661,6 +2738,7 @@ async def test_agents_remain_responsive_during_blocking_initialization(
         assert bottom > 0
         await pilot.press("home")
         await pilot.pause()
+        await wait_for(pilot, lambda: scroll.scroll_y < bottom)
         assert scroll.scroll_y < bottom
 
     try:
@@ -2681,6 +2759,9 @@ async def test_agents_remain_responsive_during_blocking_initialization(
             schema_release.set()
             await app.workers.wait_for_complete()
             await pilot.pause()
+            await wait_for(
+                pilot, lambda: screen.query("#agent-tools-0 .agent-tool")
+            )
             assert screen.query("#agent-tools-0 .agent-tool")
             assert screen._tool_loading_timers == {}
             assert screen._tool_loading_frames == {}
@@ -2730,6 +2811,9 @@ async def test_dismissing_agents_during_loading_cleans_up_and_publishes(
             loading_screen = app.screen
             await pilot.press("escape")
             await pilot.pause()
+            await wait_for(
+                pilot, lambda: not isinstance(app.screen, AgentsScreen)
+            )
             assert not isinstance(app.screen, AgentsScreen)
             assert loading_screen._tool_loading_timers == {}
             assert loading_screen._tool_loading_frames == {}
@@ -2738,6 +2822,9 @@ async def test_dismissing_agents_during_loading_cleans_up_and_publishes(
             await wrapper.wait_until_initialized()
             await app._show_command("agents")
             await pilot.pause()
+            await wait_for(
+                pilot, lambda: not app.screen.query(".agent-tools-loading")
+            )
             assert not app.screen.query(".agent-tools-loading")
             assert app.screen.query("#agent-tools-0 .agent-tool")
     finally:
@@ -2787,6 +2874,7 @@ async def test_agents_lazily_render_execution_agent_tools(tmp_path, chat_model):
         assert children.index(tools_title) < children.index(tools_container)
         app.screen.refresh(layout=True)
         await pilot.pause()
+        await wait_for(pilot, lambda: first_tool.region.height > 0)
         assert first_tool.region.height > 0
         assert tools_container.region.contains_region(first_tool.region)
         assert first_tool.region.y < app.screen.region.bottom

--- a/tests/cli/tui/test_widgets.py
+++ b/tests/cli/tui/test_widgets.py
@@ -28,7 +28,7 @@ from textual.widgets import (
 )
 
 import ursa.util.crossplatform as crossplatform
-from tests.cli._app_fakes import FakeHITL
+from tests.cli._app_fakes import FakeHITL, wait_for
 from ursa.agents.base import AgentWithTools
 from ursa.agents.execution_agent import ExecutionAgent
 from ursa.cli.config import (
@@ -148,12 +148,13 @@ async def test_macro_selectors_close_with_escape(tmp_path):
         prompt.move_cursor((0, 6))
 
         await pilot.press("#")
-        await pilot.pause()
-        assert isinstance(app.screen, HotlistScreen)
+        assert await wait_for(
+            pilot, lambda: isinstance(app.screen, HotlistScreen)
+        )
         await pilot.press("escape")
-        await pilot.pause()
-
-        assert prompt.text == "Review# docs carefully"
+        assert await wait_for(
+            pilot, lambda: prompt.text == "Review# docs carefully"
+        )
         assert prompt.cursor_location == (0, 7)
         assert prompt.has_focus
 
@@ -166,11 +167,11 @@ async def test_macro_selectors_close_with_escape(tmp_path):
 
         prompt.load_text("")
         await pilot.press("@")
-        await pilot.pause()
-        assert isinstance(app.screen, HotlistScreen)
+        assert await wait_for(
+            pilot, lambda: isinstance(app.screen, HotlistScreen)
+        )
         await pilot.press("escape")
-        await pilot.pause()
-        assert prompt.text == "@"
+        assert await wait_for(pilot, lambda: prompt.text == "@")
         assert prompt.has_focus
 
 
@@ -2636,9 +2637,9 @@ async def test_agents_remain_responsive_during_blocking_initialization(
     async def assert_ui_is_live(pilot, screen):
         loading = screen.query_one(".agent-tools-loading", Static)
         first_frame = str(loading.render())
-        await asyncio.sleep(0.35)
-        await pilot.pause()
-        assert str(loading.render()) != first_frame
+        assert await wait_for(
+            pilot, lambda: str(loading.render()) != first_frame
+        )
         await pilot.press("right")
         assert screen.query_one("#agents-tabs", TabbedContent).active == (
             "agent-tab-1"

--- a/tests/cli/tui/test_widgets.py
+++ b/tests/cli/tui/test_widgets.py
@@ -99,8 +99,9 @@ async def test_agent_hotlist_routes_selected_agent(tmp_path):
 
     async with app.run_test(size=(100, 36)) as pilot:
         await pilot.press("#")
-        await pilot.pause()
-        assert isinstance(app.screen, HotlistScreen)
+        assert await wait_for(
+            pilot, lambda: isinstance(app.screen, HotlistScreen)
+        )
 
         options = app.screen.query_one("#hotlist-options")
         assert options.highlighted == 0
@@ -153,8 +154,10 @@ async def test_macro_selectors_close_with_escape(tmp_path):
         )
         await pilot.press("escape")
         assert await wait_for(
-            pilot, lambda: prompt.text == "Review# docs carefully"
+            pilot, lambda: not isinstance(app.screen, HotlistScreen)
         )
+
+        assert prompt.text == "Review# docs carefully"
         assert prompt.cursor_location == (0, 7)
         assert prompt.has_focus
 
@@ -171,7 +174,10 @@ async def test_macro_selectors_close_with_escape(tmp_path):
             pilot, lambda: isinstance(app.screen, HotlistScreen)
         )
         await pilot.press("escape")
-        assert await wait_for(pilot, lambda: prompt.text == "@")
+        assert await wait_for(
+            pilot, lambda: not isinstance(app.screen, HotlistScreen)
+        )
+        assert prompt.text == "@"
         assert prompt.has_focus
 
 
@@ -186,8 +192,9 @@ async def test_escaping_command_picker_preserves_multiline_draft_and_undo(
         prompt.move_cursor((0, 0))
 
         await pilot.press("/")
-        await pilot.pause()
-        assert isinstance(app.screen, HotlistScreen)
+        assert await wait_for(
+            pilot, lambda: isinstance(app.screen, HotlistScreen)
+        )
         await pilot.press("escape")
         await pilot.pause()
 
@@ -249,8 +256,9 @@ async def test_file_hotlist_uses_at_trigger(tmp_path):
 
     async with app.run_test(size=(100, 36)) as pilot:
         await pilot.press("@")
-        await pilot.pause()
-        assert isinstance(app.screen, HotlistScreen)
+        assert await wait_for(
+            pilot, lambda: isinstance(app.screen, HotlistScreen)
+        )
         assert app.screen.candidates == [
             f"{Path('docs')}{os.sep}",
             str(Path("docs/guide.md")),
@@ -585,8 +593,9 @@ async def test_slash_picker_opens_status_inside_textual(tmp_path):
 
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.press("/")
-        await pilot.pause()
-        assert isinstance(app.screen, HotlistScreen)
+        assert await wait_for(
+            pilot, lambda: isinstance(app.screen, HotlistScreen)
+        )
         hotlist = app.screen.query_one("#hotlist")
         options = app.screen.query_one("#hotlist-options")
         assert hotlist.region.width == 80
@@ -2848,3 +2857,15 @@ def test_hotlist_mount_survives_absent_children():
     screen = HotlistScreen("pick", ["one"])
 
     screen.on_mount()
+
+
+async def test_hotlist_mount_race_with_teardown_does_not_crash(tmp_path):
+    # Real-machinery pin for the mount race: exiting right after the push
+    # makes mount_all skip composing children while Mount still
+    # dispatches, and the unguarded on_mount crashed the app (NoMatches
+    # raised at run_test exit).
+    app = UrsaTextualApp(FakeHITL(tmp_path))
+
+    async with app.run_test(size=(100, 36)):
+        app.push_screen(HotlistScreen("pick", ["one"]))
+        app.exit()


### PR DESCRIPTION
## Summary

CI has been failing intermittently on a rotating cast of TUI pilot tests, most often on Windows (both runs on #322 drew different ones; the pre-merge #315 branch saw the same pattern across five runs, once reaching macOS and Ubuntu). To pin the causes and prove the fix, I ran a controlled experiment on real windows-latest runners: 20 runs of `tests/cli/tui` at current main failed 7 of 20 across six distinct signatures, and 20 runs with this branch passed 20 of 20. The failures decompose into three mechanisms, two in product code.

First, `HotlistScreen.on_mount` ran bare queries. Textual skips composing children once the app is exiting while the Mount event still dispatches, so a mount racing teardown raised `NoMatches` from inside the event handler, and `run_test` re-raises it at context exit, masking the test's own failure. `ModelScreen.on_mount` had the same shape.

Second, the agent worker's tail ran bare queries (`PromptArea`, the turn marker, and `_update_status`'s `#status`). App-level workers survive teardown pruning, unlike widget-bound workers and timers, which Textual cancels or stops on removal, so the tail could wake mid-teardown and crash with `WorkerFailed: NoMatches('#status')` after every test assertion had passed. That signature appears three times across the recorded evidence, from two different tests.

Third, tests asserted timer-driven or message-deferred progress inside windows with little or no margin: a 0.08 second spinner interval given 0.1 seconds, a 0.3 second interval given 0.35, and screen pushes that Textual defers through `call_after_refresh` asserted after a single pause. The experiment showed this genus has a long tail: the base arm surfaced settle failures in three tests that had never appeared in the recorded CI history.

## The change

- Guarded queries at both mount sites and an early return in the agent worker's tail during exit, so neither race can crash the app or the worker. The closure argument: Textual stops widget timers on unmount and cancels widget-bound workers on removal, so mount handlers and app-level workers are the only teardown-exposed contexts, and all of them are now guarded.
- A shared `wait_for(pilot, condition)` helper polls conditions with a generous ceiling, and every monotone pause-then-assert site in the TUI tests (66 across the suite, found by census) now polls its own condition before asserting, preserving assertion diagnostics. Non-monotone stability and not-yet assertions were deliberately left, since polling would invert their meaning. The spinner test also drains its worker before its context exits.

## Verification

- Deterministic regression tests, committed red first, for both product mechanisms: a bare hotlist mount and a status update with the widget removed each reproduce the exact recorded exception without their guard and pass with it; a third test pins the mount race through the real machinery by pushing the picker and exiting immediately.
- The controlled experiment above: 20 windows-latest runs per arm from an identical workflow, base 7 of 20 failed (including both crash signatures), this branch 20 of 20 passed. Under the measured base rate, that is below a two-in-ten-thousand chance if the branch had no effect.
- Locally: the hardened tests ran dozens of consecutive iterations under six CPU burners with zero failures; `tests/cli` passes in full; ruff clean.
