### PR TITLE
fix: return the per-run telemetry panel and display it on raw_debug

### DIFF
--- a/src/ursa/observability/timing.py
+++ b/src/ursa/observability/timing.py
@@ -1453,7 +1453,14 @@ class Telemetry:
         otel_headers: str | Mapping | None = None,
         save_raw_snapshot: bool | None = None,
         save_raw_records: bool | None = None,
-    ):
+    ) -> Panel | str:
+        """Finalize the run and return the per-run report as a Rich renderable.
+
+        Saves and exports as configured and feeds the session rollup. The
+        report is printed to the console only when ``raw`` is true; by
+        default nothing is printed, because the TUI captures stdout and the
+        one-shot CLI uses stdout as the response channel.
+        """
         if not self.enable:
             return ""
 
@@ -1612,4 +1619,14 @@ class Telemetry:
                 Text.from_markup(pricing_str),
             ]  # <- parse markup
 
+        panel = Panel.fit(
+            Group(*renderables),
+            title=f"[bold white]Metrics[/] • [cyan]{agent_label}[/]",
+            border_style="bright_magenta",
+            padding=(1, 2),
+            box=HEAVY,
+        )
+        if raw:
+            get_console().print(panel)
         _session_ingest(payload)
+        return panel

--- a/src/ursa/observability/timing.py
+++ b/src/ursa/observability/timing.py
@@ -23,6 +23,7 @@ from langchain_core.callbacks import BaseCallbackHandler
 from rich import get_console
 from rich.box import HEAVY
 from rich.console import Group
+from rich.markup import escape
 from rich.panel import Panel
 from rich.rule import Rule
 from rich.table import Table
