### PR TITLE
Fix typos in the documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ the following in the current directory:
 # If using pip with venv, first activate your environment, then
 pre-commit install
 
-# If usign uv
+# If using uv
 uv run pre-commit install
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The original ArXiv paper is [here](https://arxiv.org/abs/2506.22653).
 
 ## Documentation
 
-Detailed documenation including:
+Detailed documentation including:
 - Installation
 - Getting Started Guides
 - Configuration

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ uv tool install --python 3.13 'ursa-ai[dashboard]'
 ```
 
 See [Getting started][getting-started] for installation alternatives and a
-walkthough of using URSA.
+walkthrough of using URSA.
 
 ## Quick first run
 

--- a/docs/reference/tutorials/neutron-star.md
+++ b/docs/reference/tutorials/neutron-star.md
@@ -48,7 +48,7 @@ executor = ExecutionAgent(llm=model)
 
 # Create a task for the ExecutionAgent
 execution_plan = f"""
-The following is the summaries of research papers on the contraints on neutron
+The following is the summaries of research papers on the constraints on neutron
 star radius: 
 {research_results}
 

--- a/examples/runai_examples/README.md
+++ b/examples/runai_examples/README.md
@@ -21,6 +21,6 @@ First, you will need to talk to your RunAI admins to give you your RunAI account
 
 Once you have completed that step, you will need to login to RunAI with `runai login remote browser` (if you are using CLI). The system will then ask you to copy a string to your terminal to complete authentication.
 
-Next, you can conviniently use the `sleep_inf.sh` and `exec_container.sh` scripts to start your workload, and then interact with it inside a shell instance. You could do this all by yourself too, and use the `.sh` files as a guide. Note that you will need to include your RunAI account/project variables in a `.env`. Included in this folder is a template you can follow as a reference.
+Next, you can conveniently use the `sleep_inf.sh` and `exec_container.sh` scripts to start your workload, and then interact with it inside a shell instance. You could do this all by yourself too, and use the `.sh` files as a guide. Note that you will need to include your RunAI account/project variables in a `.env`. Included in this folder is a template you can follow as a reference.
 
 Then from there, you can install URSA inside the RunAI container. You can use `isolation_summary.sh` to check for isolation inside the container.


### PR DESCRIPTION
5 spelling fixes across 5 documentation files, found with `codespell`. Prose only, no code or identifiers touched.

I read each hit in context and left the false positives alone.