### PR TITLE
Generate a default thread_id instead of sharing one constant

### DIFF
--- a/src/ursa/agents/base.py
+++ b/src/ursa/agents/base.py
@@ -37,6 +37,7 @@ from typing import (
     TypeVar,
     final,
 )
+from uuid import uuid4
 
 from langchain.chat_models import BaseChatModel
 from langchain.embeddings import Embeddings
@@ -313,7 +314,14 @@ class BaseAgent(Generic[TState], ABC):
         else:
             # Keep current behavior if the user is not persisting.
             self.den = self.workspace
-        self.thread_id = thread_id or "ursa"
+        # A generated default, as the docstring above promises. A constant here
+        # means two agents that share a checkpoint store share one thread, so
+        # the second one's model request carries the first one's messages.
+        # langgraph would otherwise refuse to run a checkpointed graph with no
+        # thread selector at all; a constant turns that error into a silent
+        # merge. The CLI and the dashboard pin "ursa" themselves, so only
+        # library callers reach this. See issue #332.
+        self.thread_id = thread_id or uuid4().hex
         self.telemetry = Telemetry(
             enable=enable_metrics,
             output_dir=self.den.joinpath(metrics_dir),

--- a/tests/agents/test_base/test_base.py
+++ b/tests/agents/test_base/test_base.py
@@ -712,3 +712,26 @@ def test_runtime_injection_preserved_for_nodes(tmp_path: Path):
     assert runtime is not None
     assert isinstance(runtime, Runtime)
     assert runtime.context.workspace == Path(tmp_path)
+
+
+def test_default_thread_id_is_unique_per_agent(tmp_path):
+    """Two agents built without a thread_id must not share a checkpoint thread.
+
+    The constructor docstring promises a generated identifier. A constant one
+    puts every library-built agent on the same thread of whatever checkpoint
+    store it is given, so two agents sharing a store share a conversation
+    (issue #332).
+    """
+    first = BasicChatAgent(llm=TinyCountingModel(), workspace=tmp_path / "w1")
+    second = BasicChatAgent(llm=TinyCountingModel(), workspace=tmp_path / "w2")
+
+    assert first.thread_id != second.thread_id
+
+
+def test_explicit_thread_id_is_respected(tmp_path):
+    """Passing a thread_id still pins it, which is how the CLI shares a thread."""
+    agent = BasicChatAgent(
+        llm=TinyCountingModel(), workspace=tmp_path / "w", thread_id="ursa"
+    )
+
+    assert agent.thread_id == "ursa"


### PR DESCRIPTION
Closes #332.

`BaseAgent` defaulted `thread_id` to the literal `"ursa"`, so every agent built without one wrote to the same thread of whatever checkpointer it was handed. Two agents sharing a store therefore shared a conversation, and the second one's model request carried the first one's messages.

Restored to `uuid4().hex`, which is what the constructor docstring three hundred lines up still promises ("Unique identifier for this agent instance. Generated if not provided") and what the code did before #246 extended the CLI's constant into the library constructor.

I checked that this does not disturb the callers that want a shared thread, since that was my first worry about changing a default. `cli/runtime.py:185` sets its own `self.config.thread_id or "ursa"` and passes it explicitly at :355, and `ursa_dashboard/worker_main.py:272` sets `agent_init["thread_id"] = "ursa"`. Both keep the behaviour they have. `experimental/agents/multiagent.py` and `simulator_agent.py` already suffix a caller-supplied id per sub-agent, so they are unaffected too. The default is reached only by library callers, which is where the bleed was.

Verified with the reproducer from the issue, which needs no API keys. Before the change:

    thread ids: ursa ursa
    BLEED

After:

    thread ids: b71dfa9edc5347ce8e0d7e32ba6421b1 9a1940242567444f94f8002337fe7f7e
    ISOLATED

Two tests added to `tests/agents/test_base/test_base.py`: two agents built without a `thread_id` get different ones, and an explicit `thread_id` is still honoured, which is the property the CLI depends on. The first fails on the current code with `assert 'ursa' != 'ursa'`.

`pytest tests/agents/test_base/test_base.py` goes from 9 passed to 11 passed. The ten failures in that file are the same ten before and after this branch, all in the persistent-agent async sqlite tests, and I checked that rather than assuming it. `ruff check` reports the same 54 errors either way and `ruff format --check` is clean.

Worth noting for #331: this stops a library caller resuming by `agent_name` alone from silently landing in another agent's thread, but it does not change the append-instead-of-restore behaviour itself.