@@ -1564,7 +1565,7 @@ class Telemetry:
         # --- Build header & attribution lines (markup-aware) ---
         header_lines = []
         header_lines.append(
-            f"[bold magenta]{agent_label}[/] [dim]•[/] thread [bold]{thread_id}[/] [dim]•[/] run [bold]{run_id}[/]"
+            f"[bold magenta]{escape(agent_label)}[/] [dim]•[/] thread [bold]{thread_id}[/] [dim]•[/] run [bold]{run_id}[/]"
         )
         if start_dt and end_dt:
             header_lines.append(
@@ -1621,7 +1622,7 @@ class Telemetry:
 
         panel = Panel.fit(
             Group(*renderables),
-            title=f"[bold white]Metrics[/] • [cyan]{agent_label}[/]",
+            title=f"[bold white]Metrics[/] • [cyan]{escape(agent_label)}[/]",
             border_style="bright_magenta",
             padding=(1, 2),
             box=HEAVY,

--- a/tests/agents/test_base/test_base.py
+++ b/tests/agents/test_base/test_base.py
@@ -736,3 +736,20 @@ def test_disabled_metrics_render_is_silent_even_with_raw_debug(
 
     assert agent.telemetry.render() == ""
     assert buffer.getvalue() == ""
+
+
+def test_agent_short_id_survives_markup_in_the_report(
+    tmpdir: Path, monkeypatch
+):
+    # Rich reads a bracketed suffix such as "[abc123]" as a style tag and
+    # drops it, so a short id starting with a letter vanished from the
+    # header line and the panel title.
+    buffer = _capturing_console(monkeypatch)
+    agent = Agent(
+        llm=TinyCountingModel(), enable_metrics=True, workspace=tmpdir
+    )
+    agent.telemetry._short_id = "abc123"
+
+    agent.invoke("hello", raw_debug=True)
+
+    assert buffer.getvalue().count("[abc123]") == 2

--- a/tests/agents/test_base/test_base.py
+++ b/tests/agents/test_base/test_base.py
@@ -655,3 +655,84 @@ def test_runtime_injection_preserved_for_nodes(tmp_path: Path):
     assert runtime is not None
     assert isinstance(runtime, Runtime)
     assert runtime.context.workspace == Path(tmp_path)
+
+
+def _capturing_console(monkeypatch):
+    import io
+
+    from rich.console import Console  # noqa: TID251
+
+    import ursa.observability.timing as timing
+
+    buffer = io.StringIO()
+    console = Console(file=buffer, force_terminal=False, width=200)
+    monkeypatch.setattr(timing, "get_console", lambda: console)
+    return buffer
+
+
+def _rendered(renderable) -> str:
+    import io
+
+    from rich.console import Console  # noqa: TID251
+
+    buffer = io.StringIO()
+    Console(file=buffer, force_terminal=False, width=200).print(renderable)
+    return buffer.getvalue()
+
+
+def test_render_returns_the_per_run_panel(tmpdir: Path):
+    # Issue #304: render() assembled the per-run report and discarded it.
+    agent = Agent(
+        llm=TinyCountingModel(), enable_metrics=True, workspace=tmpdir
+    )
+    agent.invoke("hello")
+
+    # invoke() discards what render() returns, so call it again to look.
+    panel = agent.telemetry.render(save_json=False)
+
+    text = _rendered(panel)
+    assert "Metrics" in text
+    assert "Attribution" in text
+
+
+def test_raw_debug_displays_the_per_run_panel(tmpdir: Path, monkeypatch):
+    # raw_debug is documented as displaying telemetry for debugging; the
+    # display must include the save confirmation that was invisible.
+    buffer = _capturing_console(monkeypatch)
+    agent = Agent(
+        llm=TinyCountingModel(), enable_metrics=True, workspace=tmpdir
+    )
+
+    agent.invoke("hello", raw_debug=True)
+
+    text = buffer.getvalue()
+    assert "Metrics" in text
+    assert "Attribution" in text
+    assert "Saved metrics JSON to" in text
+
+
+def test_default_invoke_prints_no_telemetry(tmpdir: Path, monkeypatch):
+    # Guard: the TUI captures stdout and one-shot mode uses stdout as the
+    # response channel, so nothing may print unless asked.
+    buffer = _capturing_console(monkeypatch)
+    agent = Agent(
+        llm=TinyCountingModel(), enable_metrics=True, workspace=tmpdir
+    )
+
+    agent.invoke("hello")
+
+    assert buffer.getvalue() == ""
+
+
+def test_disabled_metrics_render_is_silent_even_with_raw_debug(
+    tmpdir: Path, monkeypatch
+):
+    buffer = _capturing_console(monkeypatch)
+    agent = Agent(
+        llm=TinyCountingModel(), enable_metrics=False, workspace=tmpdir
+    )
+
+    agent.invoke("hello", raw_debug=True)
+
+    assert agent.telemetry.render() == ""
+    assert buffer.getvalue() == ""


### PR DESCRIPTION
## Summary

Fixes #304. `Telemetry.render()` assembles the complete per-run report (header, the three timing tables, the attribution block with the "Saved metrics JSON to" and OTLP flush confirmations, and the cost summary when pricing applies) and then discards it. #40 printed that panel, #85 commented the print out, and #99 removed the commented lines, so the assembly has been dead since and everything that only lands in it, including the save confirmations, has been invisible. Separately, the `raw` argument that `invoke(raw_debug=...)` passes through is used nowhere inside `render()`. #40 shipped its only use already commented out (appending a pretty-printed raw snapshot to a plain-text report that was itself commented out), and the `invoke` docstrings added in #73 describe it as displaying raw telemetry data for debugging, so no version has ever given `raw_debug=True` a visible effect; the `simulation_use_workflow` example even carries a comment noting that `raw_debug=True` does not seem to trigger anything.

## The change

`render()` now builds the panel #40 printed (same title, border, and box) and returns it, so the assembly is live and library callers can print or inspect it. It prints the panel to the console only when `raw` is true, which gives `raw_debug=True` a visible effect for the first time without adding any API. The default stays silent on purpose: the Textual TUI captures stdout during a run (a print goes to devtools only, never the screen), and one-shot mode uses stdout as the response channel, so an unconditional print would either vanish or contaminate piped output. The parameters are unchanged (only a return annotation is added), the three call sites in `base.py` are untouched, and the disabled path still returns `""`.

Making the panel visible exposed one inherited quirk, fixed here as well: Rich parsed the bracketed short-id suffix of the agent label (for example `[abc123]`) as a style tag and dropped it from the header line and the panel title whenever the id started with a letter, which is roughly a third of runs. The label is now markup-escaped at both sites.

Two alternatives are reasonable and easy to switch to if preferred: an always-print behind a new flag, or deleting the assembly and the `raw` parameter outright. This PR takes the shape that changes nothing for current callers while making the documented surface real. The `raw_debug` docstrings in `base.py` still say "raw telemetry data", which fits the JSON snapshot options better than the formatted report; I left them alone here and can reword them separately if wanted.

## Tests

Five tests in `tests/agents/test_base/test_base.py`, in two red-first pairs. First pair: the returned value renders as the per-run panel (it was `None`), and `invoke(raw_debug=True)` prints the panel including the "Saved metrics JSON to" line the issue called invisible (nothing was printed). Running that test commit without its fix commit reproduces the exact 2 failed / 2 passed pattern, with two guards passing throughout: a default `invoke` with metrics enabled prints nothing, and disabled telemetry prints nothing even with `raw_debug=True`. Second pair: with the short id pinned to `abc123`, the id must appear in both the header and the title; without the escape it appears in neither. Full suite locally: 824 passed, 8 skipped.
