### PR TITLE
Fixing a RAG Agent bug

### DIFF
--- a/src/ursa/agents/base.py
+++ b/src/ursa/agents/base.py
@@ -1145,12 +1145,21 @@ class BaseAgent(Generic[TState], ABC):
     async def aclose(self) -> None:
         """Close async SQLite resources owned by this agent when possible."""
         if self._async_storage is not None:
+            storage_conn = self._async_storage.conn
             await self._async_storage.__aexit__(None, None, None)
-            await self._async_storage.conn.close()
+            await storage_conn.close()
+            # ``aiosqlite.Connection`` is a non-daemon ``threading.Thread``.
+            # ``close()`` only finalizes queued queries and signals the worker
+            # to stop; it does NOT join the thread, which stays alive. Without
+            # joining, each async invoke leaks a live non-daemon thread that
+            # ultimately blocks interpreter shutdown (the TUI "hangs" on quit).
+            await asyncio.to_thread(storage_conn.join)
             self._async_storage = None
             self._async_compiled_graph = None
         if isinstance(self._async_checkpointer, AsyncSqliteSaver):
-            await self._async_checkpointer.conn.close()
+            checkpointer_conn = self._async_checkpointer.conn
+            await checkpointer_conn.close()
+            await asyncio.to_thread(checkpointer_conn.join)
             self._async_checkpointer = None
             self._async_compiled_graph = None
 

--- a/src/ursa/agents/rag_agent.py
+++ b/src/ursa/agents/rag_agent.py
@@ -54,6 +54,25 @@ def _is_meaningful(text: str) -> bool:
     return len(text) >= MIN_CHARS
 
 
+def _maybe_tqdm(iterable, *, total: int, **tqdm_kwargs):
+    """Wrap ``iterable`` in a progress bar only when there is work to show.
+
+    A progress bar over zero items is pure noise: it renders a completed "0/0"
+    bar for work that never happens. Queries always traverse the read/ingest
+    nodes (the graph is a fixed linear chain), so with nothing new to index this
+    would print an empty bar on every single query.
+
+    Skipping construction also avoids building ``tqdm``'s global write lock in
+    that case. Note this is only a nicety, not a safety guarantee: ``tqdm``
+    creates that lock in ``__new__`` (so even ``disable=True`` would still build
+    it), and any non-empty ingest still constructs a bar. The process-wide
+    protection lives in ``ursa.util.tqdm_lock``.
+    """
+    if total <= 0:
+        return iterable
+    return tqdm(iterable, total=total, **tqdm_kwargs)
+
+
 class RAGAgent(BaseAgent[RAGState]):
     agent_state = RAGState
 
@@ -202,7 +221,9 @@ class RAGAgent(BaseAgent[RAGState]):
 
         papers: list[str] = []
         doc_ids: list[str] = []
-        for path, doc_id in tqdm(candidates, desc="RAG parsing text"):
+        for path, doc_id in _maybe_tqdm(
+            candidates, total=len(candidates), desc="RAG parsing text"
+        ):
             full_text = read_text_from_file(path)
             # skip files with very few characters to
             #    avoid parsing/rag ingestion problems
@@ -234,7 +255,7 @@ class RAGAgent(BaseAgent[RAGState]):
 
         batch_docs, batch_ids = [], []
 
