### PR TITLE
feat: ursa self command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The MkDocs documentation in `docs/` is organized around installation, getting st
 You can install `ursa` as a command line app with `pip install`; or with [`uv`](https://docs.astral.sh/uv/) via
 
 ```bash
-uv tool install 'ursa-ai[dashboard]'
+uv tool install --python 3.13 'ursa-ai[dashboard]'
 ```
 
 A standard OpenAI setup needs no configuration file:
@@ -85,7 +85,7 @@ The URSA web interface can be launched with:
 ursa-dashboard
 ```
 
-or with 
+or with
 ```
 ursa-dashboard --host 127.0.0.1 --port 8080
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The MkDocs documentation in `docs/` is organized around installation, getting st
 You can install `ursa` as a command line app with `pip install`; or with [`uv`](https://docs.astral.sh/uv/) via
 
 ```bash
-uv tool install 'ursa[dashboard]'
+uv tool install 'ursa-ai[dashboard]'
 ```
 
 A standard OpenAI setup needs no configuration file:

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -3,7 +3,7 @@
 You can install `ursa` as a command line app with `pip install`; or with [`uv`](https://docs.astral.sh/uv/) via
 
 ```bash
-uv tool install 'ursa-ai[dashboard]'
+uv tool install --python 3.13 'ursa-ai[dashboard]'
 ```
 
 To use the command line app, run

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -3,7 +3,7 @@
 You can install `ursa` as a command line app with `pip install`; or with [`uv`](https://docs.astral.sh/uv/) via
 
 ```bash
-uv tool install 'ursa[dashboard]'
+uv tool install 'ursa-ai[dashboard]'
 ```
 
 To use the command line app, run
@@ -43,3 +43,13 @@ You can get a list of available command line options via
 ```bash
 ursa --help
 ```
+
+Inspect the running URSA and Python installation with:
+
+```bash
+ursa self status
+```
+
+When installed with `uv tool install`, run `ursa self update` to update URSA
+or `ursa self modify --help` to change extras, additional packages, or the
+selected version/source revision.

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -1,12 +1,13 @@
 # Models and inference providers
 
-URSA initializes chat and embedding models through LangChain. A model name
-normally uses `<provider>:<model-name>`. Connection settings belong in a named
-`inference_providers` entry; `llm_model` and `emb_model` select that entry with
-`inference_provider`.
+URSA initializes chat and embedding models through LangChain. Model names
+normally use the form `<provider>:<model-name>`. Connection settings belong in
+an `inference_providers` entry, and `llm_model` and `emb_model` select that
+entry with `inference_provider`.
 
 For the standard OpenAI service, no YAML is required. Set `OPENAI_API_KEY` and
-run `ursa`; URSA's built-in `openai` provider supplies the endpoint and defaults.
+run `ursa`; URSA's built-in `openai` provider supplies the endpoint and
+defaults.
 
 ## Hosted and local model examples
 
@@ -46,8 +47,8 @@ run `ursa`; URSA's built-in `openai` provider supplies the endpoint and defaults
       inference_provider: research_gateway
     ```
 
-    Use the provider's actual model name and put the non-secret URL directly in
-    the file.
+    Use the provider's actual model name, and put the non-secret URL directly
+    in the file.
 
 === "Anthropic"
 
@@ -109,7 +110,7 @@ run `ursa`; URSA's built-in `openai` provider supplies the endpoint and defaults
 ## Use one provider for chat and embeddings
 
 Models inherit endpoint and credential values from the selected provider. They
-can share one provider while retaining their own model names:
+can share one provider while using different model names:
 
 ```yaml
 inference_providers:
@@ -126,12 +127,12 @@ emb_model:
 ```
 
 A value set directly on a model overrides the provider value. Set a nullable
-model value to `null` to clear an inherited value.
+model field to `null` to clear an inherited value.
 
 ## Temporary CLI overrides
 
-Configuration files are preferable for reusable endpoint settings, but every
-model field can also be overridden for a single run. For example:
+Configuration files are preferable for reusable endpoint settings, but you can
+also override any model field for a single run. For example:
 
 === "macOS/Linux"
 
@@ -157,7 +158,7 @@ complete precedence order.
 ## TLS verification
 
 URSA verifies TLS certificates by default and loads the operating system trust
-store. For a temporary test endpoint only, verification can be disabled on the
+store. For a temporary test endpoint only, you can disable verification on the
 provider:
 
 ```yaml
@@ -174,8 +175,28 @@ the correct certificate authority instead whenever possible.
 
 URSA includes `langchain-openai`, `langchain-anthropic`,
 `langchain-google-genai`, and `langchain-ollama`. Other model integrations use
-their corresponding `langchain-*` package. LangGraph extensions such as durable
-checkpoint backends use `langgraph-*` packages.
+the corresponding `langchain-*` package. LangGraph extensions, such as durable
+checkpoint backends, use `langgraph-*` packages.
+
+=== "ursa self"
+
+    When URSA is installed with `uv tool install ursa-ai`, you can use
+    `ursa self modify` to add or remove additional packages from your URSA
+    installation:
+
+    ```bash
+    ursa self modify --with langgraph-checkpoint-postgres
+    ```
+
+    For an additional model provider, replace the `langgraph-*` package with
+    its integration package, for example `--with langchain-groq`.
+
+    You can also enable URSA extras with the `--extra` flag. For example, to
+    enable the LAMMPS agent:
+
+    ```bash
+    ursa self modify --extra lammps
+    ```
 
 === "uv tool installation"
 
@@ -186,6 +207,7 @@ checkpoint backends use `langgraph-*` packages.
 
         ```bash
         uv tool install --force \
+          --python 3.13 \
           --with langgraph-checkpoint-postgres \
           'ursa[dashboard]'
         ```
@@ -194,6 +216,7 @@ checkpoint backends use `langgraph-*` packages.
 
         ```powershell
         uv tool install --force `
+          --python 3.13 `
           --with langgraph-checkpoint-postgres `
           'ursa[dashboard]'
         ```

--- a/docs/getting-started/dashboard.md
+++ b/docs/getting-started/dashboard.md
@@ -2,7 +2,7 @@
 
 The URSA web dashboard provides a browser-based interface for running URSA workflows.
 
-Install URSA first with `uv tool install 'ursa[dashboard]'` as described in the
+Install URSA first with `uv tool install 'ursa-ai[dashboard]'` as described in the
 [getting started guide][getting-started].
 
 ## Launch the dashboard

--- a/docs/getting-started/dashboard.md
+++ b/docs/getting-started/dashboard.md
@@ -2,7 +2,7 @@
 
 The URSA web dashboard provides a browser-based interface for running URSA workflows.
 
-Install URSA first with `uv tool install 'ursa-ai[dashboard]'` as described in the
+Install URSA first with `uv tool install --python 3.13 'ursa-ai[dashboard]'` as described in the
 [getting started guide][getting-started].
 
 ## Launch the dashboard

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -15,7 +15,7 @@ URSA requires Python 3.11 or newer. The `uv` tool installation is recommended:
     needed, then install URSA and the dashboard in an isolated tool environment:
 
     ```bash
-    uv tool install 'ursa-ai[dashboard]'
+    uv tool install --python 3.13 'ursa-ai[dashboard]'
     ```
 
     Update URSA with: `ursa self update` or `uv tool upgrade ursa-ai`
@@ -45,7 +45,7 @@ URSA requires Python 3.11 or newer. The `uv` tool installation is recommended:
 === "Conda + pip"
 
     ```bash
-    conda create -y -n ursa-env python=3.12
+    conda create -y -n ursa-env python=3.13
     conda activate ursa-env
     python -m pip install 'ursa-ai[dashboard]'
     ```

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -5,7 +5,7 @@ the terminal interface and browser dashboard. OpenAI models work without a confi
 file; configuration is only needed when you want to change a default or use a
 different endpoint.
 
-## 1. Install URSA
+## Install URSA
 
 URSA requires Python 3.11 or newer. The `uv` tool installation is recommended:
 
@@ -15,14 +15,10 @@ URSA requires Python 3.11 or newer. The `uv` tool installation is recommended:
     needed, then install URSA and the dashboard in an isolated tool environment:
 
     ```bash
-    uv tool install 'ursa[dashboard]'
+    uv tool install 'ursa-ai[dashboard]'
     ```
 
-    Upgrade it later with:
-
-    ```bash
-    uv tool upgrade ursa
-    ```
+    Update URSA with: `ursa self update` or `uv tool upgrade ursa-ai`
 
 === "venv + pip"
 
@@ -61,7 +57,7 @@ ursa --help
 ursa-dashboard --help
 ```
 
-## 2. Start with the built-in OpenAI configuration
+## Start with the built-in OpenAI configuration
 
 Set your OpenAI API key and launch URSA:
 
@@ -88,7 +84,7 @@ unnecessary.
     disposable exercise directory, or pass `--workspace` with a directory you
     are comfortable modifying.
 
-## 3. Optional: customize your user configuration
+## Optional: customize your user configuration
 
 Use a user config for defaults that should follow you across projects. Do not
 copy the same `config.yaml` into every project.
@@ -115,7 +111,7 @@ ursa --print-config=user,resolved
 
 See [Configuration][configuration] for other providers and precedence rules.
 
-## 4. Learn the TUI
+## Learn the TUI
 
 Run `ursa`. The welcome panel confirms the active model, workspace, and agent.
 
@@ -149,7 +145,7 @@ ursa --name tutorial
 The [TUI guide][getting-started-tui] covers commands, web-tool opt-in, and named
 agents in more detail.
 
-## 5. Use the dashboard
+## Use the dashboard
 
 Launch the browser interface:
 
@@ -171,7 +167,7 @@ managed in **Settings** and each dashboard session has an explicit workspace.
 See the [dashboard guide][getting-started-web-dashboard] for credential storage,
 remote-access safety, and environment runs.
 
-## 6. Run an example
+## Run an example
 
 Continue with the [examples gallery][examples]. The environment walkthrough is
 a good first exercise; the Nomad/MIST example shows how URSA can call a served

--- a/docs/getting-started/python-scripts.md
+++ b/docs/getting-started/python-scripts.md
@@ -5,7 +5,7 @@ URSA agents can be used directly from Python. This is useful when you want to bu
 ## Set up a Python project
 
 Install URSA in the project environment that will run your script. A separate
-`uv tool install ursa` installation provides the `ursa` command, but its
+`uv tool install ursa-ai` installation provides the `ursa` command, but its
 isolated environment is not importable by project scripts.
 
 === "uv project (recommended)"

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ Use URSA when you want to:
 We recommend installing with [`uv`](https://docs.astral.sh/uv/):
 
 ```bash
-uv tool install 'ursa-ai[dashboard]'
+uv tool install --python 3.13 'ursa-ai[dashboard]'
 ```
 
 See [Getting started][getting-started] for installation alternatives and a

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ Use URSA when you want to:
 We recommend installing with [`uv`](https://docs.astral.sh/uv/):
 
 ```bash
-uv tool install 'ursa[dashboard]'
+uv tool install 'ursa-ai[dashboard]'
 ```
 
 See [Getting started][getting-started] for installation alternatives and a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -13,6 +13,7 @@ ursa mcp-server --help
 ursa exec --help
 ursa rag-ingest --help
 ursa rag-query --help
+ursa self --help
 ```
 
 ## Common top-level commands
@@ -36,9 +37,45 @@ Current URSA installations include subcommands for:
 - managing persistent agents,
 - sharing/importing agents,
 - managing persistent RAG collections,
+- inspecting and managing the URSA installation,
 - non-interactive execution.
 
 Use `ursa --help` to confirm the exact set in your installed version.
+
+## Self management
+
+Installation status is available for every installation method:
+
+```bash
+ursa self status
+```
+
+It reports the URSA version and the running Python version and executable.
+For uv tool installations, it also reports the selected URSA extras and any
+additional packages installed in the tool environment.
+
+When URSA was installed with `uv tool install`, it can update itself while
+preserving the installation recipe:
+
+```bash
+ursa self update
+```
+
+Use `modify` to change the recipe. Options can add extras or additional
+packages, select an exact release or Git ref, and clear the existing extras
+and additional packages:
+
+```bash
+ursa self modify --extra dashboard
+ursa self modify --with some-package
+ursa self modify --version 1.2.3
+ursa self modify --ref main
+ursa self modify --clean --extra fm
+```
+
+Run `ursa self modify --help` for the complete option list. For pip, Conda,
+and other installations, use the same package manager that installed URSA;
+`self update` and `self modify` will reject installations not managed by uv.
 
 ## Python callback API
 

--- a/examples/environments/README.md
+++ b/examples/environments/README.md
@@ -79,14 +79,14 @@ Install the dashboard-enabled URSA tool, then launch it:
 === "macOS/Linux"
 
     ```bash
-    uv tool install 'ursa[dashboard]'
+    uv tool install --python 3.13 'ursa[dashboard]'
     ursa-dashboard
     ```
 
 === "Windows PowerShell"
 
     ```powershell
-    uv tool install "ursa[dashboard]"
+    uv tool install --python 3.13 "ursa[dashboard]"
     ursa-dashboard
     ```
 

--- a/examples/environments/run_team.py
+++ b/examples/environments/run_team.py
@@ -2,7 +2,6 @@ from langchain.chat_models import init_chat_model
 
 from ursa.environments import AgentTeamEnvironment
 
-
 llm = init_chat_model("openai:gpt-5.4-mini")
 team = AgentTeamEnvironment.from_yaml("agent_team.yaml", llm=llm)
 result = team.invoke(

--- a/examples/mcp_agent_tools/laboratory_server.py
+++ b/examples/mcp_agent_tools/laboratory_server.py
@@ -1,6 +1,5 @@
 from mcp.server.fastmcp import FastMCP
 
-
 mcp = FastMCP("Laboratory measurements", json_response=True)
 
 

--- a/src/ursa/cli/__init__.py
+++ b/src/ursa/cli/__init__.py
@@ -40,6 +40,7 @@ from ursa.cli.rag_management import (
     add_rag_subcommands,
     handle_rag_command,
 )
+from ursa.cli.self import add_self_subcommands
 from ursa.util.http import inject_truststore_into_ssl
 
 set_parsing_settings(docstring_parse_attribute_docstrings=True)
@@ -141,6 +142,8 @@ def build_parser() -> ArgumentParser:
     # Credential management commands
     add_auth_subcommands(subparsers)
 
+    add_self_subcommands(subparsers)
+
     exec_parser = ArgumentParser()
     exec_parser.add_argument("prompt", type=str)
     subparsers.add_subcommand(
@@ -191,6 +194,11 @@ def main(args=None):
     _apply_legacy_name_env(cfg, env_overrides)
 
     match subcommand:
+        case "self":
+            self_config = cfg.self
+            command_config = self_config[self_config.subcommand]
+            command_config.action(command_config)
+            return
         case "auth":
             auth_config = cfg.auth
             command_config = auth_config[auth_config.subcommand]

--- a/src/ursa/cli/self.py
+++ b/src/ursa/cli/self.py
@@ -1,0 +1,308 @@
+"""Inspect and manage the running URSA installation."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tomllib
+from argparse import SUPPRESS
+from importlib.metadata import PackageNotFoundError, metadata
+from importlib.metadata import version as package_version
+from pathlib import Path
+
+TOOL_PACKAGE = "ursa-ai"
+DEFAULT_GIT_REPOSITORY = "https://github.com/lanl/ursa"
+_INVALID_RECEIPT = "Cannot update: uv's URSA installation receipt is invalid."
+_NOT_UV_TOOL = (
+    "Cannot update: this copy of URSA was not installed with `uv tool install`.\n"
+    "Update it using the same mechanism that installed it."
+)
+
+
+def _command(commands, name, help, action):
+    from jsonargparse import ArgumentParser
+
+    parser = ArgumentParser(description=help)
+    parser.add_argument(
+        "--_action", dest="action", default=action, help=SUPPRESS
+    )
+    commands.add_subcommand(name, parser, help=help).default_env = False
+    return parser
+
+
+def add_self_subcommands(subparsers) -> None:
+    """Register commands without inspecting the installation."""
+    from jsonargparse import ArgumentParser
+
+    parser = ArgumentParser(
+        description="Inspect and manage this URSA installation.",
+        epilog=(
+            "Self update and modification require a uv tool installation: "
+            f"`uv tool install {TOOL_PACKAGE}`"
+        ),
+    )
+    subparsers.add_subcommand(
+        "self", parser, help=parser.description, dest="subcommand"
+    ).default_env = False
+    commands = parser.add_subcommands(required=True)
+    _command(commands, "status", "Show installation details", show_status)
+    _command(
+        commands,
+        "update",
+        "Update URSA while preserving its recipe",
+        lambda _args: upgrade(),
+    )
+    modify = _command(
+        commands, "modify", "Modify the URSA installation", _modify
+    )
+    modify.add_argument("--extra", action="append", default=None)
+    modify.add_argument(
+        "--with", dest="with_packages", action="append", default=None
+    )
+    modify.add_argument("--clean", action="store_true")
+    source = modify.add_mutually_exclusive_group()
+    source.add_argument("--version", help="Install an exact registry version")
+    source.add_argument("--ref", help="Install a Git branch, tag, or commit")
+
+
+def _modify(args) -> None:
+    upgrade(
+        extras=args.extra,
+        with_packages=args.with_packages,
+        version=args.version,
+        ref=args.ref,
+        clean=args.clean,
+    )
+
+
+def _read_requirements(receipt: Path) -> list[dict]:
+    try:
+        with receipt.open("rb") as stream:
+            requirements = tomllib.load(stream)["tool"]["requirements"]
+        if not isinstance(requirements, list):
+            raise TypeError
+        return requirements
+    except (OSError, KeyError, TypeError, tomllib.TOMLDecodeError):
+        raise SystemExit(_INVALID_RECEIPT) from None
+
+
+def _read_requirement(receipt: Path) -> dict:
+    try:
+        return next(
+            item
+            for item in _read_requirements(receipt)
+            if item.get("name") == TOOL_PACKAGE
+        )
+    except (AttributeError, StopIteration):
+        raise SystemExit(_INVALID_RECEIPT) from None
+
+
+def _running_uv_receipt(prefix: Path | None = None) -> Path | None:
+    receipt = (prefix or Path(sys.prefix)) / "uv-receipt.toml"
+    if not receipt.is_file():
+        return None
+    try:
+        _read_requirement(receipt)
+        return receipt
+    except SystemExit:
+        return None
+
+
+def _uv_install() -> tuple[Path, Path]:
+    if not (executable := shutil.which("uv")):
+        raise SystemExit("Cannot update: uv was not found on PATH.")
+    uv = Path(executable)
+    result = subprocess.run(
+        [str(uv), "tool", "dir"], capture_output=True, text=True, check=False
+    )
+    if result.returncode:
+        detail = f"\n{result.stderr.strip()}" if result.stderr.strip() else ""
+        raise SystemExit(
+            f"Cannot update: failed to determine uv's tool directory.{detail}"
+        )
+    if not (tool_dir := result.stdout.strip()):
+        raise SystemExit("Cannot update: uv returned an empty tool directory.")
+    current = Path(sys.prefix)
+    receipt = current / "uv-receipt.toml"
+    try:
+        valid = (
+            current.samefile(Path(tool_dir) / TOOL_PACKAGE)
+            and receipt.is_file()
+        )
+    except OSError:
+        valid = False
+    if not valid:
+        raise SystemExit(_NOT_UV_TOOL)
+    _read_requirement(receipt)
+    return uv, receipt
+
+
+def _source(requirement: dict) -> str:
+    if git := requirement.get("git"):
+        ref = next(
+            (
+                requirement.get(key)
+                for key in ("branch", "tag", "rev")
+                if requirement.get(key)
+            ),
+            None,
+        )
+        return f" @ git+{git}{f'@{ref}' if ref else ''}"
+    if url := requirement.get("url"):
+        return f" @ {url}"
+    if path := requirement.get("directory") or requirement.get("path"):
+        return f" @ {Path(path).resolve().as_uri()}"
+    return requirement.get("specifier", "")
+
+
+def _format_requirement(requirement: dict) -> str:
+    extras = requirement.get("extras", [])
+    name = requirement["name"] + (f"[{','.join(extras)}]" if extras else "")
+    return name + _source(requirement)
+
+
+def show_status(_args=None) -> None:
+    try:
+        installed = package_version(TOOL_PACKAGE)
+    except PackageNotFoundError:
+        installed = "unknown"
+    print(f"Version: {installed}")  # noqa: T201
+    print(f"Python: {sys.version.split()[0]} ({sys.implementation.name})")  # noqa: T201
+    print(f"Python path: {Path(sys.executable).resolve()}")  # noqa: T201
+    print(f"Platform: {sys.platform}")  # noqa: T201
+    receipt = _running_uv_receipt()
+    if receipt is None:
+        unavailable = "unavailable (not a uv tool installation)"
+        print(f"Extras: {unavailable}")  # noqa: T201
+        print(f"Additional packages: {unavailable}")  # noqa: T201
+        return
+    requirements = _read_requirements(receipt)
+    extras = _read_requirement(receipt).get("extras", [])
+    additional = [
+        _format_requirement(item)
+        for item in requirements
+        if item.get("name") != TOOL_PACKAGE
+    ]
+    print(f"Extras: {', '.join(extras) if extras else 'none'}")  # noqa: T201
+    print(  # noqa: T201
+        f"Additional packages: {', '.join(additional) if additional else 'none'}"
+    )
+
+
+def _merge(
+    existing: list[str], additions: list[str] | None, clean: bool
+) -> list[str]:
+    if any(not item for item in additions or []):
+        raise SystemExit(
+            "Cannot update: names and requirements cannot be empty."
+        )
+    return list(
+        dict.fromkeys([*([] if clean else existing), *(additions or [])])
+    )
+
+
+def get_package_repository() -> str:
+    try:
+        urls = metadata(TOOL_PACKAGE).get_all("Project-URL") or []
+    except PackageNotFoundError:
+        return DEFAULT_GIT_REPOSITORY
+    parsed = {
+        label.strip().casefold(): url.strip()
+        for value in urls
+        for label, separator, url in [value.partition(",")]
+        if separator and url.strip()
+    }
+    return next(
+        (
+            parsed[key]
+            for key in ("repository", "source", "source code", "homepage")
+            if key in parsed
+        ),
+        DEFAULT_GIT_REPOSITORY,
+    )
+
+
+def build_upgrade_requirement(
+    receipt: Path,
+    *,
+    extras: list[str] | None = None,
+    version: str | None = None,
+    ref: str | None = None,
+) -> str:
+    original = _read_requirement(receipt)
+    selected = original.get("extras", []) if extras is None else extras
+    name = TOOL_PACKAGE + (f"[{','.join(selected)}]" if selected else "")
+    if version is not None:
+        if not version.strip():
+            raise SystemExit("Cannot update: version cannot be empty.")
+        return f"{name}=={version}"
+    if ref is not None:
+        if not ref.strip():
+            raise SystemExit("Cannot update: ref cannot be empty.")
+        return f"{name} @ git+{original.get('git') or get_package_repository()}@{ref}"
+    return name + _source(original)
+
+
+def upgrade(
+    *,
+    extras: list[str] | None = None,
+    with_packages: list[str] | None = None,
+    version: str | None = None,
+    ref: str | None = None,
+    clean: bool = False,
+) -> None:
+    """Replace the running process with uv update or install."""
+    uv, receipt = _uv_install()
+    changed = clean or any(
+        value is not None for value in (extras, with_packages, version, ref)
+    )
+    if changed:
+        selected = _merge(
+            _read_requirement(receipt).get("extras", []), extras, clean
+        )
+        packages = _merge(
+            [
+                _format_requirement(item)
+                for item in _read_requirements(receipt)
+                if item.get("name") != TOOL_PACKAGE
+            ],
+            with_packages,
+            clean,
+        )
+        requirement = build_upgrade_requirement(
+            receipt,
+            extras=selected,
+            version=version,
+            ref=ref,
+        )
+        argv = [
+            str(uv),
+            "tool",
+            "install",
+            "--force",
+            "--reinstall",
+            "--compile-bytecode",
+        ]
+        for package in packages:
+            argv += ["--with", package]
+        argv.append(requirement)
+    else:
+        argv = [
+            str(uv),
+            "tool",
+            "upgrade",
+            "--reinstall",
+            "--compile-bytecode",
+            TOOL_PACKAGE,
+        ]
+    try:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os.execv(str(uv), argv)
+    except OSError as exc:
+        raise SystemExit(
+            f"Cannot update: uv could not be started: {exc}"
+        ) from None
+    raise AssertionError("unreachable")

--- a/src/ursa/cli/self.py
+++ b/src/ursa/cli/self.py
@@ -170,7 +170,7 @@ def show_status(_args=None) -> None:
         installed = "unknown"
     print(f"Version: {installed}")  # noqa: T201
     print(f"Python: {sys.version.split()[0]} ({sys.implementation.name})")  # noqa: T201
-    print(f"Python path: {Path(sys.executable).resolve()}")  # noqa: T201
+    print(f"Python path: {sys.executable}")  # noqa: T201
     print(f"Platform: {sys.platform}")  # noqa: T201
     receipt = _running_uv_receipt()
     if receipt is None:
@@ -284,6 +284,8 @@ def upgrade(
             "--force",
             "--reinstall",
             "--compile-bytecode",
+            "--python",
+            str(Path(sys.executable).resolve()),
         ]
         for package in packages:
             argv += ["--with", package]

--- a/src/ursa/cli/self.py
+++ b/src/ursa/cli/self.py
@@ -170,7 +170,7 @@ def show_status(_args=None) -> None:
         installed = "unknown"
     print(f"Version: {installed}")  # noqa: T201
     print(f"Python: {sys.version.split()[0]} ({sys.implementation.name})")  # noqa: T201
-    print(f"Python path: {sys.executable}")  # noqa: T201
+    print(f"Python path: {Path(sys.executable).resolve()}")  # noqa: T201
     print(f"Platform: {sys.platform}")  # noqa: T201
     receipt = _running_uv_receipt()
     if receipt is None:

--- a/tests/cli/test_self.py
+++ b/tests/cli/test_self.py
@@ -1,0 +1,380 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from ursa.cli import build_parser, main
+from ursa.cli.self import (
+    TOOL_PACKAGE,
+    _select_extras,
+    _select_with_packages,
+    build_install_argv,
+    build_upgrade_argv,
+    build_upgrade_requirement,
+    get_package_repository,
+    get_uv_tool_dir,
+    show_status,
+    verify_uv_tool_install,
+)
+
+
+def _receipt(path: Path, requirement: str) -> Path:
+    path.write_text(f"[tool]\nrequirements = [{requirement}]\n")
+    return path
+
+
+def test_get_uv_tool_dir_strips_output(monkeypatch):
+    monkeypatch.setattr(
+        "ursa.cli.self.subprocess.run",
+        MagicMock(return_value=MagicMock(returncode=0, stdout="/tools\n")),
+    )
+    assert get_uv_tool_dir(Path("/bin/uv")) == Path("/tools")
+
+
+def test_get_uv_tool_dir_reports_stderr(monkeypatch):
+    monkeypatch.setattr(
+        "ursa.cli.self.subprocess.run",
+        MagicMock(return_value=MagicMock(returncode=1, stderr="bad uv\n")),
+    )
+    with pytest.raises(SystemExit, match="bad uv"):
+        get_uv_tool_dir(Path("/bin/uv"))
+
+
+def test_verify_install_accepts_samefile_and_receipt(tmp_path):
+    environment = tmp_path / TOOL_PACKAGE
+    environment.mkdir()
+    receipt = _receipt(environment / "uv-receipt.toml", '{ name = "ursa-ai" }')
+    assert verify_uv_tool_install(tmp_path, environment) == receipt
+
+
+def test_verify_install_rejects_missing_receipt(tmp_path):
+    environment = tmp_path / TOOL_PACKAGE
+    environment.mkdir()
+    with pytest.raises(SystemExit, match="not installed"):
+        verify_uv_tool_install(tmp_path, environment)
+
+
+def test_fixed_upgrade_argv():
+    assert build_upgrade_argv(Path("/bin/uv")) == [
+        "/bin/uv",
+        "tool",
+        "upgrade",
+        "--reinstall",
+        "--compile-bytecode",
+        "ursa-ai",
+    ]
+
+
+def test_install_argv_with_additional_packages():
+    assert build_install_argv(
+        Path("/bin/uv"), "ursa-ai[dashboard]>=1", ["pytest>=8", "tox"]
+    ) == [
+        "/bin/uv",
+        "tool",
+        "install",
+        "--force",
+        "--reinstall",
+        "--compile-bytecode",
+        "--with",
+        "pytest>=8",
+        "--with",
+        "tox",
+        "ursa-ai[dashboard]>=1",
+    ]
+
+
+def test_with_packages_are_added(tmp_path):
+    receipt = tmp_path / "receipt.toml"
+    receipt.write_text(
+        "[tool]\n"
+        'requirements = [{ name = "ursa-ai" }, '
+        '{ name = "pytest", specifier = ">=8" }, { name = "tox" }]\n'
+    )
+
+    assert _select_with_packages(receipt, ["ruff"], clean=False) == [
+        "pytest>=8",
+        "tox",
+        "ruff",
+    ]
+    assert _select_with_packages(receipt, ["ruff"], clean=True) == ["ruff"]
+
+
+def test_extras_are_added():
+    assert _select_extras(["dashboard", "fm"], ["image"], clean=False) == [
+        "dashboard",
+        "fm",
+        "image",
+    ]
+    assert _select_extras(["dashboard"], ["image"], clean=True) == ["image"]
+
+
+def test_upgrade_requirement_uses_selected_extras(tmp_path):
+    receipt = _receipt(
+        tmp_path / "receipt.toml",
+        '{ name = "ursa-ai", extras = ["dashboard", "fm"], specifier = ">=1" }',
+    )
+    assert build_upgrade_requirement(receipt, extras=["office_readers"]) == (
+        "ursa-ai[office_readers]>=1"
+    )
+    assert build_upgrade_requirement(receipt, extras=["image"]) == (
+        "ursa-ai[image]>=1"
+    )
+
+
+def test_upgrade_requirement_preserves_file_source(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    receipt = _receipt(
+        tmp_path / "receipt.toml",
+        f'{{ name = "ursa-ai", directory = "{source}" }}',
+    )
+
+    assert build_upgrade_requirement(receipt, extras=["dashboard"]) == (
+        f"ursa-ai[dashboard] @ {source.as_uri()}"
+    )
+
+
+def test_version_and_ref_requirements(monkeypatch, tmp_path):
+    registry = _receipt(
+        tmp_path / "registry.toml",
+        '{ name = "ursa-ai", extras = ["dashboard"] }',
+    )
+    assert build_upgrade_requirement(registry, version="1.2.3") == (
+        "ursa-ai[dashboard]==1.2.3"
+    )
+    monkeypatch.setattr(
+        "ursa.cli.self.get_package_repository",
+        lambda: "https://example.test/default.git",
+    )
+    assert build_upgrade_requirement(registry, ref="main") == (
+        "ursa-ai[dashboard] @ git+https://example.test/default.git@main"
+    )
+
+    git = _receipt(
+        tmp_path / "git.toml",
+        '{ name = "ursa-ai", git = "https://example.test/ursa.git" }',
+    )
+    assert build_upgrade_requirement(git, ref="release") == (
+        "ursa-ai @ git+https://example.test/ursa.git@release"
+    )
+
+
+def test_package_repository_prefers_metadata(monkeypatch):
+    package_metadata = MagicMock()
+    package_metadata.get_all.return_value = [
+        "Homepage, https://example.test/home",
+        "Repository, https://example.test/repository.git",
+    ]
+    monkeypatch.setattr(
+        "ursa.cli.self.metadata", lambda _name: package_metadata
+    )
+
+    assert get_package_repository() == "https://example.test/repository.git"
+
+
+def test_package_repository_has_lanl_fallback(monkeypatch):
+    package_metadata = MagicMock()
+    package_metadata.get_all.return_value = []
+    monkeypatch.setattr(
+        "ursa.cli.self.metadata", lambda _name: package_metadata
+    )
+
+    assert get_package_repository() == "https://github.com/lanl/ursa"
+
+
+def test_parser_supports_recipe_flags():
+    cfg = build_parser().parse_args([
+        "self",
+        "modify",
+        "--extra",
+        "dashboard",
+        "--extra",
+        "fm",
+        "--with",
+        "pytest",
+        "--with",
+        "tox",
+        "--ref",
+        "main",
+    ])
+    assert cfg.self.modify.extra == ["dashboard", "fm"]
+    assert cfg.self.modify.ref == "main"
+    assert cfg.self.modify.with_packages == ["pytest", "tox"]
+    assert callable(cfg.self.modify.action)
+
+
+def test_parser_accepts_clean():
+    cfg = build_parser().parse_args(["self", "modify", "--clean"])
+
+    assert cfg.self.modify.clean is True
+    assert cfg.self.modify.with_packages is None
+
+
+def test_parser_ignores_self_management_environment_flags(monkeypatch):
+    monkeypatch.setenv("URSA_SELF__MODIFY__EXTRA", "dashboard")
+    monkeypatch.setenv("URSA_SELF__MODIFY__VERSION", "1.2.3")
+    monkeypatch.setenv("URSA_SELF__MODIFY__REF", "main")
+    monkeypatch.setenv("URSA_SELF__MODIFY__WITH_PACKAGES", "pytest")
+
+    cfg = build_parser().parse_args(["self", "modify"])
+
+    assert cfg.self.modify.extra is None
+    assert cfg.self.modify.version is None
+    assert cfg.self.modify.ref is None
+    assert cfg.self.modify.with_packages is None
+    assert cfg.self.modify.clean is False
+
+
+def test_main_routes_upgrade_before_config(monkeypatch):
+    called = MagicMock(side_effect=SystemExit(0))
+    monkeypatch.setattr("ursa.cli.inject_truststore_into_ssl", lambda: None)
+    parser = build_parser()
+    monkeypatch.setattr("ursa.cli.build_parser", lambda: parser)
+    monkeypatch.setattr("ursa.cli.self.upgrade", called)
+    with pytest.raises(SystemExit, match="0"):
+        main(["self", "modify", "--extra", "dashboard", "--version", "1.2.3"])
+    called.assert_called_once_with(
+        extras=["dashboard"],
+        with_packages=None,
+        version="1.2.3",
+        ref=None,
+        clean=False,
+    )
+
+
+def test_main_self_update_preserves_recipe(monkeypatch):
+    called = MagicMock(side_effect=SystemExit(0))
+    monkeypatch.setattr("ursa.cli.inject_truststore_into_ssl", lambda: None)
+    parser = build_parser()
+    monkeypatch.setattr("ursa.cli.build_parser", lambda: parser)
+    monkeypatch.setattr("ursa.cli.self.upgrade", called)
+
+    with pytest.raises(SystemExit, match="0"):
+        main(["self", "update"])
+
+    called.assert_called_once_with()
+
+
+def test_main_clean_clears_extras_and_additional_packages(monkeypatch):
+    called = MagicMock(side_effect=SystemExit(0))
+    monkeypatch.setattr("ursa.cli.inject_truststore_into_ssl", lambda: None)
+    parser = build_parser()
+    monkeypatch.setattr("ursa.cli.build_parser", lambda: parser)
+    monkeypatch.setattr("ursa.cli.self.upgrade", called)
+
+    with pytest.raises(SystemExit, match="0"):
+        main(["self", "modify", "--clean"])
+
+    called.assert_called_once_with(
+        extras=None,
+        with_packages=None,
+        version=None,
+        ref=None,
+        clean=True,
+    )
+
+
+def test_main_clean_applies_requested_extras_and_packages(monkeypatch):
+    called = MagicMock(side_effect=SystemExit(0))
+    monkeypatch.setattr("ursa.cli.inject_truststore_into_ssl", lambda: None)
+    parser = build_parser()
+    monkeypatch.setattr("ursa.cli.build_parser", lambda: parser)
+    monkeypatch.setattr("ursa.cli.self.upgrade", called)
+
+    with pytest.raises(SystemExit, match="0"):
+        main([
+            "self",
+            "modify",
+            "--clean",
+            "--extra",
+            "fm",
+            "--with",
+            "pytest",
+        ])
+
+    called.assert_called_once_with(
+        extras=["fm"],
+        with_packages=["pytest"],
+        version=None,
+        ref=None,
+        clean=True,
+    )
+
+
+def test_status_reports_registry_recipe(monkeypatch, tmp_path, capsys):
+    environment = tmp_path / TOOL_PACKAGE
+    environment.mkdir()
+    _receipt(
+        environment / "uv-receipt.toml",
+        '{ name = "ursa-ai", extras = ["dashboard"], specifier = ">=1" }',
+    )
+    monkeypatch.setattr("ursa.cli.self.find_uv", lambda: Path("/bin/uv"))
+    monkeypatch.setattr("ursa.cli.self.get_uv_tool_dir", lambda _uv: tmp_path)
+    monkeypatch.setattr("ursa.cli.self.sys.prefix", str(environment))
+    monkeypatch.setattr("ursa.cli.self.package_version", lambda _name: "1.2.3")
+
+    show_status()
+
+    output = capsys.readouterr().out.splitlines()
+    assert output[0] == "Version: 1.2.3"
+    assert output[1].startswith("Python: ")
+    assert output[2].startswith("Python path: ")
+    assert output[3:] == ["Extras: dashboard", "Additional packages: none"]
+
+
+def test_status_reports_additional_receipt_requirements(
+    monkeypatch, tmp_path, capsys
+):
+    environment = tmp_path / TOOL_PACKAGE
+    environment.mkdir()
+    (environment / "uv-receipt.toml").write_text(
+        "[tool]\n"
+        'requirements = [{ name = "ursa-ai" }, '
+        '{ name = "pytest", specifier = ">=8" }]\n'
+    )
+    monkeypatch.setattr("ursa.cli.self.find_uv", lambda: Path("/bin/uv"))
+    monkeypatch.setattr("ursa.cli.self.get_uv_tool_dir", lambda _uv: tmp_path)
+    monkeypatch.setattr("ursa.cli.self.sys.prefix", str(environment))
+    monkeypatch.setattr("ursa.cli.self.package_version", lambda _name: "1.2.3")
+
+    show_status()
+
+    assert "Additional packages: pytest>=8" in capsys.readouterr().out
+
+
+def test_status_works_without_uv_tool_install(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr("ursa.cli.self.sys.prefix", str(tmp_path))
+    monkeypatch.setattr("ursa.cli.self.package_version", lambda _name: "1.2.3")
+
+    show_status()
+
+    output = capsys.readouterr().out
+    assert "Version: 1.2.3" in output
+    assert "Extras: unavailable (not a uv tool installation)" in output
+
+
+def test_self_registration_does_not_inspect_installation(monkeypatch, capsys):
+    inspected = MagicMock(side_effect=AssertionError("installation inspected"))
+    monkeypatch.setattr("ursa.cli.self.is_uv_tool_install", inspected)
+    monkeypatch.setattr("ursa.cli.self._running_uv_receipt", inspected)
+    parser = build_parser()
+
+    parser.parse_args(["self", "status"])
+    parser.parse_args(["self", "update"])
+    parser.parse_args(["self", "modify"])
+    inspected.assert_not_called()
+
+    with pytest.raises(SystemExit) as help_exit:
+        parser.parse_args(["self", "--help"])
+    assert help_exit.value.code == 0
+    assert "uv tool install" in capsys.readouterr().out
+
+
+def test_self_registers_update_and_modify():
+    parser = build_parser()
+
+    update = parser.parse_args(["self", "update"])
+    modify = parser.parse_args(["self", "modify", "--ref", "main"])
+
+    assert callable(update.self["update"].action)
+    assert modify.self.modify.ref == "main"

--- a/tests/cli/test_self.py
+++ b/tests/cli/test_self.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -6,15 +7,10 @@ import pytest
 from ursa.cli import build_parser, main
 from ursa.cli.self import (
     TOOL_PACKAGE,
-    _select_extras,
-    _select_with_packages,
-    build_install_argv,
-    build_upgrade_argv,
     build_upgrade_requirement,
     get_package_repository,
-    get_uv_tool_dir,
     show_status,
-    verify_uv_tool_install,
+    upgrade,
 )
 
 
@@ -23,89 +19,171 @@ def _receipt(path: Path, requirement: str) -> Path:
     return path
 
 
-def test_get_uv_tool_dir_strips_output(monkeypatch):
-    monkeypatch.setattr(
-        "ursa.cli.self.subprocess.run",
-        MagicMock(return_value=MagicMock(returncode=0, stdout="/tools\n")),
-    )
-    assert get_uv_tool_dir(Path("/bin/uv")) == Path("/tools")
-
-
-def test_get_uv_tool_dir_reports_stderr(monkeypatch):
-    monkeypatch.setattr(
-        "ursa.cli.self.subprocess.run",
-        MagicMock(return_value=MagicMock(returncode=1, stderr="bad uv\n")),
-    )
-    with pytest.raises(SystemExit, match="bad uv"):
-        get_uv_tool_dir(Path("/bin/uv"))
-
-
-def test_verify_install_accepts_samefile_and_receipt(tmp_path):
-    environment = tmp_path / TOOL_PACKAGE
-    environment.mkdir()
-    receipt = _receipt(environment / "uv-receipt.toml", '{ name = "ursa-ai" }')
-    assert verify_uv_tool_install(tmp_path, environment) == receipt
-
-
-def test_verify_install_rejects_missing_receipt(tmp_path):
-    environment = tmp_path / TOOL_PACKAGE
-    environment.mkdir()
-    with pytest.raises(SystemExit, match="not installed"):
-        verify_uv_tool_install(tmp_path, environment)
-
-
-def test_fixed_upgrade_argv():
-    assert build_upgrade_argv(Path("/bin/uv")) == [
-        "/bin/uv",
-        "tool",
-        "upgrade",
-        "--reinstall",
-        "--compile-bytecode",
-        "ursa-ai",
-    ]
-
-
-def test_install_argv_with_additional_packages():
-    assert build_install_argv(
-        Path("/bin/uv"), "ursa-ai[dashboard]>=1", ["pytest>=8", "tox"]
-    ) == [
-        "/bin/uv",
-        "tool",
-        "install",
-        "--force",
-        "--reinstall",
-        "--compile-bytecode",
-        "--with",
-        "pytest>=8",
-        "--with",
-        "tox",
-        "ursa-ai[dashboard]>=1",
-    ]
-
-
-def test_with_packages_are_added(tmp_path):
-    receipt = tmp_path / "receipt.toml"
-    receipt.write_text(
+@pytest.fixture
+def isolated_uv_tool(monkeypatch, tmp_path):
+    """Provide a complete fake uv tool environment without invoking uv."""
+    tool_dir = tmp_path / "tools"
+    environment = tool_dir / TOOL_PACKAGE
+    environment.mkdir(parents=True)
+    source = tmp_path / "source"
+    source.mkdir()
+    (environment / "uv-receipt.toml").write_text(
         "[tool]\n"
-        'requirements = [{ name = "ursa-ai" }, '
-        '{ name = "pytest", specifier = ">=8" }, { name = "tox" }]\n'
+        f'requirements = [{{ name = "ursa-ai", extras = ["dashboard"], '
+        f'directory = "{source.as_posix()}" }}, '
+        '{ name = "pytest", specifier = ">=8" }]\n'
+    )
+    uv = tmp_path / "bin" / "uv"
+    execv = MagicMock(side_effect=SystemExit(0))
+    monkeypatch.setattr("ursa.cli.inject_truststore_into_ssl", lambda: None)
+    monkeypatch.setattr(
+        "ursa.cli.self._uv_install",
+        lambda: (uv, environment / "uv-receipt.toml"),
+    )
+    monkeypatch.setattr("ursa.cli.self.sys.prefix", str(environment))
+    monkeypatch.setattr("ursa.cli.self.package_version", lambda _name: "1.2.3")
+    monkeypatch.setattr("ursa.cli.self.shutil.which", lambda _name: str(uv))
+    monkeypatch.setattr(
+        "ursa.cli.self.subprocess.run",
+        MagicMock(
+            return_value=MagicMock(
+                stdout=(
+                    "ursa-ai v1.2.3 [extras: dashboard] [with: pytest>=8] "
+                    "[CPython 3.12.0]\n- ursa\nother v1.0.0\n"
+                )
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "ursa.cli.self.get_package_repository",
+        lambda: "https://example.test/ursa.git",
+    )
+    monkeypatch.setattr("ursa.cli.self.os.execv", execv)
+    return {"execv": execv, "source": source, "uv": uv}
+
+
+def test_self_status_command_uses_isolated_receipt(isolated_uv_tool, capsys):
+    main(["self", "status"])
+
+    output = capsys.readouterr().out
+    assert "Version: 1.2.3" in output
+    assert "Extras: dashboard" in output
+    assert "Additional packages: pytest>=8" in output
+    isolated_uv_tool["execv"].assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("arguments", "expected_tail"),
+    [
+        (
+            ["modify", "--ref", "main"],
+            [
+                "--with",
+                "pytest>=8",
+                "ursa-ai[dashboard] @ git+https://example.test/ursa.git@main",
+            ],
+        ),
+        (
+            ["modify", "--version", "2.0.0"],
+            ["--with", "pytest>=8", "ursa-ai[dashboard]==2.0.0"],
+        ),
+        (
+            ["modify", "--with", "tox"],
+            [
+                "--with",
+                "pytest>=8",
+                "--with",
+                "tox",
+                "ursa-ai[dashboard] @ {source}",
+            ],
+        ),
+        (
+            ["modify", "--extra", "fm"],
+            [
+                "--with",
+                "pytest>=8",
+                "ursa-ai[dashboard,fm] @ {source}",
+            ],
+        ),
+        (
+            ["modify", "--clean", "--extra", "fm", "--with", "tox"],
+            ["--with", "tox", "ursa-ai[fm] @ {source}"],
+        ),
+    ],
+)
+def test_self_modify_commands_are_isolated(
+    isolated_uv_tool, arguments, expected_tail
+):
+    source_uri = isolated_uv_tool["source"].as_uri()
+    expected_tail = [value.format(source=source_uri) for value in expected_tail]
+
+    with pytest.raises(SystemExit, match="0"):
+        main(["self", *arguments])
+
+    isolated_uv_tool["execv"].assert_called_once_with(
+        str(isolated_uv_tool["uv"]),
+        [
+            str(isolated_uv_tool["uv"]),
+            "tool",
+            "install",
+            "--force",
+            "--reinstall",
+            "--compile-bytecode",
+            "--python",
+            str(Path(sys.executable).resolve()),
+            *expected_tail,
+        ],
     )
 
-    assert _select_with_packages(receipt, ["ruff"], clean=False) == [
-        "pytest>=8",
-        "tox",
-        "ruff",
-    ]
-    assert _select_with_packages(receipt, ["ruff"], clean=True) == ["ruff"]
+
+def test_self_update_command_is_isolated(isolated_uv_tool):
+    with pytest.raises(SystemExit, match="0"):
+        main(["self", "update"])
+
+    isolated_uv_tool["execv"].assert_called_once_with(
+        str(isolated_uv_tool["uv"]),
+        [
+            str(isolated_uv_tool["uv"]),
+            "tool",
+            "upgrade",
+            "--reinstall",
+            "--compile-bytecode",
+            TOOL_PACKAGE,
+        ],
+    )
 
 
-def test_extras_are_added():
-    assert _select_extras(["dashboard", "fm"], ["image"], clean=False) == [
-        "dashboard",
-        "fm",
-        "image",
-    ]
-    assert _select_extras(["dashboard"], ["image"], clean=True) == ["image"]
+@pytest.mark.parametrize("command", ["update", "modify"])
+def test_self_management_rejects_non_uv_install_without_exec(
+    monkeypatch, tmp_path, command
+):
+    execv = MagicMock(side_effect=AssertionError("process replaced"))
+    monkeypatch.setattr("ursa.cli.inject_truststore_into_ssl", lambda: None)
+    monkeypatch.setattr(
+        "ursa.cli.self._uv_install",
+        MagicMock(side_effect=SystemExit("not installed with uv tool install")),
+    )
+    monkeypatch.setattr("ursa.cli.self.os.execv", execv)
+
+    with pytest.raises(SystemExit, match="not installed with"):
+        main(["self", command])
+
+    execv.assert_not_called()
+
+
+def test_self_modify_rejects_version_and_ref_together(isolated_uv_tool):
+    with pytest.raises(SystemExit) as exc_info:
+        main([
+            "self",
+            "modify",
+            "--version",
+            "2.0.0",
+            "--ref",
+            "main",
+        ])
+
+    assert exc_info.value.code == 2
+    isolated_uv_tool["execv"].assert_not_called()
 
 
 def test_upgrade_requirement_uses_selected_extras(tmp_path):
@@ -126,7 +204,7 @@ def test_upgrade_requirement_preserves_file_source(tmp_path):
     source.mkdir()
     receipt = _receipt(
         tmp_path / "receipt.toml",
-        f'{{ name = "ursa-ai", directory = "{source}" }}',
+        f'{{ name = "ursa-ai", directory = "{source.as_posix()}" }}',
     )
 
     assert build_upgrade_requirement(receipt, extras=["dashboard"]) == (
@@ -156,6 +234,49 @@ def test_version_and_ref_requirements(monkeypatch, tmp_path):
     )
     assert build_upgrade_requirement(git, ref="release") == (
         "ursa-ai @ git+https://example.test/ursa.git@release"
+    )
+
+
+def test_local_install_can_switch_to_git_ref(monkeypatch, tmp_path):
+    environment = tmp_path / TOOL_PACKAGE
+    environment.mkdir()
+    source = tmp_path / "source"
+    source.mkdir()
+    (environment / "uv-receipt.toml").write_text(
+        "[tool]\n"
+        f'requirements = [{{ name = "ursa-ai", directory = "{source.as_posix()}" }}, '
+        '{ name = "pytest", specifier = ">=8" }]\n'
+    )
+    monkeypatch.setattr(
+        "ursa.cli.self._uv_install",
+        lambda: (Path("/bin/uv"), environment / "uv-receipt.toml"),
+    )
+    monkeypatch.setattr(
+        "ursa.cli.self.get_package_repository",
+        lambda: "https://example.test/ursa.git",
+    )
+    execv = MagicMock(side_effect=SystemExit(0))
+    monkeypatch.setattr("ursa.cli.self.os.execv", execv)
+
+    with pytest.raises(SystemExit, match="0"):
+        upgrade(ref="main")
+
+    uv = str(Path("/bin/uv"))
+    execv.assert_called_once_with(
+        uv,
+        [
+            uv,
+            "tool",
+            "install",
+            "--force",
+            "--reinstall",
+            "--compile-bytecode",
+            "--python",
+            str(Path(sys.executable).resolve()),
+            "--with",
+            "pytest>=8",
+            "ursa-ai @ git+https://example.test/ursa.git@main",
+        ],
     )
 
 
@@ -301,47 +422,6 @@ def test_main_clean_applies_requested_extras_and_packages(monkeypatch):
     )
 
 
-def test_status_reports_registry_recipe(monkeypatch, tmp_path, capsys):
-    environment = tmp_path / TOOL_PACKAGE
-    environment.mkdir()
-    _receipt(
-        environment / "uv-receipt.toml",
-        '{ name = "ursa-ai", extras = ["dashboard"], specifier = ">=1" }',
-    )
-    monkeypatch.setattr("ursa.cli.self.find_uv", lambda: Path("/bin/uv"))
-    monkeypatch.setattr("ursa.cli.self.get_uv_tool_dir", lambda _uv: tmp_path)
-    monkeypatch.setattr("ursa.cli.self.sys.prefix", str(environment))
-    monkeypatch.setattr("ursa.cli.self.package_version", lambda _name: "1.2.3")
-
-    show_status()
-
-    output = capsys.readouterr().out.splitlines()
-    assert output[0] == "Version: 1.2.3"
-    assert output[1].startswith("Python: ")
-    assert output[2].startswith("Python path: ")
-    assert output[3:] == ["Extras: dashboard", "Additional packages: none"]
-
-
-def test_status_reports_additional_receipt_requirements(
-    monkeypatch, tmp_path, capsys
-):
-    environment = tmp_path / TOOL_PACKAGE
-    environment.mkdir()
-    (environment / "uv-receipt.toml").write_text(
-        "[tool]\n"
-        'requirements = [{ name = "ursa-ai" }, '
-        '{ name = "pytest", specifier = ">=8" }]\n'
-    )
-    monkeypatch.setattr("ursa.cli.self.find_uv", lambda: Path("/bin/uv"))
-    monkeypatch.setattr("ursa.cli.self.get_uv_tool_dir", lambda _uv: tmp_path)
-    monkeypatch.setattr("ursa.cli.self.sys.prefix", str(environment))
-    monkeypatch.setattr("ursa.cli.self.package_version", lambda _name: "1.2.3")
-
-    show_status()
-
-    assert "Additional packages: pytest>=8" in capsys.readouterr().out
-
-
 def test_status_works_without_uv_tool_install(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr("ursa.cli.self.sys.prefix", str(tmp_path))
     monkeypatch.setattr("ursa.cli.self.package_version", lambda _name: "1.2.3")
@@ -355,7 +435,6 @@ def test_status_works_without_uv_tool_install(monkeypatch, tmp_path, capsys):
 
 def test_self_registration_does_not_inspect_installation(monkeypatch, capsys):
     inspected = MagicMock(side_effect=AssertionError("installation inspected"))
-    monkeypatch.setattr("ursa.cli.self.is_uv_tool_install", inspected)
     monkeypatch.setattr("ursa.cli.self._running_uv_receipt", inspected)
     parser = build_parser()
 

--- a/tests/cli/test_self_uv_integration.py
+++ b/tests/cli/test_self_uv_integration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import os
 import shutil
 import subprocess
@@ -47,20 +48,27 @@ def test_self_commands_with_real_isolated_uv(tmp_path):
     ursa = bin_dir / ("ursa.exe" if os.name == "nt" else "ursa")
 
     status = _run([ursa, "self", "status"], env=env).stdout
-    assert "Version:" in status
-    assert f"Python path: {tool_dir / 'ursa-ai'}" in status
-    assert "Extras: none" in status
-    assert "Additional packages: none" in status
+    assert re.search(r"^Version: .+", status, re.MULTILINE)
+    assert re.search(r"^Python: \d+\.\d+\.\d+ \([^)]+\)$", status, re.MULTILINE)
+    assert re.search(r"^Python path: .+", status, re.MULTILINE)
+    assert re.search(r"^Extras: none$", status, re.MULTILINE)
+    assert re.search(r"^Additional packages: none$", status, re.MULTILINE)
 
     _run([ursa, "self", "update"], env=env)
     updated_status = _run([ursa, "self", "status"], env=env).stdout
-    assert "Additional packages: none" in updated_status
+    assert re.search(
+        r"^Additional packages: none$", updated_status, re.MULTILINE
+    )
 
     _run([ursa, "self", "modify", "--with", "pytest"], env=env)
     modified_status = _run([ursa, "self", "status"], env=env).stdout
     if os.name != "nt":
-        assert "Additional packages: pytest" in modified_status
+        assert re.search(
+            r"^Additional packages: pytest$", modified_status, re.MULTILINE
+        )
 
     _run([ursa, "self", "modify", "--clean"], env=env)
     cleaned_status = _run([ursa, "self", "status"], env=env).stdout
-    assert "Additional packages: none" in cleaned_status
+    assert re.search(
+        r"^Additional packages: none$", cleaned_status, re.MULTILINE
+    )

--- a/tests/cli/test_self_uv_integration.py
+++ b/tests/cli/test_self_uv_integration.py
@@ -1,0 +1,66 @@
+"""Integration coverage for self-management against an isolated uv store."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _run(
+    argv: list[str | Path], *, env: dict[str, str]
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [str(value) for value in argv],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+@pytest.mark.slow
+def test_self_commands_with_real_isolated_uv(tmp_path):
+    """Exercise uv itself without reading or writing the user's tool store."""
+    uv = shutil.which("uv")
+    if uv is None:
+        pytest.skip("uv is not installed")
+
+    repository = Path(__file__).resolve().parents[2]
+    tool_dir = tmp_path / "tools"
+    bin_dir = tmp_path / "bin"
+    env = {
+        **os.environ,
+        "UV_TOOL_DIR": str(tool_dir),
+        "UV_TOOL_BIN_DIR": str(bin_dir),
+        "UV_PYTHON_DOWNLOADS": "never",
+    }
+
+    _run(
+        [uv, "tool", "install", repository, "--python", sys.executable],
+        env=env,
+    )
+    ursa = bin_dir / ("ursa.exe" if os.name == "nt" else "ursa")
+
+    status = _run([ursa, "self", "status"], env=env).stdout
+    assert "Version:" in status
+    assert f"Python path: {tool_dir / 'ursa-ai'}" in status
+    assert "Extras: none" in status
+    assert "Additional packages: none" in status
+
+    _run([ursa, "self", "update"], env=env)
+    updated_status = _run([ursa, "self", "status"], env=env).stdout
+    assert "Additional packages: none" in updated_status
+
+    _run([ursa, "self", "modify", "--with", "pytest"], env=env)
+    modified_status = _run([ursa, "self", "status"], env=env).stdout
+    if os.name != "nt":
+        assert "Additional packages: pytest" in modified_status
+
+    _run([ursa, "self", "modify", "--clean"], env=env)
+    cleaned_status = _run([ursa, "self", "status"], env=env).stdout
+    assert "Additional packages: none" in cleaned_status


### PR DESCRIPTION
Adds command for inspecting, modify and updating an ursa installation

The big ones is `ursa self update` which does what it says on the tin.
`usra self modify` is a nice bonus for swapping between ursa versions.

Both are build around a `uv tool install ursa-ai` installation. We could do
something similar with `pipx`, but of the base installation methods (pip&venv,
conda) neither support an equivalent installation.

This doesn't totally replace `uv tool` (i.e. swapping python versions) but
it does make things like adding packages (i.e. a langchain provider),
swapping URSA versions or enabling extras simpler / self contained within
URSA

## Testing

1. Install this version `uv tool install .`
2. Check it out:
- `ursa self status`
- `ursa self modify --with langchain-ollama`
- `ursa self modify --extra dashboard`
- `ursa self modify --version main`

> Switching versions will remove `ursa self`. Do step 1 again to restore