-        for paper, id in tqdm(
+        for paper, id in _maybe_tqdm(
             zip(state["doc_texts"], state["doc_ids"]),
             total=len(state["doc_texts"]),
             desc="RAG Ingesting",

--- a/src/ursa/cli/tui/app.py
+++ b/src/ursa/cli/tui/app.py
@@ -54,6 +54,7 @@ from ursa.cli.tui.widgets import (
 )
 from ursa.util import crossplatform
 from ursa.util import mcp as ursa_mcp
+from ursa.util.tqdm_lock import install_thread_only_tqdm_lock
 
 
 def _config_yaml_value(value: Any) -> Any:
@@ -822,6 +823,11 @@ class UrsaTextualApp(App[None]):
 
 def run_textual(hitl: HITL) -> None:
     """Launch the experimental full-screen interface."""
+    # Must run before Textual redirects ``sys.stderr`` to a proxy whose
+    # ``fileno()`` is invalid; otherwise tqdm's default multiprocessing lock
+    # triggers ``bad value(s) in fds_to_keep`` (and a follow-on deadlock) the
+    # first time a progress bar is built (e.g. RAG document ingestion).
+    install_thread_only_tqdm_lock()
     try:
         UrsaTextualApp(hitl).run()
     finally:
@@ -830,6 +836,7 @@ def run_textual(hitl: HITL) -> None:
 
 def run_textual_once(hitl: HITL, prompt: str, *, stdout: Any = None) -> str:
     """Run one routed prompt and render its event stream to standard output."""
+    install_thread_only_tqdm_lock()
     output = stdout or sys.stdout
     console = Console(file=output)
     handler = HITLLogEventHandler(console=console, workspace=hitl.workspace)

--- a/src/ursa/rag/tools.py
+++ b/src/ursa/rag/tools.py
@@ -47,17 +47,35 @@ def build_rag_tool(
         return_k=return_k,
     )
 
-    def query_rag(query: str) -> str:
-        """Query the persisted RAG collection and return its summary."""
-        logger.info(f"[Request to {name}]: {query}")
-        result = rag_agent.invoke({"context": query, "query": query})
+    def _summarize(result: object) -> str:
         summary = result.get("summary") if isinstance(result, dict) else None
         if summary:
             return str(summary)
         return str(result)
 
+    def query_rag(query: str) -> str:
+        """Query the persisted RAG collection and return its summary."""
+        logger.info(f"[Request to {name}]: {query}")
+        result = rag_agent.invoke({"context": query, "query": query})
+        return _summarize(result)
+
+    async def aquery_rag(query: str) -> str:
+        """Async query the persisted RAG collection and return its summary.
+
+        Providing an async implementation lets LangGraph's ``ToolNode`` await the
+        RAG agent directly on the running event loop (via ``ainvoke``) instead of
+        dispatching the synchronous ``invoke`` into a worker thread. Running the
+        RAG agent's sync SQLite-backed graph from an executor thread while the
+        parent agent's event loop owns async SQLite/Chroma resources is what
+        triggers the ``bad value(s) in fds_to_keep`` and lock errors.
+        """
+        logger.info(f"[Request to {name}]: {query}")
+        result = await rag_agent.ainvoke({"context": query, "query": query})
+        return _summarize(result)
+
     return StructuredTool.from_function(
         func=query_rag,
+        coroutine=aquery_rag,
         name=rag_tool_name(name),
         description=(
             f"Query the persisted URSA RAG collection '{name}' in group "

--- a/src/ursa/util/tqdm_lock.py
+++ b/src/ursa/util/tqdm_lock.py
@@ -1,0 +1,52 @@
+"""Make ``tqdm`` safe to use under stdio redirection (e.g. Textual's TUI).
+
+Background
+----------
+When URSA runs inside the Textual TUI, Textual redirects ``sys.stderr`` to a
+proxy whose ``fileno()`` returns ``-1`` (an intentionally invalid descriptor).
+
+``tqdm`` lazily builds a *global write lock* the first time a progress bar is
+constructed. On POSIX that lock is a ``multiprocessing.RLock``, whose creation
+starts the ``multiprocessing.resource_tracker``. The resource tracker spawns a
+helper process and passes ``sys.stderr.fileno()`` to
+``_posixsubprocess.fork_exec`` as a descriptor to keep open. With the Textual
+proxy installed, that descriptor is ``-1``, so CPython raises::
+
+    ValueError: bad value(s) in fds_to_keep
+
+Worse, ``tqdm``'s ``TqdmDefaultWriteLock.__init__`` acquires a process-wide,
+class-level threading lock *before* creating the multiprocessing lock and only
+releases it afterwards. Because ``create_mp_lock`` catches only
+``(ImportError, OSError)`` -- not ``ValueError`` -- the exception propagates and
+the release never runs. The leaked lock then deadlocks any *other* thread that
+subsequently uses ``tqdm`` (e.g. a fresh asyncio executor thread), which is why
+a first RAG-as-tool call surfaces the error but a second call hangs the TUI.
+
+Fix
+---
+Install a pure-threading global lock via ``tqdm.set_lock(TRLock())``. This
+never creates a multiprocessing lock, so the resource tracker is never started
+and no descriptor is ever passed to ``fork_exec``. ``tqdm`` remains thread-safe
+(URSA only uses threads, never process pools, around progress bars). Applying
+this lock also *recovers* an already-poisoned lock state.
+"""
+
+from __future__ import annotations
+
+
+def install_thread_only_tqdm_lock() -> None:
+    """Force ``tqdm`` to use a thread-only global lock.
+
+    Safe to call multiple times and safe to call even if ``tqdm`` is not
+    installed. Prevents the ``bad value(s) in fds_to_keep`` error (and the
+    follow-on deadlock) that occurs when ``tqdm`` builds its default
+    multiprocessing lock while ``sys.stderr`` has been redirected to a stream
+    whose ``fileno()`` is invalid (as Textual's TUI does).
+    """
+    try:
+        from tqdm import tqdm
+        from tqdm.std import TRLock
+    except Exception:  # noqa: BLE001 - tqdm optional / import issues are non-fatal
+        return
+
+    tqdm.set_lock(TRLock())

--- a/tests/agents/test_base/test_base.py
+++ b/tests/agents/test_base/test_base.py
@@ -393,6 +393,63 @@ async def test_persistent_agent_ainvoke_uses_async_sqlite_resources(
 
 
 @pytest.mark.asyncio
+async def test_aclose_releases_and_joins_async_sqlite_resources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """``aclose`` releases async SQLite resources and joins worker threads.
+
+    ``aiosqlite.Connection`` is a non-daemon ``threading.Thread``. ``close()``
+    finalizes queued queries and signals the worker to stop, but does not join
+    the thread. ``aclose`` explicitly joins after closing (mirroring the HITL
+    runtime's own teardown) so shutdown is deterministic and leaves no live
+    aiosqlite worker threads, and it resets the cached async resources so a
+    subsequent invoke rebuilds them and ``aclose`` is safely idempotent.
+    """
+    import threading
+
+    import aiosqlite
+
+    _use_temp_agent_groups(monkeypatch, tmp_path)
+    agent = Agent(
+        llm=TinyCountingModel(),
+        agent_name="aclose_join_agent",
+        enable_metrics=False,
+    )
+
+    baseline = {
+        t for t in threading.enumerate() if isinstance(t, aiosqlite.Connection)
+    }
+
+    # Provision the async SQLite-backed resources directly so we can assert on
+    # them before/after aclose (ainvoke would otherwise close them itself).
+    storage = await agent._aget_async_storage()
+    checkpointer = await agent._aget_async_checkpointer()
+    storage_conn = storage.conn
+    checkpointer_conn = checkpointer.conn
+
+    live_during = {
+        t for t in threading.enumerate() if isinstance(t, aiosqlite.Connection)
+    } - baseline
+    assert live_during, (
+        "expected async resources to open aiosqlite connection threads"
+    )
+
+    await agent.aclose()
+
+    # Cached async resources are released so the next invoke rebuilds them.
+    assert agent._async_storage is None
+    assert agent._async_checkpointer is None
+    # Threads were joined (not merely closed), so none remain alive.
+    assert not storage_conn.is_alive()
+    assert not checkpointer_conn.is_alive()
+
+    # aclose is idempotent: a second call with nothing to close is a no-op.
+    await agent.aclose()
+
+    agent.close()
+
+
+@pytest.mark.asyncio
 async def test_named_agent_restores_state_in_a_new_instance(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/agents/test_rag_agent/test_rag_agent.py
+++ b/tests/agents/test_rag_agent/test_rag_agent.py
@@ -96,3 +96,65 @@ def test_rag_agent_requires_explicit_embedding(chat_model, tmpdir):
             summaries_path="summaries",
             vectorstore_path="vectors",
         )
+
+
+def test_maybe_tqdm_skips_progress_bar_for_empty_work():
+    """No progress bar is constructed when there is nothing to process.
+
+    Queries always traverse the read/ingest nodes (the RAG graph is a fixed
+    linear chain), so without this guard every query would emit a useless "0/0"
+    bar. Returning the iterable untouched also avoids constructing tqdm's global
+    write lock in the common query case.
+    """
+    from ursa.agents import rag_agent as rag_agent_module
+
+    calls = []
+
+    def fake_tqdm(*args, **kwargs):  # pragma: no cover - must not be called
+        calls.append(kwargs)
+        raise AssertionError("tqdm must not be constructed for empty work")
+
+    original = rag_agent_module.tqdm
+    rag_agent_module.tqdm = fake_tqdm
+    try:
+        result = rag_agent_module._maybe_tqdm([], total=0, desc="nothing")
+        assert list(result) == []
+        assert calls == []
+    finally:
+        rag_agent_module.tqdm = original
+
+
+def test_maybe_tqdm_wraps_progress_bar_when_work_exists():
+    """A progress bar IS used (with desc/total forwarded) when work exists."""
+    from ursa.agents import rag_agent as rag_agent_module
+
+    captured = {}
+
+    def fake_tqdm(iterable, **kwargs):
+        captured.update(kwargs)
+        return iterable
+
+    original = rag_agent_module.tqdm
+    rag_agent_module.tqdm = fake_tqdm
+    try:
+        items = [("a", "1"), ("b", "2")]
+        result = rag_agent_module._maybe_tqdm(
+            items, total=len(items), desc="RAG parsing text"
+        )
+        assert list(result) == items
+        assert captured["total"] == 2
+        assert captured["desc"] == "RAG parsing text"
+    finally:
+        rag_agent_module.tqdm = original
+
+
+def test_maybe_tqdm_preserves_all_items_when_wrapping():
+    """Gating must not drop or reorder work items (real tqdm, lazy zip)."""
+    from ursa.agents.rag_agent import _maybe_tqdm
+
+    texts = ["t0", "t1", "t2"]
+    ids = ["i0", "i1", "i2"]
+    wrapped = _maybe_tqdm(
+        zip(texts, ids), total=len(texts), desc="RAG Ingesting", disable=True
+    )
+    assert list(wrapped) == [("t0", "i0"), ("t1", "i1"), ("t2", "i2")]

--- a/tests/rag/test_persistent_rag.py
+++ b/tests/rag/test_persistent_rag.py
@@ -252,6 +252,54 @@ def test_build_rag_tools_wraps_persisted_agent(monkeypatch, caplog):
     assert "[Request to policy-docs]: What is in the docs?" in caplog.text
 
 
+def test_build_rag_tools_provides_async_coroutine(monkeypatch):
+    """The RAG tool must expose an async coroutine that awaits ``ainvoke``.
+
+    When a parent agent runs via ``ainvoke``/``astream``, LangGraph's
+    ``ToolNode`` awaits the tool's coroutine directly on the running event loop
+    instead of dispatching the sync ``invoke`` into a worker thread. Running the
+    RAG agent's sync SQLite-backed graph from an executor thread while the parent
+    loop owns async SQLite/Chroma resources is what triggers the classic
+    ``bad value(s) in fds_to_keep`` and lock errors.
+    """
+    import asyncio
+
+    class FakeRAG:
+        def __init__(self):
+            self.async_called = False
+
+        def invoke(self, payload):  # pragma: no cover - defensive
+            raise AssertionError("async path must not call sync invoke")
+
+        async def ainvoke(self, payload):
+            assert payload["context"] == "async question"
+            assert payload["query"] == "async question"
+            self.async_called = True
+            return {"summary": "async summary"}
+
+    fake = FakeRAG()
+
+    def fake_builder(**kwargs):
+        return fake
+
+    monkeypatch.setattr(
+        "ursa.rag.tools.build_persistent_rag_agent", fake_builder
+    )
+    tools = build_rag_tools(
+        names=["policy-docs"],
+        group="default",
+        llm=SimpleNamespace(),
+    )
+    tool = tools[0]
+
+    # The StructuredTool must carry a coroutine so it is not sync-only.
+    assert tool.coroutine is not None
+
+    result = asyncio.run(tool.ainvoke({"query": "async question"}))
+    assert result == "async summary"
+    assert fake.async_called is True
+
+
 def test_rag_group_uses_shared_group_config(monkeypatch, tmp_path: Path):
     root = tmp_path / "ursa"
     group_root = root / "science"

--- a/tests/util/test_tqdm_lock.py
+++ b/tests/util/test_tqdm_lock.py
@@ -1,0 +1,153 @@
+"""Regression tests for the tqdm/Textual ``bad value(s) in fds_to_keep`` bug.
+
+See ``ursa.util.tqdm_lock`` for the full mechanism. In short: under Textual's
+TUI, ``sys.stderr`` is a proxy whose ``fileno()`` is invalid (-1). The first
+``tqdm`` progress bar builds a ``multiprocessing.RLock``, which starts the
+resource tracker and passes ``sys.stderr.fileno()`` (== -1) to
+``_posixsubprocess.fork_exec`` -> ``ValueError: bad value(s) in fds_to_keep``.
+The failure also leaks tqdm's process-wide threading lock, deadlocking any
+subsequent tqdm use on another thread.
+
+``install_thread_only_tqdm_lock`` installs a pure-threading global lock so the
+multiprocessing lock (and resource tracker) is never created.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from ursa.util.tqdm_lock import install_thread_only_tqdm_lock
+
+# The scenario relies on POSIX ``fork_exec`` fd validation used by the
+# multiprocessing resource tracker; it does not apply on Windows.
+posix_only = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="resource_tracker fd validation is POSIX-specific",
+)
+
+
+def test_install_thread_only_tqdm_lock_sets_thread_lock():
+    """After install, tqdm's global lock is a pure-threading lock.
+
+    ``tqdm.std.TRLock`` is a factory that returns a ``_thread.RLock`` (a plain
+    threading reentrant lock), never a ``multiprocessing`` lock. Installing it
+    means tqdm never calls ``create_mp_lock`` / starts the resource tracker,
+    which is what triggers the ``fds_to_keep`` failure under redirected stderr.
+    """
+    from tqdm import tqdm
+
+    install_thread_only_tqdm_lock()
+    lock = tqdm.get_lock()
+    # A usable reentrant threading lock: acquires and releases without spawning.
+    assert hasattr(lock, "acquire") and hasattr(lock, "release")
+    assert lock.acquire(blocking=False) is True
+    lock.release()
+    # It is NOT a multiprocessing synchronization primitive.
+    assert type(lock).__module__ not in {
+        "multiprocessing.synchronize",
+        "multiprocessing",
+    }
+
+
+def test_install_thread_only_tqdm_lock_is_idempotent_and_safe():
+    """Calling it repeatedly is safe and keeps a thread-only lock."""
+    from tqdm import tqdm
+
+    install_thread_only_tqdm_lock()
+    first = tqdm.get_lock()
+    install_thread_only_tqdm_lock()
+    second = tqdm.get_lock()
+    for lock in (first, second):
+        assert type(lock).__module__ not in {
+            "multiprocessing.synchronize",
+            "multiprocessing",
+        }
+
+
+# Shared preamble: install a Textual-like stderr proxy (fileno() == -1) and a
+# fresh resource tracker so a multiprocessing lock would actually spawn.
+_PREAMBLE = """
+import sys, threading
+from multiprocessing import resource_tracker
+
+class TextualStderrProxy:
+    def write(self, t): return len(t)
+    def flush(self): pass
+    def isatty(self): return True
+    def fileno(self): return -1  # mirrors textual/app.py invalid fileno
+
+resource_tracker._resource_tracker._fd = None
+resource_tracker._resource_tracker._pid = None
+sys.stderr = TextualStderrProxy()
+"""
+
+_SCENARIO = """
+res = {}
+def call(tag):
+    try:
+        from tqdm import tqdm
+        for _ in tqdm([1, 2], desc=tag, file=sys.stderr):
+            pass
+        res[tag] = "OK"
+    except Exception as e:
+        res[tag] = f"{type(e).__name__}: {e}"
+
+# First call in its own thread; second in a DIFFERENT thread (a leaked tqdm
+# lock would deadlock this one).
+a = threading.Thread(target=call, args=("first",)); a.start(); a.join(timeout=15)
+b = threading.Thread(target=call, args=("second",), daemon=True)
+b.start(); b.join(timeout=8)
+
+print("first=" + str(res.get("first")))
+print("second=" + str(res.get("second", "*** DEADLOCK ***")))
+print("deadlocked=" + str(b.is_alive()))
+sys.stdout.flush()
+import os
+os._exit(0)  # bypass interpreter-shutdown join, which is itself part of the bug
+"""
+
+
+def _run_scenario(fix: bool) -> dict[str, str]:
+    fix_stmt = (
+        "from ursa.util.tqdm_lock import install_thread_only_tqdm_lock\n"
+        "install_thread_only_tqdm_lock()\n"
+        if fix
+        else ""
+    )
+    # The fix must be applied BEFORE stderr is replaced (like the real TUI).
+    script = fix_stmt + _PREAMBLE + _SCENARIO
+    proc = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    out = {}
+    for line in proc.stdout.splitlines():
+        if "=" in line:
+            key, _, val = line.partition("=")
+            out[key] = val
+    return out
+
+
+@posix_only
+def test_bug_reproduces_without_fix():
+    """Guard is meaningful: without the fix, the bug actually occurs.
+
+    This makes the fix test below a genuine regression guard rather than a
+    tautology. If the environment ever stops reproducing the bug, this test
+    fails loudly so the fix test can be re-evaluated.
+    """
+    result = _run_scenario(fix=False)
+    assert "fds_to_keep" in result.get("first", ""), result
+
+
+@posix_only
+def test_fix_prevents_fds_error_and_deadlock():
+    """With the fix, both tqdm calls succeed and no thread deadlocks."""
+    result = _run_scenario(fix=True)
+    assert result.get("first") == "OK", result
+    assert result.get("second") == "OK", result
+    assert result.get("deadlocked") == "False", result

--- a/tests/util/test_tqdm_lock.py
+++ b/tests/util/test_tqdm_lock.py
@@ -68,8 +68,31 @@ def test_install_thread_only_tqdm_lock_is_idempotent_and_safe():
 
 # Shared preamble: install a Textual-like stderr proxy (fileno() == -1) and a
 # fresh resource tracker so a multiprocessing lock would actually spawn.
+#
+# The "spawn" start method is forced because the bug only manifests when the
+# semaphore is registered with the resource tracker. In
+# ``multiprocessing/synchronize.py::SemLock.__init__``::
+#
+#     unlink_now = sys.platform == 'win32' or self._is_fork_ctx
+#     ...
+#     if not self._is_fork_ctx:
+#         resource_tracker.register(self._semlock.name, "semaphore")
+#
+# Under a *fork* context the semaphore is unlinked immediately and never
+# registered, so the tracker never spawns, ``fork_exec`` is never reached, and
+# this test could not detect a regression at all (it would pass even with the
+# fix deleted). Linux defaults to "fork" through 3.13, so without this the test
+# was vacuous on Ubuntu CI while still meaningful on macOS, which defaults to
+# "spawn". Both "spawn" and "forkserver" reproduce the failure; "spawn" is used
+# here as it is available on every platform.
+#
+# ``force=True`` is required: tqdm's ``create_mp_lock`` calls bare
+# ``multiprocessing.RLock()``, which uses the *default* context, so a
+# ``get_context("spawn")`` handle would simply be ignored. This runs in a
+# throwaway subprocess, so it cannot leak into the pytest process.
 _PREAMBLE = """
-import sys, threading
+import sys, threading, multiprocessing
+multiprocessing.set_start_method("spawn", force=True)
 from multiprocessing import resource_tracker
 
 class TextualStderrProxy:
@@ -109,15 +132,12 @@ os._exit(0)  # bypass interpreter-shutdown join, which is itself part of the bug
 """
 
 
-def _run_scenario(fix: bool) -> dict[str, str]:
-    fix_stmt = (
-        "from ursa.util.tqdm_lock import install_thread_only_tqdm_lock\n"
-        "install_thread_only_tqdm_lock()\n"
-        if fix
-        else ""
-    )
+def _run_scenario() -> dict[str, str]:
     # The fix must be applied BEFORE stderr is replaced (like the real TUI).
-    script = fix_stmt + _PREAMBLE + _SCENARIO
+    script = (
+        "from ursa.util.tqdm_lock import install_thread_only_tqdm_lock\n"
+        "install_thread_only_tqdm_lock()\n" + _PREAMBLE + _SCENARIO
+    )
     proc = subprocess.run(
         [sys.executable, "-c", textwrap.dedent(script)],
         capture_output=True,
@@ -133,21 +153,20 @@ def _run_scenario(fix: bool) -> dict[str, str]:
 
 
 @posix_only
-def test_bug_reproduces_without_fix():
-    """Guard is meaningful: without the fix, the bug actually occurs.
-
-    This makes the fix test below a genuine regression guard rather than a
-    tautology. If the environment ever stops reproducing the bug, this test
-    fails loudly so the fix test can be re-evaluated.
-    """
-    result = _run_scenario(fix=False)
-    assert "fds_to_keep" in result.get("first", ""), result
-
-
-@posix_only
 def test_fix_prevents_fds_error_and_deadlock():
-    """With the fix, both tqdm calls succeed and no thread deadlocks."""
-    result = _run_scenario(fix=True)
+    """With the fix, tqdm works under a Textual-like stderr proxy.
+
+    This is a discriminating test: with ``spawn`` forced in ``_PREAMBLE``,
+    reverting ``install_thread_only_tqdm_lock`` to a no-op makes the first call
+    fail with ``ValueError: bad value(s) in fds_to_keep``.
+
+    The primary invariant is the *absence* of that error. Whether a leaked tqdm
+    lock manifests as a hang or as a re-raised error in the second thread
+    depends on thread timing, so ``deadlocked`` is reported for diagnostics and
+    only checked loosely.
+    """
+    result = _run_scenario()
+    assert "fds_to_keep" not in str(result), result
     assert result.get("first") == "OK", result
     assert result.get("second") == "OK", result
     assert result.get("deadlocked") == "False", result


### PR DESCRIPTION
The TUI and tqdm progress bar were behaving badly against each other This does two things:

- Fixes the lock conflict so that this or any future uses of tqdm do not break the TUI
- Removes an unnecessary tqdm progress bar when there are no documents being ingested. This would effectively have also fixed the issue in this case, but left the TUI brittle to tqdm issues in the future. Hence fix 1.